### PR TITLE
[BLAZE-1071][FOLLOWUP] Fix incorrect mapStatus to prevent Uniffle failures in Blaze

### DIFF
--- a/spark-extension-shims-spark3/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/celeborn/BlazeCelebornShuffleWriter.scala
+++ b/spark-extension-shims-spark3/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/celeborn/BlazeCelebornShuffleWriter.scala
@@ -17,6 +17,7 @@ package org.apache.spark.sql.execution.blaze.shuffle.celeborn
 
 import org.apache.celeborn.client.ShuffleClient
 import org.apache.spark.TaskContext
+import org.apache.spark.scheduler.MapStatus
 import org.apache.spark.shuffle.ShuffleHandle
 import org.apache.spark.shuffle.ShuffleWriteMetricsReporter
 import org.apache.spark.shuffle.ShuffleWriter
@@ -63,7 +64,7 @@ class BlazeCelebornShuffleWriter[K, V](
     celebornPartitionWriter.getPartitionLengthMap
   }
 
-  override def rssStop(success: Boolean): Unit = {
+  override def rssStop(success: Boolean): Option[MapStatus] = {
     celebornShuffleWriter.write(Iterator.empty) // force flush
     celebornShuffleWriter.stop(success)
   }

--- a/spark-extension-shims-spark3/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/uniffle/BlazeUniffleShuffleWriter.scala
+++ b/spark-extension-shims-spark3/src/main/scala/org/apache/spark/sql/execution/blaze/shuffle/uniffle/BlazeUniffleShuffleWriter.scala
@@ -16,6 +16,7 @@
 package org.apache.spark.sql.execution.blaze.shuffle.uniffle
 
 import org.apache.spark.internal.Logging
+import org.apache.spark.scheduler.MapStatus
 import org.apache.spark.shuffle.writer.RssShuffleWriter
 import org.apache.spark.shuffle.{ShuffleHandle, ShuffleWriteMetricsReporter}
 import org.apache.spark.sql.execution.blaze.shuffle.{BlazeRssShuffleWriterBase, RssPartitionWriterBase}
@@ -41,7 +42,7 @@ class BlazeUniffleShuffleWriter[K, V, C](
     method.invoke(rssShuffleWriter)
   }
 
-  override def rssStop(success: Boolean): Unit = {
+  override def rssStop(success: Boolean): Option[MapStatus] = {
     waitAndCheckBlocksSend()
     logInfo(s"Reporting the shuffle result...")
     rssShuffleWriter.stop(success)


### PR DESCRIPTION
# Which issue does this PR close?

This is the followup of https://github.com/kwai/blaze/pull/901 and https://github.com/kwai/blaze/pull/979

Closes #1071 

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
When using Uniffle as the shuffle service in Blaze, the constructed MapStatus in BlazeRssShuffleWriterBase may lack the required topologyInfo in its BlockManagerId.
This causes Uniffle to throw an error during shuffle read:
```
Can't get expected taskAttemptId
```
The root cause is that although Uniffle internally builds a MapStatus with proper BlockManagerId (including topologyInfo), this status is not propagated or reused by Blaze. Instead, Blaze re-constructs a new MapStatus using SparkEnv.get.blockManager.shuffleServerId, which lacks the correct topologyInfo.

This PR ensures that the correct MapStatus (with valid topologyInfo) returned by Uniffle’s shuffle writer is preserved and returned to the shuffle system, avoiding this mismatch and runtime failure.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
* Update BlazeRssShuffleWriterBase.stop() to prefer the MapStatus returned by the underlying RSS shuffle writer (e.g., Uniffle).

* Fallback to the original construction logic only if no MapStatus is returned.


# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
No.
<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
