### PR TITLE
[AURON #1390]Separate the spark.auron.enable.aggr parameter to distin…

### DIFF
--- a/spark-extension-shims-spark3/src/test/scala/org/apache/spark/sql/auron/AuronCheckConvertAggrSuite.scala
+++ b/spark-extension-shims-spark3/src/test/scala/org/apache/spark/sql/auron/AuronCheckConvertAggrSuite.scala
@@ -1,0 +1,229 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.auron
+
+import scala.collection.mutable.ArrayBuffer
+
+import org.apache.spark.sql.{QueryTest, Row, SparkSession}
+import org.apache.spark.sql.catalyst.expressions.aggregate.Partial
+import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanExec
+import org.apache.spark.sql.execution.aggregate.{HashAggregateExec, ObjectHashAggregateExec, SortAggregateExec}
+import org.apache.spark.sql.execution.auron.plan.NativeAggExec
+import org.apache.spark.sql.test.SharedSparkSession
+
+class AuronCheckConvertAggrSuite
+    extends QueryTest
+    with SharedSparkSession
+    with AuronSQLTestHelper
+    with org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper {
+  import testImplicits._
+
+  test("test hash aggr convert to native") {
+    val spark = SparkSession
+      .builder()
+      .master("local[2]")
+      .appName("checkSeparateAggr")
+      .config("spark.sql.shuffle.partitions", "4")
+      .config("spark.sql.autoBroadcastJoinThreshold", -1)
+      .config("spark.sql.extensions", "org.apache.spark.sql.auron.AuronSparkSessionExtension")
+      .config(
+        "spark.shuffle.manager",
+        "org.apache.spark.sql.execution.auron.shuffle.AuronShuffleManager")
+      .config("spark.memory.offHeap.enabled", "false")
+      .config("spark.auron.enable", "true")
+      .getOrCreate()
+    Seq((1, 2, "test test"))
+      .toDF("c1", "c2", "part")
+      .createOrReplaceTempView("separate_hash_aggr")
+    val executePlan = spark.sql("select c1, count(1) from separate_hash_aggr group by c1")
+    val plan = executePlan.queryExecution.executedPlan.asInstanceOf[AdaptiveSparkPlanExec]
+    val hashAggregateExec =
+      plan.executedPlan.collectFirst {
+        case hashAggregateExec: HashAggregateExec
+            if hashAggregateExec.aggregateExpressions.forall(_.mode == Partial) =>
+          hashAggregateExec
+      }
+    val afterConvertPlan = AuronConverters.convertSparkPlan(hashAggregateExec.get)
+    assert(afterConvertPlan.isInstanceOf[NativeAggExec])
+    checkAnswer(executePlan, Seq(Row(1, 1)))
+  }
+
+  test("test hash aggr do not convert to native") {
+    val spark = SparkSession
+      .builder()
+      .master("local[2]")
+      .appName("checkSeparateAggr")
+      .config("spark.sql.shuffle.partitions", "4")
+      .config("spark.sql.autoBroadcastJoinThreshold", -1)
+      .config("spark.sql.extensions", "org.apache.spark.sql.auron.AuronSparkSessionExtension")
+      .config(
+        "spark.shuffle.manager",
+        "org.apache.spark.sql.execution.auron.shuffle.AuronShuffleManager")
+      .config("spark.memory.offHeap.enabled", "false")
+      .config("spark.auron.enable.hash.aggr", "false")
+      .config("spark.auron.enable", "true")
+      .getOrCreate()
+    Seq((1, 2, "test test"))
+      .toDF("c1", "c2", "part")
+      .createOrReplaceTempView("separate_hash_aggr")
+    val executePlan = spark.sql("select c1, count(1) from separate_hash_aggr group by c1")
+    val plan = executePlan.queryExecution.executedPlan.asInstanceOf[AdaptiveSparkPlanExec]
+    val hashAggregateExec =
+      plan.executedPlan
+        .collectFirst {
+          case hashAggregateExec: HashAggregateExec
+              if hashAggregateExec.aggregateExpressions.forall(_.mode == Partial) =>
+            hashAggregateExec
+        }
+    val afterConvertPlan = AuronConverters.convertSparkPlan(hashAggregateExec.get)
+    assert(afterConvertPlan.isInstanceOf[HashAggregateExec])
+    checkAnswer(executePlan, Seq(Row(1, 1)))
+  }
+
+  test("test sort aggr convert to native") {
+    val spark = SparkSession
+      .builder()
+      .master("local[2]")
+      .appName("checkSeparateAggr")
+      .config("spark.sql.shuffle.partitions", "4")
+      .config("spark.sql.autoBroadcastJoinThreshold", -1)
+      .config("spark.sql.extensions", "org.apache.spark.sql.auron.AuronSparkSessionExtension")
+      .config(
+        "spark.shuffle.manager",
+        "org.apache.spark.sql.execution.auron.shuffle.AuronShuffleManager")
+      .config("spark.memory.offHeap.enabled", "false")
+      .config("spark.sql.execution.useObjectHashAggregateExec", "false")
+      .config("spark.sql.execution.useHashAggregateExec", "false")
+      .config("spark.auron.enable", "true")
+      .getOrCreate()
+    Seq((1, 2, "test test"))
+      .toDF("c1", "c2", "part")
+      .createOrReplaceTempView("separate_hash_aggr")
+    val executePlan = spark.sql("select c1, collect_list(c2) from separate_hash_aggr group by c1")
+    val plan = executePlan.queryExecution.executedPlan.asInstanceOf[AdaptiveSparkPlanExec]
+    val sortAggregateExec =
+      plan.executedPlan
+        .collectFirst {
+          case sortAggregateExec: SortAggregateExec
+              if sortAggregateExec.aggregateExpressions.forall(_.mode == Partial) =>
+            sortAggregateExec
+        }
+    val afterConvertPlan = AuronConverters.convertSparkPlan(sortAggregateExec.get)
+    assert(afterConvertPlan.isInstanceOf[NativeAggExec])
+    checkAnswer(executePlan, Seq(Row(1, ArrayBuffer(2))))
+  }
+
+  test("test sort aggr do not convert to native") {
+    val spark = SparkSession
+      .builder()
+      .master("local[2]")
+      .appName("checkSeparateAggr")
+      .config("spark.sql.shuffle.partitions", "4")
+      .config("spark.sql.autoBroadcastJoinThreshold", -1)
+      .config("spark.sql.extensions", "org.apache.spark.sql.auron.AuronSparkSessionExtension")
+      .config(
+        "spark.shuffle.manager",
+        "org.apache.spark.sql.execution.auron.shuffle.AuronShuffleManager")
+      .config("spark.memory.offHeap.enabled", "false")
+      .config("spark.sql.execution.useObjectHashAggregateExec", "false")
+      .config("spark.sql.execution.useHashAggregateExec", "false")
+      .config("spark.auron.enable.sort.aggr", "false")
+      .config("spark.auron.enable", "true")
+      .getOrCreate()
+    Seq((1, 2, "test test"))
+      .toDF("c1", "c2", "part")
+      .createOrReplaceTempView("separate_hash_aggr")
+    val executePlan = spark.sql("select c1, collect_list(c2) from separate_hash_aggr group by c1")
+    val plan = executePlan.queryExecution.executedPlan.asInstanceOf[AdaptiveSparkPlanExec]
+    val sortAggregateExec =
+      plan.executedPlan
+        .collectFirst {
+          case sortAggregateExec: SortAggregateExec
+              if sortAggregateExec.aggregateExpressions.forall(_.mode == Partial) =>
+            sortAggregateExec
+        }
+    val afterConvertPlan = AuronConverters.convertSparkPlan(sortAggregateExec.get)
+    assert(afterConvertPlan.isInstanceOf[SortAggregateExec])
+    checkAnswer(executePlan, Seq(Row(1, ArrayBuffer(2))))
+  }
+
+  test("test object hash aggr convert to native") {
+    val spark = SparkSession
+      .builder()
+      .master("local[2]")
+      .appName("checkSeparateAggr")
+      .config("spark.sql.shuffle.partitions", "4")
+      .config("spark.sql.autoBroadcastJoinThreshold", -1)
+      .config("spark.sql.extensions", "org.apache.spark.sql.auron.AuronSparkSessionExtension")
+      .config(
+        "spark.shuffle.manager",
+        "org.apache.spark.sql.execution.auron.shuffle.AuronShuffleManager")
+      .config("spark.memory.offHeap.enabled", "false")
+      .config("spark.sql.execution.useHashAggregateExec", "false")
+      .config("spark.auron.enable", "true")
+      .getOrCreate()
+    Seq((1, 2, "test test"))
+      .toDF("c1", "c2", "part")
+      .createOrReplaceTempView("separate_hash_aggr")
+    val executePlan = spark.sql("select c1, collect_list(c2) from separate_hash_aggr group by c1")
+    val plan = executePlan.queryExecution.executedPlan.asInstanceOf[AdaptiveSparkPlanExec]
+    val objectHashAggregateExec =
+      plan.executedPlan
+        .collectFirst {
+          case objectHashAggregateExec: ObjectHashAggregateExec
+              if objectHashAggregateExec.aggregateExpressions.forall(_.mode == Partial) =>
+            objectHashAggregateExec
+        }
+    val afterConvertPlan = AuronConverters.convertSparkPlan(objectHashAggregateExec.get)
+    assert(afterConvertPlan.isInstanceOf[NativeAggExec])
+    checkAnswer(executePlan, Seq(Row(1, ArrayBuffer(2))))
+  }
+
+  test("test object hash aggr do not convert to native") {
+    val spark = SparkSession
+      .builder()
+      .master("local[2]")
+      .appName("checkSeparateAggr")
+      .config("spark.sql.shuffle.partitions", "4")
+      .config("spark.sql.autoBroadcastJoinThreshold", -1)
+      .config("spark.sql.extensions", "org.apache.spark.sql.auron.AuronSparkSessionExtension")
+      .config(
+        "spark.shuffle.manager",
+        "org.apache.spark.sql.execution.auron.shuffle.AuronShuffleManager")
+      .config("spark.memory.offHeap.enabled", "false")
+      .config("spark.sql.execution.useHashAggregateExec", "false")
+      .config("spark.auron.enable.object.hash.aggr", "false")
+      .config("spark.auron.enable", "true")
+      .getOrCreate()
+    Seq((1, 2, "test test"))
+      .toDF("c1", "c2", "part")
+      .createOrReplaceTempView("separate_hash_aggr")
+    val executePlan = spark.sql("select c1, collect_list(c2) from separate_hash_aggr group by c1")
+    val plan = executePlan.queryExecution.executedPlan.asInstanceOf[AdaptiveSparkPlanExec]
+    val objectHashAggregateExec =
+      plan.executedPlan
+        .collectFirst {
+          case objectHashAggregateExec: ObjectHashAggregateExec
+              if objectHashAggregateExec.aggregateExpressions.forall(_.mode == Partial) =>
+            objectHashAggregateExec
+        }
+    val afterConvertPlan = AuronConverters.convertSparkPlan(objectHashAggregateExec.get)
+    assert(afterConvertPlan.isInstanceOf[ObjectHashAggregateExec])
+    checkAnswer(executePlan, Seq(Row(1, ArrayBuffer(2))))
+  }
+
+}

--- a/spark-extension/src/main/scala/org/apache/spark/sql/auron/AuronConverters.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/auron/AuronConverters.scala
@@ -120,8 +120,12 @@ object AuronConverters extends Logging {
     getBooleanConf("spark.auron.enable.global.limit", defaultValue = true)
   def enableTakeOrderedAndProject: Boolean =
     getBooleanConf("spark.auron.enable.take.ordered.and.project", defaultValue = true)
-  def enableAggr: Boolean =
-    getBooleanConf("spark.auron.enable.aggr", defaultValue = true)
+  def enableHashAggr: Boolean =
+    getBooleanConf("spark.auron.enable.hash.aggr", defaultValue = true)
+  def enableSortAggr: Boolean =
+    getBooleanConf("spark.auron.enable.sort.aggr", defaultValue = true)
+  def enableObjectHashAggr: Boolean =
+    getBooleanConf("spark.auron.enable.object.hash.aggr", defaultValue = true)
   def enableExpand: Boolean =
     getBooleanConf("spark.auron.enable.expand", defaultValue = true)
   def enableWindow: Boolean =
@@ -204,7 +208,7 @@ object AuronConverters extends Logging {
       case e: TakeOrderedAndProjectExec if enableTakeOrderedAndProject =>
         tryConvert(e, convertTakeOrderedAndProjectExec)
 
-      case e: HashAggregateExec if enableAggr => // hash aggregate
+      case e: HashAggregateExec if enableHashAggr => // hash aggregate
         val convertedAgg = tryConvert(e, convertHashAggregateExec)
         if (!e.getTagValue(convertibleTag).contains(true)) {
           if (e.requiredChildDistributionExpressions.isDefined) {
@@ -215,7 +219,7 @@ object AuronConverters extends Logging {
         }
         convertedAgg
 
-      case e: ObjectHashAggregateExec if enableAggr => // object hash aggregate
+      case e: ObjectHashAggregateExec if enableObjectHashAggr => // object hash aggregate
         val convertedAgg = tryConvert(e, convertObjectHashAggregateExec)
         if (!e.getTagValue(convertibleTag).contains(true)) {
           if (e.requiredChildDistributionExpressions.isDefined) {
@@ -226,7 +230,7 @@ object AuronConverters extends Logging {
         }
         convertedAgg
 
-      case e: SortAggregateExec if enableAggr => // sort aggregate
+      case e: SortAggregateExec if enableSortAggr => // sort aggregate
         val convertedAgg = tryConvert(e, convertSortAggregateExec)
         if (!e.getTagValue(convertibleTag).contains(true)) {
           if (e.requiredChildDistributionExpressions.isDefined) {


### PR DESCRIPTION
…guish hash aggregate, sort aggregate, and object hash aggregate.

<!--
Thanks for sending a pull request!  Please keep the following tips in mind:
  - Start the PR title with the related issue ID, e.g. '[AURON #XXXX] Short summary...'.
  - Make your PR title clear and descriptive, summarizing what this PR changes.
  - Provide a concise example to reproduce the issue, if possible.
  - Keep the PR description up to date with all changes.
-->

# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1390


 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
Introduce three new parameters to separately control the native conversion of hash aggregate, sort aggregate, and object hash aggregate.




# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
Delete conf : spark.auron.enable.aggr, and add three new conf : spark.auron.enable.hash.aggr, spark.auron.enable.sort.aggr and spark.auron.enable.object.hash.aggr.


# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
Use new conf to control aggr to native.

# How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Add new UT.
