### PR TITLE
[AURON-1226] Use git submodules for setup-rust-toolchain

### DIFF
--- a/.github/workflows/build-arm-releases.yml
+++ b/.github/workflows/build-arm-releases.yml
@@ -50,6 +50,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
       - uses: actions/setup-java@v4
         with:
           distribution: 'adopt-hotspot'

--- a/.github/workflows/build-arm-releases.yml
+++ b/.github/workflows/build-arm-releases.yml
@@ -61,7 +61,7 @@ jobs:
           version: "21.7"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses:  ./.github/actions/setup-rust-toolchain
         with:
           rustflags: --allow warnings -C target-feature=+aes
           components:

--- a/.github/workflows/build-ce7-releases.yml
+++ b/.github/workflows/build-ce7-releases.yml
@@ -49,7 +49,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: s4u/setup-maven-action@main
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses:  ./.github/actions/setup-rust-toolchain
 
       - uses: prompt/actions-commit-hash@v3
         id: commit

--- a/.github/workflows/build-ce7-releases.yml
+++ b/.github/workflows/build-ce7-releases.yml
@@ -48,6 +48,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
       - uses: s4u/setup-maven-action@main
       - uses:  ./.github/actions/setup-rust-toolchain
 

--- a/.github/workflows/tpcds-reusable.yml
+++ b/.github/workflows/tpcds-reusable.yml
@@ -110,6 +110,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
       - uses: actions/setup-java@v4
         with:
           distribution: 'adopt-hotspot'

--- a/.github/workflows/tpcds-reusable.yml
+++ b/.github/workflows/tpcds-reusable.yml
@@ -121,15 +121,12 @@ jobs:
           version: "21.7"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses:  ./.github/actions/setup-rust-toolchain
         with:
           rustflags: --allow warnings -C target-feature=+aes
           components:
             cargo
             rustfmt
-
-      - name: Rustfmt Check
-        uses: actions-rust-lang/rustfmt@v1
 
       - name: Cargo test
         run: |

--- a/.gitmodules
+++ b/.gitmodules
@@ -17,7 +17,7 @@
 
 [submodule "dev/tpcds_1g"]
 	path = dev/tpcds_1g
-	url = git@github.com:blaze-init/tpcds_1g.git
+	url = https://github.com/auron-project/tpcds_1g
 [submodule ".github/actions/setup-rust-toolchain"]
 	path = .github/actions/setup-rust-toolchain
 	url = https://github.com/actions-rust-lang/setup-rust-toolchain

--- a/.gitmodules
+++ b/.gitmodules
@@ -18,3 +18,6 @@
 [submodule "dev/tpcds_1g"]
 	path = dev/tpcds_1g
 	url = git@github.com:blaze-init/tpcds_1g.git
+[submodule ".github/actions/setup-rust-toolchain"]
+	path = .github/actions/setup-rust-toolchain
+	url = https://github.com/actions-rust-lang/setup-rust-toolchain


### PR DESCRIPTION
<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-   http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
-->

# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1226

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
Fix GA issue due to apache policy.

```
The actions actions-rust-lang/setup-rust-toolchain@v1 and actions-rust-lang/rustfmt@v1 are not allowed in apache/auron because all actions must be from a repository owned by your enterprise, created by GitHub, verified in the GitHub Marketplace, or match one of the patterns: 1Password/load-secrets-action@13f58eec611f8e5db52ec16247f58c508398f3e6, 1Password/load-secrets-action@581a835fb51b8e7ec56b71cf2ffddd7e68bb25e0, AdoptOpenJDK/install-jdk@*, BobAnkh/auto-generate-changelog@*, DavidAnson/markdownlint-cli2-action@992badcdf24e3b8eb7e87ff9287fe931bcb00c6e, DavidAnson/markdownlint-cli2-action@b4c9feab76d8025d1e83c653fa3990936df0e6c8, EnricoMi/publish-unit-test-result-action@*, JamesIves/github-pages-deploy-action@6c2d9db40f9296374acc17b90404b6e8864128c8, JamesIves/github-pages-deploy-action@881db5376404c5c8d621010bcbec0310b58d5e29, JustinBeckwith/linkinator-action@3d5ba091319fa7b0ac14703761eebb7d100e6f6d, Kesin11/actions-timeline@427ee2cf860166e404d0d69b4f2b24012bb7af4f, Kesin11/action...
```
# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

```
git submodule add --force  https://github.com/actions-rust-lang/setup-rust-toolchain .github/actions/setup-rust-toolchain
git -C .github/actions/setup-rust-toolchain checkout ac90e63697ac2784f4ecfe2964e1a285c304003a
```
https://github.com/actions-rust-lang/setup-rust-toolchain/commit/ac90e63697ac2784f4ecfe2964e1a285c304003a 

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
No
# How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
GA