### PR TITLE
[BLAZE-978] Avoid recursive stop in BlazeUniffleShuffleWriter to prevent StackOverflowError

### DIFF
--- a/spark-extension-shims-spark3/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/uniffle/BlazeUniffleShuffleWriter.scala
+++ b/spark-extension-shims-spark3/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/uniffle/BlazeUniffleShuffleWriter.scala
@@ -44,7 +44,6 @@ class BlazeUniffleShuffleWriter[K, V, C](
   override def rssStop(success: Boolean): Unit = {
     waitAndCheckBlocksSend()
     logInfo(s"Reporting the shuffle result...")
-    super.stop(success)
     rssShuffleWriter.stop(success)
   }
 }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #978.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Recent refactoring (#901) introduced a unified rssStop() mechanism in BlazeRssShuffleWriterBase.
However, BlazeUniffleShuffleWriter still called super.stop(success) in its rssStop() implementation, causing infinite recursion and stack overflow at runtime.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

A patch will follow to make BlazeUniffleShuffleWriter properly override rssStop() without calling super.stop(success), preventing recursion

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

No

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
