### PR TITLE
[AURON-1316] Support trim in cast expression

### DIFF
--- a/native-engine/datafusion-ext-commons/src/arrow/cast.rs
+++ b/native-engine/datafusion-ext-commons/src/arrow/cast.rs
@@ -284,7 +284,8 @@ fn try_cast_string_array_to_date(array: &dyn Array) -> Result<ArrayRef> {
 }
 
 // this implementation is original copied from spark UTF8String.scala
-// The original implementation included trimming logic, but it was omitted here since Auron’s NativeConverters will handle trimming.
+// The original implementation included trimming logic, but it was omitted here
+// since Auron’s NativeConverters will handle trimming.
 fn to_integer<T: Bounded + FromPrimitive + Integer + Signed + Copy>(input: &str) -> Option<T> {
     let bytes = input.as_bytes();
 

--- a/native-engine/datafusion-ext-commons/src/arrow/cast.rs
+++ b/native-engine/datafusion-ext-commons/src/arrow/cast.rs
@@ -284,6 +284,7 @@ fn try_cast_string_array_to_date(array: &dyn Array) -> Result<ArrayRef> {
 }
 
 // this implementation is original copied from spark UTF8String.scala
+// The original implementation included trimming logic, but it was omitted here since Auron’s NativeConverters will handle trimming.
 fn to_integer<T: Bounded + FromPrimitive + Integer + Signed + Copy>(input: &str) -> Option<T> {
     let bytes = input.as_bytes();
 

--- a/native-engine/datafusion-ext-commons/src/arrow/cast.rs
+++ b/native-engine/datafusion-ext-commons/src/arrow/cast.rs
@@ -19,7 +19,7 @@ use arrow::{array::*, datatypes::*};
 use bigdecimal::BigDecimal;
 use chrono::Datelike;
 use datafusion::common::Result;
-use num::{Bounded, FromPrimitive, Integer, Signed};
+use num::{Bounded, FromPrimitive, Integer, Signed, traits::float};
 
 use crate::df_execution_err;
 

--- a/native-engine/datafusion-ext-commons/src/arrow/cast.rs
+++ b/native-engine/datafusion-ext-commons/src/arrow/cast.rs
@@ -19,7 +19,7 @@ use arrow::{array::*, datatypes::*};
 use bigdecimal::BigDecimal;
 use chrono::Datelike;
 use datafusion::common::Result;
-use num::{Bounded, FromPrimitive, Integer, Signed, traits::float};
+use num::{Bounded, FromPrimitive, Integer, Signed};
 
 use crate::df_execution_err;
 

--- a/native-engine/datafusion-ext-commons/src/arrow/cast.rs
+++ b/native-engine/datafusion-ext-commons/src/arrow/cast.rs
@@ -19,7 +19,7 @@ use arrow::{array::*, datatypes::*};
 use bigdecimal::BigDecimal;
 use chrono::Datelike;
 use datafusion::common::Result;
-use num::{Bounded, FromPrimitive, Integer, Signed, traits::float};
+use num::{Bounded, FromPrimitive, Integer, Signed};
 
 use crate::df_execution_err;
 
@@ -49,11 +49,6 @@ pub fn cast_impl(
         // spark compatible str to date
         (&DataType::Utf8, &DataType::Date32) => {
             return try_cast_string_array_to_date(array);
-        }
-
-        // use std parse to cast string to float
-        (&DataType::Utf8, to_dt) if to_dt.is_floating() => {
-            return try_cast_string_array_to_float(array, to_dt);
         }
 
         // float to int
@@ -253,31 +248,6 @@ fn to_plain_string_array(array: &dyn Array) -> ArrayRef {
     Arc::new(StringArray::from(converted_values))
 }
 
-fn try_cast_string_array_to_float(array: &dyn Array, cast_type: &DataType) -> Result<ArrayRef> {
-    macro_rules! cast {
-        ($target_type:ident) => {{
-            type B = paste::paste! {[<$target_type Builder>]};
-            let array = array.as_any().downcast_ref::<StringArray>().unwrap();
-            let mut builder = B::new();
-
-            for v in array.iter() {
-                match v {
-                    Some(s) => builder.append_option(s.trim().parse().ok()),
-                    None => builder.append_null(),
-                }
-            }
-            let result = Arc::new(builder.finish());
-            result
-        }};
-    }
-
-    Ok(match cast_type {
-        DataType::Float32 => cast!(Float32),
-        DataType::Float64 => cast!(Float64),
-        _ => arrow::compute::cast(array, cast_type)?,
-    })
-}
-
 fn try_cast_string_array_to_integer(array: &dyn Array, cast_type: &DataType) -> Result<ArrayRef> {
     macro_rules! cast {
         ($target_type:ident) => {{
@@ -291,8 +261,7 @@ fn try_cast_string_array_to_integer(array: &dyn Array, cast_type: &DataType) -> 
                     None => builder.append_null(),
                 }
             }
-            let result = Arc::new(builder.finish());
-            result
+            Arc::new(builder.finish())
         }};
     }
 
@@ -316,26 +285,15 @@ fn try_cast_string_array_to_date(array: &dyn Array) -> Result<ArrayRef> {
 
 // this implementation is original copied from spark UTF8String.scala
 fn to_integer<T: Bounded + FromPrimitive + Integer + Signed + Copy>(input: &str) -> Option<T> {
-    let mut offset = 0;
-    while offset < input.len() && input.as_bytes()[offset].is_ascii_whitespace() {
-        offset += 1;
-    }
-    if offset == input.len() {
-        return None;
-    }
-    let mut end = input.len() - 1;
-    while end > offset && input.as_bytes()[end].is_ascii_whitespace() {
-        end -= 1;
-    }
-
     let bytes = input.as_bytes();
 
     if bytes.is_empty() {
         return None;
     }
 
-    let b = bytes[offset];
+    let b = bytes[0];
     let negative = b == b'-';
+    let mut offset = 0;
 
     if negative || b == b'+' {
         offset += 1;
@@ -349,7 +307,7 @@ fn to_integer<T: Bounded + FromPrimitive + Integer + Signed + Copy>(input: &str)
     let stop_value = T::min_value() / radix;
     let mut result = T::zero();
 
-    while offset <= end {
+    while offset < bytes.len() {
         let b = bytes[offset];
         offset += 1;
         if b == separator {
@@ -385,7 +343,7 @@ fn to_integer<T: Bounded + FromPrimitive + Integer + Signed + Copy>(input: &str)
     // This is the case when we've encountered a decimal separator. The fractional
     // part will not change the number, but we will verify that the fractional part
     // is well-formed.
-    while offset < end {
+    while offset < bytes.len() {
         let current_byte = bytes[offset];
         if !current_byte.is_ascii_digit() {
             return None;
@@ -559,7 +517,6 @@ mod test {
         let string_array: ArrayRef = Arc::new(StringArray::from_iter(vec![
             None,
             Some("1e-8"),
-            Some("  123.456  "),
             Some("1.012345678911111111e10"),
             Some("1.42e-6"),
             Some("0.00000142"),
@@ -574,7 +531,6 @@ mod test {
             &Decimal128Array::from_iter(vec![
                 None,
                 Some(10000000000),
-                Some(123456000000000000000i128),
                 Some(10123456789111111110000000000i128),
                 Some(1420000000000),
                 Some(1420000000000),
@@ -623,13 +579,6 @@ mod test {
             Some("123"),
             Some("987"),
             Some("987.654"),
-            Some(" 123"),
-            Some(" 123 "),
-            Some("\t123 "),
-            Some("\t123\t"),
-            Some(" +123 "),
-            Some(" -456 "),
-            Some(" 987.654 "),
             Some("123456789012345"),
             Some("-123456789012345"),
             Some("999999999999999999999999999999999"),
@@ -642,51 +591,8 @@ mod test {
                 Some(123),
                 Some(987),
                 Some(987),
-                Some(123),
-                Some(123),
-                Some(123),
-                Some(123),
-                Some(123),
-                Some(-456),
-                Some(987),
                 Some(123456789012345),
                 Some(-123456789012345),
-                None,
-            ])
-        );
-    }
-
-    #[test]
-    fn test_string_to_float() {
-        let string_array: ArrayRef = Arc::new(StringArray::from_iter(vec![
-            None,
-            Some("1.23"),
-            Some("+1.23"),
-            Some("-4.56"),
-            Some("  1.23"),
-            Some(" 1.23 "),
-            Some(" 1.23\t"),
-            Some("\t1.23"),
-            Some("  -4.56  "),
-            Some("  +1.23  "),
-            Some("123.a"),
-            Some("1.23中文"),
-        ]));
-        let casted = cast(&string_array, &DataType::Float32).unwrap();
-        assert_eq!(
-            casted.as_any().downcast_ref::<Float32Array>().unwrap(),
-            &Float32Array::from_iter(vec![
-                None,
-                Some(1.23),
-                Some(1.23),
-                Some(-4.56),
-                Some(1.23),
-                Some(1.23),
-                Some(1.23),
-                Some(1.23),
-                Some(-4.56),
-                Some(1.23),
-                None,
                 None,
             ])
         );

--- a/native-engine/datafusion-ext-exprs/src/cast.rs
+++ b/native-engine/datafusion-ext-exprs/src/cast.rs
@@ -214,11 +214,7 @@ mod test {
     #[test]
     fn cast_trimmed_utf8_into_int32() {
         let batch = make_batch(
-            Arc::new(StringArray::from(vec![
-                Some(" 2"),
-                Some("3 "),
-                Some(" 4 "),
-            ])),
+            Arc::new(StringArray::from(vec![Some(" 2"), Some("3 "), Some(" 4 ")])),
             DataType::Utf8,
         );
 
@@ -249,11 +245,8 @@ mod test {
         ));
 
         let actual = evaluate(expr, &batch);
-        let expected: ArrayRef = Arc::new(Float32Array::from(vec![
-            Some(2.5),
-            Some(6.75),
-            Some(8.125),
-        ]));
+        let expected: ArrayRef =
+            Arc::new(Float32Array::from(vec![Some(2.5), Some(6.75), Some(8.125)]));
         assert_eq!(&actual, &expected);
     }
 }

--- a/native-engine/datafusion-ext-exprs/src/cast.rs
+++ b/native-engine/datafusion-ext-exprs/src/cast.rs
@@ -214,7 +214,11 @@ mod test {
     #[test]
     fn cast_trimmed_utf8_into_int32() {
         let batch = make_batch(
-            Arc::new(StringArray::from(vec![Some(" 2"), Some("3 "), Some(" 4 ")])),
+            Arc::new(StringArray::from(vec![
+                Some(" 2"),
+                Some("3 "),
+                Some(" 4 "),
+            ])),
             DataType::Utf8,
         );
 
@@ -245,8 +249,11 @@ mod test {
         ));
 
         let actual = evaluate(expr, &batch);
-        let expected: ArrayRef =
-            Arc::new(Float32Array::from(vec![Some(2.5), Some(6.75), Some(8.125)]));
+        let expected: ArrayRef = Arc::new(Float32Array::from(vec![
+            Some(2.5),
+            Some(6.75),
+            Some(8.125),
+        ]));
         assert_eq!(&actual, &expected);
     }
 }

--- a/native-engine/datafusion-ext-exprs/src/cast.rs
+++ b/native-engine/datafusion-ext-exprs/src/cast.rs
@@ -113,41 +113,38 @@ mod test {
 
     use crate::cast::TryCastExpr;
 
+    fn make_batch(array: ArrayRef, data_type: DataType) -> RecordBatch {
+        let schema = Arc::new(Schema::new(vec![Field::new("col", data_type, true)]));
+        RecordBatch::try_new(schema, vec![array]).expect("Error creating RecordBatch")
+    }
+
+    fn evaluate(expr: Arc<TryCastExpr>, batch: &RecordBatch) -> ArrayRef {
+        expr.evaluate(batch)
+            .expect("Error evaluating expr")
+            .into_array(batch.num_rows())
+            .expect("Expression did not return array")
+    }
+
     #[test]
-    fn test_ok_1() {
-        // input: Array
-        // cast Float32 into Int32
-        let float_arr: ArrayRef = Arc::new(Float32Array::from(vec![
-            Some(7.6),
-            Some(9.0),
-            Some(3.4),
-            Some(-0.0),
-            Some(-99.9),
-            None,
-        ]));
-
-        let schema = Arc::new(Schema::new(vec![Field::new(
-            "col",
+    fn cast_float32_array_into_int32() {
+        let batch = make_batch(
+            Arc::new(Float32Array::from(vec![
+                Some(7.6),
+                Some(9.0),
+                Some(3.4),
+                Some(-0.0),
+                Some(-99.9),
+                None,
+            ])),
             DataType::Float32,
-            true,
-        )]));
-
-        let batch =
-            RecordBatch::try_new(schema, vec![float_arr]).expect("Error creating RecordBatch");
-
-        let cast_type = DataType::Int32;
+        );
 
         let expr = Arc::new(TryCastExpr::new(
             phys_expr::col("col", &batch.schema()).unwrap(),
-            cast_type,
+            DataType::Int32,
         ));
 
-        let ret = expr
-            .evaluate(&batch)
-            .expect("Error evaluating expr")
-            .into_array(batch.num_rows())
-            .unwrap();
-
+        let actual = evaluate(expr, &batch);
         let expected: ArrayRef = Arc::new(Int32Array::from(vec![
             Some(7),
             Some(9),
@@ -156,39 +153,28 @@ mod test {
             Some(-99),
             None,
         ]));
-        assert_eq!(&ret, &expected);
+        assert_eq!(&actual, &expected);
     }
 
     #[test]
-    fn test_ok_2() {
-        // input: Array
-        // cast Utf8 into Float32
-        let string_arr: ArrayRef = Arc::new(StringArray::from(vec![
-            Some("123"),
-            Some("321.9"),
-            Some("-098"),
-            Some("sda"),
-            None, // null
-        ]));
-
-        let schema = Arc::new(Schema::new(vec![Field::new("col", DataType::Utf8, true)]));
-
-        let batch =
-            RecordBatch::try_new(schema, vec![string_arr]).expect("Error creating RecordBatch");
-
-        let cast_type = DataType::Float32;
+    fn cast_utf8_array_into_float32() {
+        let batch = make_batch(
+            Arc::new(StringArray::from(vec![
+                Some("123"),
+                Some("321.9"),
+                Some("-098"),
+                Some("sda"),
+                None,
+            ])),
+            DataType::Utf8,
+        );
 
         let expr = Arc::new(TryCastExpr::new(
             phys_expr::col("col", &batch.schema()).unwrap(),
-            cast_type,
+            DataType::Float32,
         ));
 
-        let ret = expr
-            .evaluate(&batch)
-            .expect("Error evaluating expr")
-            .into_array(batch.num_rows())
-            .unwrap();
-
+        let actual = evaluate(expr, &batch);
         let expected: ArrayRef = Arc::new(Float32Array::from(vec![
             Some(123.0),
             Some(321.9),
@@ -196,36 +182,25 @@ mod test {
             None,
             None,
         ]));
-        assert_eq!(&ret, &expected);
+        assert_eq!(&actual, &expected);
     }
 
     #[test]
-    fn test_ok_3() {
-        // input: Scalar
-        // cast Utf8 into Float32
-        let string_arr: ArrayRef = Arc::new(StringArray::from(vec![
-            Some("123"),
-            Some("321.9"),
-            Some("-098"),
-            Some("sda"),
-            None, // null
-        ]));
+    fn cast_utf8_scalar_into_float32() {
+        let batch = make_batch(
+            Arc::new(StringArray::from(vec![
+                Some("123"),
+                Some("321.9"),
+                Some("-098"),
+                Some("sda"),
+                None,
+            ])),
+            DataType::Utf8,
+        );
 
-        let schema = Arc::new(Schema::new(vec![Field::new("col", DataType::Utf8, true)]));
+        let expr = Arc::new(TryCastExpr::new(phys_expr::lit("123.4"), DataType::Float32));
 
-        let batch =
-            RecordBatch::try_new(schema, vec![string_arr]).expect("Error creating RecordBatch");
-
-        let cast_type = DataType::Float32;
-
-        let expr = Arc::new(TryCastExpr::new(phys_expr::lit("123.4"), cast_type));
-
-        let ret = expr
-            .evaluate(&batch)
-            .expect("Error evaluating expr")
-            .into_array(batch.num_rows())
-            .unwrap();
-
+        let actual = evaluate(expr, &batch);
         let expected: ArrayRef = Arc::new(Float32Array::from(vec![
             Some(123.4),
             Some(123.4),
@@ -233,6 +208,52 @@ mod test {
             Some(123.4),
             Some(123.4),
         ]));
-        assert_eq!(&ret, &expected);
+        assert_eq!(&actual, &expected);
+    }
+
+    #[test]
+    fn cast_trimmed_utf8_into_int32() {
+        let batch = make_batch(
+            Arc::new(StringArray::from(vec![
+                Some(" 2"),
+                Some("3 "),
+                Some(" 4 "),
+            ])),
+            DataType::Utf8,
+        );
+
+        let expr = Arc::new(TryCastExpr::new(
+            phys_expr::col("col", &batch.schema()).unwrap(),
+            DataType::Int32,
+        ));
+
+        let actual = evaluate(expr, &batch);
+        let expected: ArrayRef = Arc::new(Int32Array::from(vec![Some(2), Some(3), Some(4)]));
+        assert_eq!(&actual, &expected);
+    }
+
+    #[test]
+    fn cast_trimmed_utf8_into_float32() {
+        let batch = make_batch(
+            Arc::new(StringArray::from(vec![
+                Some(" 2.5"),
+                Some("6.75 "),
+                Some(" 8.125 "),
+            ])),
+            DataType::Utf8,
+        );
+
+        let expr = Arc::new(TryCastExpr::new(
+            phys_expr::col("col", &batch.schema()).unwrap(),
+            DataType::Float32,
+        ));
+
+        let actual = evaluate(expr, &batch);
+        let expected: ArrayRef = Arc::new(Float32Array::from(vec![
+            Some(2.5),
+            Some(6.75),
+            Some(8.125),
+        ]));
+        assert_eq!(&actual, &expected);
     }
 }

--- a/spark-extension-shims-spark3/src/test/scala/org/apache/spark/sql/auron/NativeConvertersSuite.scala
+++ b/spark-extension-shims-spark3/src/test/scala/org/apache/spark/sql/auron/NativeConvertersSuite.scala
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.auron
+
+import org.apache.spark.sql.{QueryTest, SparkSession}
+import org.apache.spark.sql.catalyst.expressions.Cast
+import org.apache.spark.sql.catalyst.expressions.Literal
+import org.apache.spark.sql.types.IntegerType
+import org.apache.spark.unsafe.types.UTF8String
+import org.apache.auron.protobuf.ScalarFunction
+import org.apache.auron.sparkverEnableMembers
+
+@sparkverEnableMembers("3.5")
+class NativeConvertersSuite extends QueryTest with BaseAuronSQLSuite
+  with AuronSQLTestHelper {
+
+  import testImplicits._
+
+  test("cast from string to numeric adds trim wrapper before native cast when enabled") {
+    withSQLConf(AuronConf.CAST_STRING_TRIM_ENABLE.key -> "true") {
+      val expr = Cast(Literal(UTF8String.fromString(" 42 ")), IntegerType)
+      val nativeExpr = NativeConverters.convertExpr(expr)
+
+      assert(nativeExpr.hasTryCast)
+      val childExpr = nativeExpr.getTryCast.getExpr
+      assert(childExpr.hasScalarFunction)
+      val scalarFn = childExpr.getScalarFunction
+      assert(scalarFn.getFun == ScalarFunction.Trim)
+      assert(scalarFn.getArgsCount == 1 && scalarFn.getArgs(0).hasLiteral)
+    }
+  }
+
+  test("cast trim disabled via auron conf") {
+    withEnvConf(AuronConf.CAST_STRING_TRIM_ENABLE.key -> "false") {
+      val expr = Cast(Literal(UTF8String.fromString(" 42 ")), IntegerType)
+      val nativeExpr = NativeConverters.convertExpr(expr)
+
+      assert(nativeExpr.hasTryCast)
+      val childExpr = nativeExpr.getTryCast.getExpr
+      assert(!childExpr.hasScalarFunction)
+      assert(childExpr.hasLiteral)
+    }
+  }
+
+  test("cast with non-string child remains unchanged") {
+    val expr = Cast(Literal(1.5), IntegerType)
+    val nativeExpr = NativeConverters.convertExpr(expr)
+
+    assert(nativeExpr.hasTryCast)
+    val childExpr = nativeExpr.getTryCast.getExpr
+    assert(!childExpr.hasScalarFunction)
+    assert(childExpr.hasLiteral)
+  }
+}

--- a/spark-extension-shims-spark3/src/test/scala/org/apache/spark/sql/auron/NativeConvertersSuite.scala
+++ b/spark-extension-shims-spark3/src/test/scala/org/apache/spark/sql/auron/NativeConvertersSuite.scala
@@ -16,15 +16,15 @@
  */
 package org.apache.spark.sql.auron
 
-import org.apache.spark.sql.{QueryTest, SparkSession}
+import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.catalyst.expressions.Cast
 import org.apache.spark.sql.catalyst.expressions.Literal
 import org.apache.spark.sql.types.IntegerType
 import org.apache.spark.unsafe.types.UTF8String
+
 import org.apache.auron.protobuf.ScalarFunction
 
-class NativeConvertersSuite extends QueryTest with BaseAuronSQLSuite
-  with AuronSQLTestHelper {
+class NativeConvertersSuite extends QueryTest with BaseAuronSQLSuite with AuronSQLTestHelper {
 
   test("cast from string to numeric adds trim wrapper before native cast when enabled") {
     withSQLConf(AuronConf.CAST_STRING_TRIM_ENABLE.key -> "true") {

--- a/spark-extension-shims-spark3/src/test/scala/org/apache/spark/sql/auron/NativeConvertersSuite.scala
+++ b/spark-extension-shims-spark3/src/test/scala/org/apache/spark/sql/auron/NativeConvertersSuite.scala
@@ -19,16 +19,15 @@ package org.apache.spark.sql.auron
 import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.catalyst.expressions.Cast
 import org.apache.spark.sql.catalyst.expressions.Literal
-import org.apache.spark.sql.types.IntegerType
+import org.apache.spark.sql.types.{IntegerType, StringType}
 import org.apache.spark.unsafe.types.UTF8String
-
 import org.apache.auron.protobuf.ScalarFunction
 
 class NativeConvertersSuite extends QueryTest with BaseAuronSQLSuite with AuronSQLTestHelper {
 
   test("cast from string to numeric adds trim wrapper before native cast when enabled") {
     withSQLConf(AuronConf.CAST_STRING_TRIM_ENABLE.key -> "true") {
-      val expr = Cast(Literal(UTF8String.fromString(" 42 ")), IntegerType)
+      val expr = Cast(Literal.create(" 42 ", StringType), IntegerType)
       val nativeExpr = NativeConverters.convertExpr(expr)
 
       assert(nativeExpr.hasTryCast)
@@ -42,7 +41,7 @@ class NativeConvertersSuite extends QueryTest with BaseAuronSQLSuite with AuronS
 
   test("cast trim disabled via auron conf") {
     withEnvConf(AuronConf.CAST_STRING_TRIM_ENABLE.key -> "false") {
-      val expr = Cast(Literal(UTF8String.fromString(" 42 ")), IntegerType)
+      val expr = Cast(Literal.create(" 42 ", StringType), IntegerType)
       val nativeExpr = NativeConverters.convertExpr(expr)
 
       assert(nativeExpr.hasTryCast)

--- a/spark-extension-shims-spark3/src/test/scala/org/apache/spark/sql/auron/NativeConvertersSuite.scala
+++ b/spark-extension-shims-spark3/src/test/scala/org/apache/spark/sql/auron/NativeConvertersSuite.scala
@@ -19,35 +19,55 @@ package org.apache.spark.sql.auron
 import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.catalyst.expressions.Cast
 import org.apache.spark.sql.catalyst.expressions.Literal
-import org.apache.spark.sql.types.{IntegerType, StringType}
+import org.apache.spark.sql.types.{BooleanType, DataType, IntegerType, StringType}
 
 import org.apache.auron.protobuf.ScalarFunction
 
 class NativeConvertersSuite extends QueryTest with BaseAuronSQLSuite with AuronSQLTestHelper {
 
+  private def assertTrimmedCast(rawValue: String, targetType: DataType): Unit = {
+    val expr = Cast(Literal.create(rawValue, StringType), targetType)
+    val nativeExpr = NativeConverters.convertExpr(expr)
+
+    assert(nativeExpr.hasTryCast)
+    val childExpr = nativeExpr.getTryCast.getExpr
+    assert(childExpr.hasScalarFunction)
+    val scalarFn = childExpr.getScalarFunction
+    assert(scalarFn.getFun == ScalarFunction.Trim)
+    assert(scalarFn.getArgsCount == 1 && scalarFn.getArgs(0).hasLiteral)
+  }
+
+  private def assertNonTrimmedCast(rawValue: String, targetType: DataType): Unit = {
+    val expr = Cast(Literal.create(rawValue, StringType), targetType)
+    val nativeExpr = NativeConverters.convertExpr(expr)
+
+    assert(nativeExpr.hasTryCast)
+    val childExpr = nativeExpr.getTryCast.getExpr
+    assert(!childExpr.hasScalarFunction)
+    assert(childExpr.hasLiteral)
+  }
+
   test("cast from string to numeric adds trim wrapper before native cast when enabled") {
     withSQLConf(AuronConf.CAST_STRING_TRIM_ENABLE.key -> "true") {
-      val expr = Cast(Literal.create(" 42 ", StringType), IntegerType)
-      val nativeExpr = NativeConverters.convertExpr(expr)
+      assertTrimmedCast(" 42 ", IntegerType)
+    }
+  }
 
-      assert(nativeExpr.hasTryCast)
-      val childExpr = nativeExpr.getTryCast.getExpr
-      assert(childExpr.hasScalarFunction)
-      val scalarFn = childExpr.getScalarFunction
-      assert(scalarFn.getFun == ScalarFunction.Trim)
-      assert(scalarFn.getArgsCount == 1 && scalarFn.getArgs(0).hasLiteral)
+  test("cast from string to boolean adds trim wrapper before native cast when enabled") {
+    withSQLConf(AuronConf.CAST_STRING_TRIM_ENABLE.key -> "true") {
+      assertTrimmedCast(" true ", BooleanType)
     }
   }
 
   test("cast trim disabled via auron conf") {
     withEnvConf(AuronConf.CAST_STRING_TRIM_ENABLE.key -> "false") {
-      val expr = Cast(Literal.create(" 42 ", StringType), IntegerType)
-      val nativeExpr = NativeConverters.convertExpr(expr)
+      assertNonTrimmedCast(" 42 ", IntegerType)
+    }
+  }
 
-      assert(nativeExpr.hasTryCast)
-      val childExpr = nativeExpr.getTryCast.getExpr
-      assert(!childExpr.hasScalarFunction)
-      assert(childExpr.hasLiteral)
+  test("cast trim disabled via auron conf for boolean cast") {
+    withEnvConf(AuronConf.CAST_STRING_TRIM_ENABLE.key -> "false") {
+      assertNonTrimmedCast(" true ", BooleanType)
     }
   }
 

--- a/spark-extension-shims-spark3/src/test/scala/org/apache/spark/sql/auron/NativeConvertersSuite.scala
+++ b/spark-extension-shims-spark3/src/test/scala/org/apache/spark/sql/auron/NativeConvertersSuite.scala
@@ -20,7 +20,7 @@ import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.catalyst.expressions.Cast
 import org.apache.spark.sql.catalyst.expressions.Literal
 import org.apache.spark.sql.types.{IntegerType, StringType}
-import org.apache.spark.unsafe.types.UTF8String
+
 import org.apache.auron.protobuf.ScalarFunction
 
 class NativeConvertersSuite extends QueryTest with BaseAuronSQLSuite with AuronSQLTestHelper {

--- a/spark-extension-shims-spark3/src/test/scala/org/apache/spark/sql/auron/NativeConvertersSuite.scala
+++ b/spark-extension-shims-spark3/src/test/scala/org/apache/spark/sql/auron/NativeConvertersSuite.scala
@@ -22,13 +22,9 @@ import org.apache.spark.sql.catalyst.expressions.Literal
 import org.apache.spark.sql.types.IntegerType
 import org.apache.spark.unsafe.types.UTF8String
 import org.apache.auron.protobuf.ScalarFunction
-import org.apache.auron.sparkverEnableMembers
 
-@sparkverEnableMembers("3.5")
 class NativeConvertersSuite extends QueryTest with BaseAuronSQLSuite
   with AuronSQLTestHelper {
-
-  import testImplicits._
 
   test("cast from string to numeric adds trim wrapper before native cast when enabled") {
     withSQLConf(AuronConf.CAST_STRING_TRIM_ENABLE.key -> "true") {

--- a/spark-extension/src/main/java/org/apache/spark/sql/auron/AuronConf.java
+++ b/spark-extension/src/main/java/org/apache/spark/sql/auron/AuronConf.java
@@ -52,6 +52,9 @@ public enum AuronConf {
     // TypedImperativeAggregate one row mem use size
     UDAF_FALLBACK_ESTIM_ROW_SIZE("spark.auron.udafFallback.typedImperativeEstimatedRowSize", 256),
 
+    /// enable trimming string inputs before casting to numeric types
+    CAST_STRING_TRIM_ENABLE("spark.auron.cast.stringTrimBeforeNumeric", true),
+
     /// ignore corrupted input files
     IGNORE_CORRUPTED_FILES("spark.files.ignoreCorruptFiles", false),
 

--- a/spark-extension/src/main/java/org/apache/spark/sql/auron/AuronConf.java
+++ b/spark-extension/src/main/java/org/apache/spark/sql/auron/AuronConf.java
@@ -52,8 +52,8 @@ public enum AuronConf {
     // TypedImperativeAggregate one row mem use size
     UDAF_FALLBACK_ESTIM_ROW_SIZE("spark.auron.udafFallback.typedImperativeEstimatedRowSize", 256),
 
-    /// enable trimming string inputs before casting to numeric types
-    CAST_STRING_TRIM_ENABLE("spark.auron.cast.stringTrimBeforeNumeric", true),
+    /// enable trimming string inputs before casting to numeric/boolean types
+    CAST_STRING_TRIM_ENABLE("spark.auron.cast.trimString", true),
 
     /// ignore corrupted input files
     IGNORE_CORRUPTED_FILES("spark.files.ignoreCorruptFiles", false),

--- a/spark-extension/src/main/scala/org/apache/spark/sql/auron/NativeConverters.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/auron/NativeConverters.scala
@@ -449,7 +449,9 @@ object NativeConverters extends Logging {
           if !Seq(cast.dataType, cast.child.dataType).exists(t =>
             t.isInstanceOf[TimestampType] || t.isInstanceOf[DateType]) =>
         val castChild =
-          if (cast.child.dataType == StringType && cast.dataType.isInstanceOf[NumericType] &&
+          if (cast.child.dataType == StringType &&
+            (cast.dataType.isInstanceOf[NumericType] || cast.dataType
+              .isInstanceOf[BooleanType]) &&
             AuronConf.CAST_STRING_TRIM_ENABLE.booleanConf()) {
             // converting Cast(str as num) to StringTrim(Cast(str as num)) if enabled
             StringTrim(cast.child)

--- a/spark-extension/src/main/scala/org/apache/spark/sql/auron/NativeConverters.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/auron/NativeConverters.scala
@@ -446,8 +446,8 @@ object NativeConverters extends Logging {
       // cast
       // not performing native cast for timestamp/dates (will use UDFWrapper instead)
       case cast: Cast
-        if !Seq(cast.dataType, cast.child.dataType).exists(t =>
-          t.isInstanceOf[TimestampType] || t.isInstanceOf[DateType]) =>
+          if !Seq(cast.dataType, cast.child.dataType).exists(t =>
+            t.isInstanceOf[TimestampType] || t.isInstanceOf[DateType]) =>
         val castChild =
           if (cast.child.dataType == StringType && cast.dataType.isInstanceOf[NumericType] &&
             AuronConf.CAST_STRING_TRIM_ENABLE.booleanConf()) {

--- a/spark-extension/src/main/scala/org/apache/spark/sql/auron/NativeConverters.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/auron/NativeConverters.scala
@@ -451,6 +451,7 @@ object NativeConverters extends Logging {
         val castChild =
           if (cast.child.dataType == StringType && cast.dataType.isInstanceOf[NumericType] &&
               AuronConf.CAST_STRING_TRIM_ENABLE.booleanConf()) {
+            // converting Cast(str as num) to StringTrim(Cast(str as num)) if enabled
             StringTrim(cast.child)
           } else {
             cast.child

--- a/spark-extension/src/main/scala/org/apache/spark/sql/auron/NativeConverters.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/auron/NativeConverters.scala
@@ -446,11 +446,11 @@ object NativeConverters extends Logging {
       // cast
       // not performing native cast for timestamp/dates (will use UDFWrapper instead)
       case cast: Cast
-          if !Seq(cast.dataType, cast.child.dataType).exists(t =>
-            t.isInstanceOf[TimestampType] || t.isInstanceOf[DateType]) =>
+        if !Seq(cast.dataType, cast.child.dataType).exists(t =>
+          t.isInstanceOf[TimestampType] || t.isInstanceOf[DateType]) =>
         val castChild =
           if (cast.child.dataType == StringType && cast.dataType.isInstanceOf[NumericType] &&
-              AuronConf.CAST_STRING_TRIM_ENABLE.booleanConf()) {
+            AuronConf.CAST_STRING_TRIM_ENABLE.booleanConf()) {
             // converting Cast(str as num) to StringTrim(Cast(str as num)) if enabled
             StringTrim(cast.child)
           } else {


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1316.

 # Rationale for this change
  - Add a new conf `spark.auron.cast.trimString` default to `true`
  - If the conf is set to `true`, the expression  `Cast(str as num)` would be converting to `StringTrim(Cast(str as num))`
    - Both `Numberic` and `Boolean` are supported.

# What changes are included in this PR?
- In `NativeConvertersSuite.scala`, add logic to support expression converting.

# Are there any user-facing changes?
  - Yes. Casting Utf8 strings that contain surrounding whitespace into numeric types now succeeds instead of yielding nulls, matching Spark casting semantics.
  - 
# How was this patch tested?
- Add `NativeConvertersSuite` to test the trim logic.

# Next step
There are still several gaps compared to Spark’s `cast` function, such as handling `+inf`. I can contribute improvements to address these in upcoming PRs.