### PR TITLE
improve DS scan unsupported message

### DIFF
--- a/spark-extension/src/main/scala/org/apache/spark/sql/blaze/BlazeConverters.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/blaze/BlazeConverters.scala
@@ -357,7 +357,10 @@ object BlazeConverters extends Logging {
       case p if p.getClass.getName.endsWith("OrcFileFormat") =>
         assert(enableScanOrc)
         addRenameColumnsExec(Shims.get.createNativeOrcScanExec(exec))
-      case _ => throw new NotImplementedError("Cannot convert non parquet/orc scan exec")
+      case p =>
+        throw new NotImplementedError(
+          s"Cannot convert FileSourceScanExec tableIdentifier: ${tableIdentifier.getOrElse(
+            "unknown")}, class: ${p.getClass.getName}")
     }
   }
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

Master
```
WARN BlazeConverters: Falling back exec: FileSourceScanExec: Cannot convert non parquet/orc scan exec
```

PR

```
WARN BlazeConverters: Falling back exec: FileSourceScanExec: Cannot convert FileSourceScanExec tableIdentifier: `spark_catalog`.`default`.`tmp_t8`, class: org.apache.spark.sql.execution.datasources.csv.CSVFileFormat
```
