### PR TITLE
[MINOR] Remove unused variables in BlazeConverters.scala

### DIFF
--- a/spark-extension/src/main/scala/org/apache/spark/sql/blaze/BlazeConverters.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/blaze/BlazeConverters.scala
@@ -136,11 +136,7 @@ object BlazeConverters extends Logging {
     SparkEnv.get.conf.getBoolean("spark.blaze.enable.scan.parquet", defaultValue = true)
   val enableScanOrc: Boolean =
     SparkEnv.get.conf.getBoolean("spark.blaze.enable.scan.orc", defaultValue = true)
-
-  import org.apache.spark.sql.catalyst.plans._
   import org.apache.spark.sql.catalyst.optimizer._
-  var _UnusedQueryPlan: QueryPlan[_] = _
-  var _UnusedOptimizer: Optimizer = _
 
   def convertSparkPlanRecursively(exec: SparkPlan): SparkPlan = {
     // convert


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Removed two unused private variables `_UnusedQueryPlan` and `_UnusedOptimizer`, which are not referenced anywhere in the codebase.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
No.
<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
