### PR TITLE
fix execute_projected_with_key_rows_output()

### DIFF
--- a/native-engine/datafusion-ext-plans/src/common/execution_context.rs
+++ b/native-engine/datafusion-ext-plans/src/common/execution_context.rs
@@ -316,12 +316,12 @@ impl ExecutionContext {
             );
         }
 
-        let output_schema = self.output_schema();
+        let input_schema = input.schema();
         let key_converter = RowConverter::new(
             keys.iter()
                 .map(|k| {
                     Ok(SortField::new_with_options(
-                        k.expr.data_type(&output_schema)?,
+                        k.expr.data_type(&input_schema)?,
                         k.options,
                     ))
                 })

--- a/native-engine/datafusion-ext-plans/src/common/row_null_checker.rs
+++ b/native-engine/datafusion-ext-plans/src/common/row_null_checker.rs
@@ -438,15 +438,6 @@ mod tests {
 
     use super::*;
 
-    // Helper function to create a SortField for testing
-    fn create_test_sort_field(data_type: DataType, nulls_first: bool) -> SortField {
-        let sort_options = SortOptions {
-            descending: false,
-            nulls_first,
-        };
-        SortField::new_with_options(data_type, sort_options)
-    }
-
     #[test]
     fn test_primitive_null_detection() {
         // Create a SortField with Int32 data type


### PR DESCRIPTION
fix incorrect schema usage in `ExecutionContext::execute_projected_with_key_rows_output`