### PR TITLE
fix execution error in non-native parquet sink tasks

### DIFF
--- a/spark-extension/src/main/scala/org/apache/spark/sql/execution/blaze/plan/NativeParquetInsertIntoHiveTableBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/execution/blaze/plan/NativeParquetInsertIntoHiveTableBase.scala
@@ -165,6 +165,7 @@ class BlazeMapredParquetOutputFormat
 case class OutputFileStat(path: String, numRows: Long, numBytes: Long)
 
 class ParquetSinkTaskContext {
+  var isNative: Boolean = false
   val processingOutputFiles = new LinkedBlockingDeque[String]()
   val processedOutputFiles = new util.ArrayDeque[OutputFileStat]()
 }

--- a/spark-extension/src/main/scala/org/apache/spark/sql/execution/blaze/plan/NativeParquetSinkBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/execution/blaze/plan/NativeParquetSinkBase.scala
@@ -97,6 +97,9 @@ abstract class NativeParquetSinkBase(
       inputRDD.isShuffleReadFull,
       (partition, context) => {
 
+        // mark for native parquet sink
+        ParquetSinkTaskContext.get.isNative = true
+
         // init hadoop fs
         val resourceId = s"NativeParquetSinkExec:${UUID.randomUUID().toString}"
         JniBridge.resourcesMap.put(


### PR DESCRIPTION
in some modified spark distribution, InsertIntoHiveTable supports running extra stage to merge small files. this pr avoids the stage from running into native logics.