### PR TITLE
[BLAZE-1169] Add GA to build blaze on ubuntu arm runners

### DIFF
--- a/.github/workflows/build-arm-releases.yml
+++ b/.github/workflows/build-arm-releases.yml
@@ -2,7 +2,6 @@ name: Build arm Releases
 
 on:
   workflow_dispatch:
-  pull_request:
   push:
     branches: ["master"]
 

--- a/.github/workflows/tpcds.yml
+++ b/.github/workflows/tpcds.yml
@@ -2,6 +2,7 @@ name: TPC-DS
 
 on:
   workflow_dispatch:
+  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1169 

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Support to download the blaze jar build on ARM runner.

Refer: https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/#how-to-use-the-runners 

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Add GA to release blaze engine jar on ARM runner.
# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
No.
<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

# How was this patch tested?
<img width="1711" height="859" alt="image" src="https://github.com/user-attachments/assets/9dd724b3-4bbb-4d7f-a457-a4716e5cb42a" />
