### PR TITLE
[AURON #1409] followup to always get active context

### DIFF
--- a/spark-extension-shims-spark3/src/main/scala/org/apache/spark/sql/auron/ShimsImpl.scala
+++ b/spark-extension-shims-spark3/src/main/scala/org/apache/spark/sql/auron/ShimsImpl.scala
@@ -158,7 +158,7 @@ class ShimsImpl extends Shims with Logging {
         .get(AuronConf.UI_ENABLED.key, "true"))
 
     if (SparkEnv.get.conf.get(AuronConf.UI_ENABLED.key, "true").equals("true")) {
-      val sparkContext = SparkContext.getActive.getOrElse{
+      val sparkContext = SparkContext.getActive.getOrElse {
         throw new IllegalStateException("No active spark context found that should not happen")
       }
       val kvStore = sparkContext.statusStore.store.asInstanceOf[ElementTrackingStore]


### PR DESCRIPTION
# Which issue does this PR close?

this is the followup PR for https://github.com/apache/auron/pull/1410#discussion_r2422458237

 # Rationale for this change

To emlinate potential bug when getting the spark context

# What changes are included in this PR?

Always to get the active context rather than creating another one when no active context found

# Are there any user-facing changes?

No

# How was this patch tested?

Neen't
