### PR TITLE
bump maven version to 3.9.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -262,7 +262,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>${maven.version}</version>
+        <version>3.14.1</version>
         <configuration>
           <source>${javaVersion}</source>
           <target>${javaVersion}</target>


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

 # Rationale for this change

Both use Maven 3.9.11

https://github.com/actions/runner-images/blob/ubuntu22/20250922.79/images/ubuntu/Ubuntu2204-Readme.md#project-management

https://github.com/actions/runner-images/blob/ubuntu24/20250922.53/images/ubuntu/Ubuntu2404-Readme.md#project-management

---

https://github.com/apache/auron/actions/runs/17983060351/job/51204371036?pr=1345

```
[WARN] Maven version mismatch:
       Detected: 3.9.11
       Required: 3.8.1

[INFO] Downloading with curl...
#=#=#                                                                         
curl: (7) Failed to connect to archive.apache.org port 443 after 174 ms: Connection refused
```

# What changes are included in this PR?

# Are there any user-facing changes?

# How was this patch tested?


```bash
[INFO] Using Maven: /usr/bin/mvn
Apache Maven 3.9.11 (3e54c93a704957b63ee3494413a2b544fd3d825b)
Maven home: /usr/share/apache-maven-3.9.11
```

https://github.com/apache/auron/actions/runs/18000531987/job/51208522366?pr=1350

