### PR TITLE
java.lang.NoClassDefFoundError on Spark local mode using --conf spark.jars

### DIFF
--- a/spark-extension-shims-spark3/src/main/java/org/apache/spark/sql/blaze/ValidateSparkPlanInjector.java
+++ b/spark-extension-shims-spark3/src/main/java/org/apache/spark/sql/blaze/ValidateSparkPlanInjector.java
@@ -34,11 +34,12 @@ public class ValidateSparkPlanInjector {
     public static void inject() {
         try {
             ByteBuddyAgent.install();
-            TypeDescription typeDescription = TypePool.Default.ofSystemLoader()
+            ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+            TypeDescription typeDescription = TypePool.Default.of(contextClassLoader)
                     .describe("org.apache.spark.sql.execution.adaptive.ValidateSparkPlan$")
                     .resolve();
             new ByteBuddy()
-                    .redefine(typeDescription, ClassFileLocator.ForClassLoader.ofSystemLoader())
+                    .redefine(typeDescription, ClassFileLocator.ForClassLoader.of(contextClassLoader))
                     .method(named("apply"))
                     .intercept(MethodDelegation.to(ValidateSparkPlanApplyInterceptor.class))
                     .make()


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1046 

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

In Spark local mode, the jar packages submitted via `--conf spark.jars` are loaded by Spark's childfirst class loader rather than the system class loader.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

use contextClassLoader instead of systemClassLoader

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
No

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
