### PR TITLE
[AURON #1419]Add neverConvertReasonTag to record the reason for non-conversion.

### DIFF
--- a/spark-extension/src/main/scala/org/apache/spark/sql/auron/AuronConverters.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/auron/AuronConverters.scala
@@ -27,12 +27,7 @@ import org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat
 import org.apache.spark.Partition
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.auron.AuronConvertStrategy.childOrderingRequiredTag
-import org.apache.spark.sql.auron.AuronConvertStrategy.convertibleTag
-import org.apache.spark.sql.auron.AuronConvertStrategy.convertStrategyTag
-import org.apache.spark.sql.auron.AuronConvertStrategy.convertToNonNativeTag
-import org.apache.spark.sql.auron.AuronConvertStrategy.isNeverConvert
-import org.apache.spark.sql.auron.AuronConvertStrategy.joinSmallerSideTag
+import org.apache.spark.sql.auron.AuronConvertStrategy.{childOrderingRequiredTag, convertibleTag, convertStrategyTag, convertToNonNativeTag, isNeverConvert, joinSmallerSideTag, neverConvertReasonTag}
 import org.apache.spark.sql.auron.NativeConverters.{roundRobinTypeSupported, scalarTypeSupported, StubExpr}
 import org.apache.spark.sql.auron.util.AuronLogUtils.logDebugPlanConversion
 import org.apache.spark.sql.catalyst.expressions.AggregateWindowFunction
@@ -265,14 +260,68 @@ object AuronConverters extends Logging {
                 if (Shims.get.isNative(exec)) { // for QueryStageInput and CustomShuffleReader
                   exec.setTagValue(convertibleTag, true)
                   exec.setTagValue(convertStrategyTag, AlwaysConvert)
+                  exec
                 } else {
-                  exec.setTagValue(convertibleTag, false)
-                  exec.setTagValue(convertStrategyTag, NeverConvert)
+                  addNeverConvertReasonTag(exec)
                 }
-                exec
             }
         }
     }
+  }
+
+  private def addNeverConvertReasonTag(exec: SparkPlan) = {
+    val neverConvertReason =
+      exec match {
+        case _: FileSourceScanExec if !enableScan =>
+          "Conversion disabled: spark.auron.enable.scan=false."
+        case _: ProjectExec if !enableProject =>
+          "Conversion disabled: spark.auron.enable.project=false."
+        case _: FilterExec if !enableFilter =>
+          "Conversion disabled: spark.auron.enable.filter=false."
+        case _: SortExec if !enableSort =>
+          "Conversion disabled: spark.auron.enable.sort=false."
+        case _: UnionExec if !enableUnion =>
+          "Conversion disabled: spark.auron.enable.union=false."
+        case _: SortMergeJoinExec if !enableSmj =>
+          "Conversion disabled: spark.auron.enable.smj=false."
+        case _: ShuffledHashJoinExec if !enableShj =>
+          "Conversion disabled: spark.auron.enable.shj=false."
+        case _: BroadcastHashJoinExec if !enableBhj =>
+          "Conversion disabled: spark.auron.enable.bhj=false."
+        case _: BroadcastNestedLoopJoinExec if !enableBnlj =>
+          "Conversion disabled: spark.auron.enable.bnlj=false."
+        case _: LocalLimitExec if !enableLocalLimit =>
+          "Conversion disabled: spark.auron.enable.local.limit=false."
+        case _: GlobalLimitExec if !enableGlobalLimit =>
+          "Conversion disabled: spark.auron.enable.global.limit=false."
+        case _: TakeOrderedAndProjectExec if !enableTakeOrderedAndProject =>
+          "Conversion disabled: spark.auron.enable.take.ordered.and.project=false."
+        case _: HashAggregateExec if !enableAggr =>
+          "Conversion disabled: spark.auron.enable.aggr=false."
+        case _: ObjectHashAggregateExec if !enableAggr =>
+          "Conversion disabled: spark.auron.enable.aggr=false."
+        case _: SortAggregateExec if !enableAggr =>
+          "Conversion disabled: spark.auron.enable.aggr=false."
+        case _: ExpandExec if !enableExpand =>
+          "Conversion disabled: spark.auron.enable.expand=false."
+        case _: WindowExec if !enableWindow =>
+          "Conversion disabled: spark.auron.enable.window=false."
+        case _: UnaryExecNode
+            if exec.getClass.getSimpleName == "WindowGroupLimitExec" && !enableWindowGroupLimit =>
+          "Conversion disabled: spark.auron.enable.window.group.limit=false."
+        case _: GenerateExec if !enableGenerate =>
+          "Conversion disabled: spark.auron.enable.generate=false."
+        case _: LocalTableScanExec if !enableLocalTableScan =>
+          "Conversion disabled: spark.auron.enable.local.table.scan=false."
+        case _: DataWritingCommandExec if !enableDataWriting =>
+          "Conversion disabled: spark.auron.enable.data.writing=false."
+        case _ =>
+          s"${exec.getClass.getSimpleName} is not supported yet."
+      }
+    exec.setTagValue(convertibleTag, false)
+    exec.setTagValue(convertStrategyTag, NeverConvert)
+    exec.setTagValue(neverConvertReasonTag, neverConvertReason)
+    exec
   }
 
   def tryConvert[T <: SparkPlan](exec: T, convert: T => SparkPlan): SparkPlan = {
@@ -283,8 +332,26 @@ object AuronConverters extends Logging {
     } catch {
       case e @ (_: NotImplementedError | _: AssertionError | _: Exception) =>
         logWarning(s"Falling back exec: ${exec.getClass.getSimpleName}: ${e.getMessage}")
+        val neverConvertReason = e match {
+          case _: AssertionError =>
+            exec match {
+              case _: FileSourceScanExec if enableScan =>
+                if (!enableScanParquet) {
+                  "Conversion disabled: spark.auron.enable.scan.parquet=false."
+                } else if (!enableScanOrc) {
+                  "Conversion disabled: spark.auron.enable.scan.orc=false."
+                } else {
+                  s"Falling back exec: ${exec.getClass.getSimpleName}: ${e.getMessage}"
+                }
+              case _ =>
+                s"Falling back exec: ${exec.getClass.getSimpleName}: ${e.getMessage}"
+            }
+          case _ =>
+            s"Falling back exec: ${exec.getClass.getSimpleName}: ${e.getMessage}"
+        }
         exec.setTagValue(convertibleTag, false)
         exec.setTagValue(convertStrategyTag, NeverConvert)
+        exec.setTagValue(neverConvertReasonTag, neverConvertReason)
         exec
     }
   }


### PR DESCRIPTION
…onversion.

<!--
Thanks for sending a pull request!  Please keep the following tips in mind:
  - Start the PR title with the related issue ID, e.g. '[AURON #XXXX] Short summary...'.
  - Make your PR title clear and descriptive, summarizing what this PR changes.
  - Provide a concise example to reproduce the issue, if possible.
  - Keep the PR description up to date with all changes.
-->

# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1419

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
During the Spark execution plan conversion process, add neverConvertReasonTag. After adding it, the Spark execution tree can be analyzed to determine which parts of the plan were not converted and the reasons for non-conversion.




# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
The following are the scenarios where conversion is currently not performed.

1. Physical execution plans that are not supported for conversion;
2. Plans that support conversion but are configured not to convert;
3. Plans that support conversion but do not meet certain conditions;
4. Special scenarios where conversion is not performed.

In these scenarios, after the convertStrategyTag is set to NeverConvert, the neverConvertReasonTag is added to describe why the plan was not converted.




# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

# How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

UT
