### PR TITLE
[AURON-1312] Add scalar coverage for spark_sha2 hashing

### DIFF
--- a/native-engine/datafusion-ext-functions/src/spark_sha2.rs
+++ b/native-engine/datafusion-ext-functions/src/spark_sha2.rs
@@ -107,7 +107,7 @@ mod tests {
     /// Helper function to run a test for a given hash function and scalar
     /// input.
     fn run_scalar_test(
-        // Accepts any function that matches the signature of your spark_sha* functions.
+        // Accepts any function that matches the signature of the spark_sha* functions.
         hash_fn: impl Fn(&[ColumnarValue]) -> DataFusionResult<ColumnarValue>,
         input_value: ColumnarValue,
         expected_output: &str,


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1312 .

 # Rationale for this change
The spark_sha2 UDFs currently lack regression coverage to ensure they produce stable digests for both UTF-8 strings and binary scalars. Adding targeted tests guards against regressions when the hashing logic evolves.

# What changes are included in this PR?
- Introduce a reusable helper that executes a provided spark_sha* function and validates the scalar result.
- Add UTF-8 and binary scalar tests for the SHA-224/256/384/512 variants to lock in the expected digests.

# Are there any user-facing changes?

No user-facing changes.

# How was this patch tested?
```
cargo test -p datafusion-ext-functions spark_sha2::tests
```

# Reference
The related spark UT can be found here: https://github.com/apache/spark/blob/b87f6d14a78744f284f5c699506419343d722253/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala#L631C1-L646C4
