### PR TITLE
use rust-toolchain `nightly-2025-05-09`

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -16,5 +16,5 @@
 # under the License.
 
 [toolchain]
-channel = "nightly"
+channel = "nightly-2025-05-09"
 components = ["rust-src", "cargo", "rustfmt", "clippy"]


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

use `nightly-2025-06-20` and `nightly` cause JVM crash

https://releases.rs/docs/1.89.0/

https://releases.rs/docs/1.88.0/

```

C  [libc.so.6+0xca679]  __memcpy_evex_unaligned_erms+0x39
```
```
C  [libc.so.6+0xf0378]  __memmove_avx512_unaligned_erms+0x78
```


# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
