### PR TITLE
Make blaze conf be runtime dynamic conf

### DIFF
--- a/spark-extension/src/main/java/org/apache/spark/sql/blaze/BlazeConf.java
+++ b/spark-extension/src/main/java/org/apache/spark/sql/blaze/BlazeConf.java
@@ -15,8 +15,8 @@
  */
 package org.apache.spark.sql.blaze;
 
-import org.apache.spark.SparkConf;
-import org.apache.spark.SparkEnv$;
+import org.apache.spark.sql.internal.SQLConf;
+import org.apache.spark.sql.internal.SQLConf$;
 
 @SuppressWarnings("unused")
 public enum BlazeConf {
@@ -123,23 +123,23 @@ public enum BlazeConf {
     }
 
     public boolean booleanConf() {
-        return conf().getBoolean(key, (boolean) defaultValue);
+        return Boolean.valueOf(stringConf());
     }
 
     public int intConf() {
-        return conf().getInt(key, (int) defaultValue);
+        return Integer.valueOf(stringConf());
     }
 
     public long longConf() {
-        return conf().getLong(key, (long) defaultValue);
+        return Long.valueOf(stringConf());
     }
 
     public double doubleConf() {
-        return conf().getDouble(key, (double) defaultValue);
+        return Double.valueOf(stringConf());
     }
 
     public String stringConf() {
-        return conf().get(key, (String) defaultValue);
+        return conf().getConfString(key, defaultValue.toString()).trim();
     }
 
     public static boolean booleanConf(String confName) {
@@ -162,7 +162,7 @@ public enum BlazeConf {
         return BlazeConf.valueOf(confName).stringConf();
     }
 
-    private static SparkConf conf() {
-        return SparkEnv$.MODULE$.get().conf();
+    private static SQLConf conf() {
+        return SQLConf$.MODULE$.get();
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Make the blaze conf be runtime config, just likes mentioned in the docs.


Customer might want to change the fallback enabled configs during runtime.

<img width="1135" height="711" alt="image" src="https://github.com/user-attachments/assets/24cf73ff-cd04-4f76-98c3-47fd4c7fbf99" />

It is helpful especially for long running applications, likes Kyuubi Spark engine, the users can change the blaze runtime config without restarting.


# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
No.
