### PR TITLE
[AURON #1346] Change spark.auron.enable to spark.auron.enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ This section describes how to submit and configure a Spark Job with Auron suppor
 2. Add the following configs to spark configuration in `spark-xx.xx.xx/conf/spark-default.conf`:
 
 ```properties
-spark.auron.enable true
+spark.auron.enabled true
 spark.sql.extensions org.apache.spark.sql.auron.AuronSparkSessionExtension
 spark.shuffle.manager org.apache.spark.sql.execution.auron.shuffle.AuronShuffleManager
 spark.memory.offHeap.enabled false

--- a/spark-extension-shims-spark3/src/test/scala/org/apache/spark/sql/auron/BaseAuronSQLSuite.scala
+++ b/spark-extension-shims-spark3/src/test/scala/org/apache/spark/sql/auron/BaseAuronSQLSuite.scala
@@ -28,7 +28,7 @@ trait BaseAuronSQLSuite extends SharedSparkSession {
         "spark.shuffle.manager",
         "org.apache.spark.sql.execution.auron.shuffle.AuronShuffleManager")
       .set("spark.memory.offHeap.enabled", "false")
-      .set("spark.auron.enable", "true")
+      .set("spark.auron.enabled", "true")
   }
 
 }

--- a/spark-extension/src/main/scala/org/apache/spark/sql/auron/AuronSparkSessionExtension.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/auron/AuronSparkSessionExtension.scala
@@ -46,7 +46,7 @@ class AuronSparkSessionExtension extends (SparkSessionExtensions => Unit) with L
 
 object AuronSparkSessionExtension extends Logging {
   lazy val auronEnabledKey: ConfigEntry[Boolean] = SQLConf
-    .buildConf("spark.auron.enable")
+    .buildConf("spark.auron.enabled")
     .booleanConf
     .createWithDefault(true)
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Please keep the following tips in mind:
  - Start the PR title with the related issue ID, e.g. '[AURON #XXXX] Short summary...'.
  - Make your PR title clear and descriptive, summarizing what this PR changes.
  - Provide a concise example to reproduce the issue, if possible.
  - Keep the PR description up to date with all changes.
-->

# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1346 

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Change spark.auron.enable to spark.auron.enabled
# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

# How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
