### PR TITLE
[AURON #1458] Centralize supported versions and simplify validation with unified build info output

### DIFF
--- a/auron-build.sh
+++ b/auron-build.sh
@@ -18,50 +18,120 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+# =============================================================================
+# Apache Auron Project Build Script
+# Description:
+#   This script automates the build process for the Apache Auron project.
+# =============================================================================
 
-# Function to display script usage
+# -----------------------------------------------------------------------------
+# Section: Supported versions constants
+# Description:
+#   Define constants for supported component versions
+# -----------------------------------------------------------------------------
+SUPPORTED_OS_IMAGES=("centos7" "ubuntu24" "rockylinux8" "debian11")
+SUPPORTED_SPARK_VERSIONS=("3.0" "3.1" "3.2" "3.3" "3.4" "3.5")
+SUPPORTED_SCALA_VERSIONS=("2.12" "2.13")
+SUPPORTED_CELEBORN_VERSIONS=("0.5" "0.6")
+# Currently only one supported version, but kept plural for consistency
+SUPPORTED_UNIFFLE_VERSIONS=("0.10")
+SUPPORTED_PAIMON_VERSIONS=("1.2")
+SUPPORTED_FLINK_VERSIONS=("1.18")
+
+# -----------------------------------------------------------------------------
+# Function: print_help
+# Description:
+#   Print script usage information, supported options, and example commands.
+# -----------------------------------------------------------------------------
 print_help() {
     echo "Usage: $0 [OPTIONS] <maven build options>"
     echo "Build Auron project with specified Maven profiles"
     echo
     echo "Options:"
-    echo "  --docker <true|false>    Build in Docker environment (default: false)"
-    echo "  --image <NAME>           Docker image to use (centos7|ubuntu24|rockylinux8|debian11, default: centos7)"
     echo "  --pre                    Activate pre-release profile"
     echo "  --release                Activate release profile"
-    echo "  --sparkver <VERSION>     Specify Spark version (e.g. 3.0/3.1/3.2/3.3/3.4/3.5)"
-    echo "  --scalaver <VERSION>     Specify Scala version (e.g. 2.12/2.13)"
-    echo "  --celeborn <VERSION>     Specify Celeborn version (e.g. 0.5/0.6)"
-    echo "  --uniffle <VERSION>      Specify Uniffle version (e.g. 0.10)"
-    echo "  --paimon <VERSION>       Specify Paimon version (e.g. 1.2)"
     echo "  --clean <true|false>     Clean before build (default: true)"
     echo "  --skiptests <true|false> Skip unit tests (default: true)"
-    echo "  --flink <VERSION>        Specify Flink version (e.g. 1.18)"
+    echo "  --docker <true|false>    Build in Docker environment (default: false)"
+    IFS=','; echo "  --image <NAME>           Docker image to use (e.g. ${SUPPORTED_OS_IMAGES[*]}, default: ${SUPPORTED_OS_IMAGES[*]:0:1})"; unset IFS
+    IFS=','; echo "  --sparkver <VERSION>     Specify Spark version (e.g. ${SUPPORTED_SPARK_VERSIONS[*]})"; unset IFS
+    IFS=','; echo "  --flinkver <VERSION>     Specify Flink version (e.g. ${SUPPORTED_FLINK_VERSIONS[*]})"; unset IFS
+    IFS=','; echo "  --scalaver <VERSION>     Specify Scala version (e.g. ${SUPPORTED_SCALA_VERSIONS[*]})"; unset IFS
+    IFS=','; echo "  --celeborn <VERSION>     Specify Celeborn version (e.g. ${SUPPORTED_CELEBORN_VERSIONS[*]})"; unset IFS
+    IFS=','; echo "  --uniffle <VERSION>      Specify Uniffle version (e.g. ${SUPPORTED_UNIFFLE_VERSIONS[*]})"; unset IFS
+    IFS=','; echo "  --paimon <VERSION>       Specify Paimon version (e.g. ${SUPPORTED_PAIMON_VERSIONS[*]})"; unset IFS
     echo "  -h, --help               Show this help message"
     echo
     echo "Examples:"
-    echo "  $0 --pre --sparkver 3.5 --scalaver 2.12 -DskipBuildNative"
-    echo "  $0 --docker true --image centos7 --clean true --skiptests true --release --sparkver 3.5 --scalaver 2.12 --celeborn 0.5 --uniffle 0.10 --paimon 1.2"
+    echo "  $0 --pre --sparkver ${SUPPORTED_SPARK_VERSIONS[*]: -1}" \
+         "--scalaver ${SUPPORTED_SCALA_VERSIONS[*]: -1} -DskipBuildNative"
+    echo "  $0 --docker true --image ${SUPPORTED_OS_IMAGES[*]:0:1}" \
+         "--clean true --skiptests true --release" \
+         "--sparkver ${SUPPORTED_SPARK_VERSIONS[*]: -1}" \
+         "--flinkver ${SUPPORTED_FLINK_VERSIONS[*]: -1}" \
+         "--scalaver ${SUPPORTED_SCALA_VERSIONS[*]: -1}" \
+         "--celeborn ${SUPPORTED_CELEBORN_VERSIONS[*]: -1}" \
+         "--uniffle ${SUPPORTED_UNIFFLE_VERSIONS[*]: -1}" \
+         "--paimon ${SUPPORTED_PAIMON_VERSIONS[*]: -1}"
     exit 0
+}
+
+# -----------------------------------------------------------------------------
+# Function: check_supported_version
+# Description:
+#   Validate if a provided version string exists in the supported version list.
+# -----------------------------------------------------------------------------
+check_supported_version() {
+  local value="$1"
+  shift
+  local arr=("$@")
+  for v in "${arr[@]}"; do
+    [[ "$v" == "$value" ]] && return 0
+  done
+  return 1
+}
+
+# -----------------------------------------------------------------------------
+# Function: print_invalid_option_error
+# Description:
+#   Print formatted error message for unsupported version or option.
+# -----------------------------------------------------------------------------
+print_invalid_option_error() {
+    local component="$1"
+    local invalid_value="$2"
+    shift 2
+    local supported_list
+    supported_list=$(IFS=','; echo "$*")
+
+    echo "ERROR: Unsupported $component: $invalid_value, currently supported: ${supported_list}" >&2
+    exit 1
 }
 
 MVN_CMD="$(dirname "$0")/build/mvn"
 
-# Initialize variables
+# -----------------------------------------------------------------------------
+# Section: Initialize Variables
+# Description:
+#   Initialize basic variables and default options for the build
+# -----------------------------------------------------------------------------
 USE_DOCKER=false
-IMAGE_NAME="centos7"
+IMAGE_NAME="${SUPPORTED_OS_IMAGES[*]:0:1})"
 PRE_PROFILE=false
 RELEASE_PROFILE=false
 CLEAN=true
 SKIP_TESTS=true
 SPARK_VER=""
+FLINK_VER=""
 SCALA_VER=""
 CELEBORN_VER=""
 UNIFFLE_VER=""
 PAIMON_VER=""
-FLINK_VER=""
 
-# Parse command-line arguments
+# -----------------------------------------------------------------------------
+# Section: Argument Parsing
+# Description:
+#   Parse command-line options and validate their values.
+# -----------------------------------------------------------------------------
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --pre)
@@ -84,13 +154,13 @@ while [[ $# -gt 0 ]]; do
         --image)
             if [[ -n "$2" && "$2" != -* ]]; then
                 IMAGE_NAME="$2"
-                if [[ ! "$IMAGE_NAME" =~ ^(centos7|ubuntu24|rockylinux8|debian11)$ ]]; then
-                    echo "ERROR: Unsupported image '$IMAGE_NAME'. Supported: centos7, ubuntu24, rockylinux8, debian11" >&2
-                    exit 1
+                if ! check_supported_version "$IMAGE_NAME" "${SUPPORTED_OS_IMAGES[@]}"; then
+                  print_invalid_option_error Image "$IMAGE_NAME" "${SUPPORTED_OS_IMAGES[@]}"
                 fi
                 shift 2
             else
-                echo "ERROR: --image requires one of: centos7, ubuntu24, rockylinux8, debian11" >&2
+                IFS=','; echo "ERROR: Missing argument for --image," \
+                "specify one of: ${SUPPORTED_OS_IMAGES[*]}" >&2; unset IFS
                 exit 1
             fi
             ;;
@@ -115,92 +185,78 @@ while [[ $# -gt 0 ]]; do
         --sparkver)
             if [[ -n "$2" && "$2" != -* ]]; then
                 SPARK_VER="$2"
-                if [ "$SPARK_VER" = "3.0" ] || [ "$SPARK_VER" = "3.1" ] \
-                  || [ "$SPARK_VER" = "3.2" ] || [ "$SPARK_VER" = "3.3" ] \
-                  || [ "$SPARK_VER" = "3.4" ] || [ "$SPARK_VER" = "3.5" ]; then
-                  echo "Building for Spark $SPARK_VER"
-                else
-                  echo "ERROR: Invalid Spark version: $SPARK_VER. The currently supported versions are: 3.0 / 3.1 / 3.2 / 3.3 / 3.4 / 3.5."
-                  exit 1
+                if ! check_supported_version "$SPARK_VER" "${SUPPORTED_SPARK_VERSIONS[@]}"; then
+                  print_invalid_option_error Spark "$SPARK_VER" "${SUPPORTED_SPARK_VERSIONS[@]}"
                 fi
                 shift 2
             else
-                echo "ERROR: --sparkver requires version argument" >&2
+                IFS=','; echo "ERROR: Missing argument for --sparkver," \
+                "specify one of: ${SUPPORTED_SPARK_VERSIONS[*]}" >&2; unset IFS
                 exit 1
             fi
             ;;
         --scalaver)
             if [[ -n "$2" && "$2" != -* ]]; then
                 SCALA_VER="$2"
-                if [ "$SCALA_VER" = "2.12" ] || [ "$SCALA_VER" = "2.13" ]; then
-                  echo "Building scala version: $SCALA_VER"
-                else
-                  echo "ERROR: Invalid scala version: $SCALA_VER. The currently supported versions are: 2.12 / 2.13."
-                  exit 1
+                if ! check_supported_version "$SCALA_VER" "${SUPPORTED_SCALA_VERSIONS[@]}"; then
+                  print_invalid_option_error Scala "$SCALA_VER" "${SUPPORTED_SCALA_VERSIONS[@]}"
                 fi
                 shift 2
             else
-                echo "ERROR: --scalaver requires version argument" >&2
+                IFS=','; echo "ERROR: Missing argument for --scalaver," \
+                "specify one of: ${SUPPORTED_SCALA_VERSIONS[*]}" >&2; unset IFS
                 exit 1
             fi
             ;;
         --celeborn)
             if [[ -n "$2" && "$2" != -* ]]; then
                 CELEBORN_VER="$2"
-                if [ "$CELEBORN_VER" = "0.5" ] || [ "$CELEBORN_VER" = "0.6" ]; then
-                  echo "Building Celeborn version: $CELEBORN_VER"
-                else
-                  echo "ERROR: Invalid Celeborn version: $CELEBORN_VER. The currently supported versions are: 0.5 / 0.6."
-                  exit 1
+                if ! check_supported_version "$CELEBORN_VER" "${SUPPORTED_CELEBORN_VERSIONS[@]}"; then
+                  print_invalid_option_error Celeborn "$CELEBORN_VER" "${SUPPORTED_CELEBORN_VERSIONS[@]}"
                 fi
                 shift 2
             else
-                echo "ERROR: --celeborn requires version argument" >&2
+                IFS=','; echo "ERROR: Missing argument for --celeborn," \
+                "specify one of: ${SUPPORTED_CELEBORN_VERSIONS[*]}" >&2; unset IFS
                 exit 1
             fi
             ;;
         --uniffle)
             if [[ -n "$2" && "$2" != -* ]]; then
                 UNIFFLE_VER="$2"
-                if [ "$UNIFFLE_VER" = "0.10" ] ; then
-                  echo "Building Uniffle version: $UNIFFLE_VER"
-                else
-                  echo "ERROR: Invalid Uniffle version: $UNIFFLE_VER. The currently supported version is: 0.10."
-                  exit 1
+                if ! check_supported_version "$UNIFFLE_VER" "${SUPPORTED_UNIFFLE_VERSIONS[@]}"; then
+                  print_invalid_option_error Uniffle "$UNIFFLE_VER" "${SUPPORTED_UNIFFLE_VERSIONS[@]}"
                 fi
                 shift 2
             else
-                echo "ERROR: --uniffle requires version argument" >&2
+                IFS=','; echo "ERROR: Missing argument for --uniffle," \
+                "specify one of: ${SUPPORTED_UNIFFLE_VERSIONS[*]}" >&2; unset IFS
                 exit 1
             fi
             ;;
         --paimon)
             if [[ -n "$2" && "$2" != -* ]]; then
                 PAIMON_VER="$2"
-                if [ "$PAIMON_VER" = "1.2" ] ; then
-                  echo "Building Paimon version: $PAIMON_VER"
-                else
-                  echo "ERROR: Invalid Paimon version: $PAIMON_VER. The currently supported version is: 1.2."
-                  exit 1
+                if ! check_supported_version "$PAIMON_VER" "${SUPPORTED_PAIMON_VERSIONS[@]}"; then
+                  print_invalid_option_error Paimon "$PAIMON_VER" "${SUPPORTED_PAIMON_VERSIONS[@]}"
                 fi
                 shift 2
             else
-                echo "ERROR: --paimon requires version argument" >&2
+                IFS=','; echo "ERROR: Missing argument for --paimon," \
+                "specify one of: ${SUPPORTED_PAIMON_VERSIONS[*]}" >&2; unset IFS
                 exit 1
             fi
             ;;
-        --flink)
+        --flinkver)
             if [[ -n "$2" && "$2" != -* ]]; then
                 FLINK_VER="$2"
-                if [ "$FLINK_VER" = "1.18" ] ; then
-                  echo "Building Flink version: $FLINK_VER"
-                else
-                  echo "ERROR: Invalid Flink version: $FLINK_VER. The currently supported version is: 1.18"
-                  exit 1
+                if ! check_supported_version "$FLINK_VER" "${SUPPORTED_FLINK_VERSIONS[@]}"; then
+                  print_invalid_option_error Flink "$FLINK_VER" "${SUPPORTED_FLINK_VERSIONS[@]}"
                 fi
                 shift 2
             else
-                echo "ERROR: --flink requires version argument" >&2
+                IFS=','; echo "ERROR: Missing argument for --flink," \
+                "specify one of: ${SUPPORTED_FLINK_VERSIONS[*]}" >&2; unset IFS
                 exit 1
             fi
             ;;
@@ -223,7 +279,11 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-# Validate required options
+# -----------------------------------------------------------------------------
+# Section: Argument Validation
+# Description:
+#   Ensure mandatory options are provided and mutually exclusive rules are respected.
+# -----------------------------------------------------------------------------
 MISSING_REQUIREMENTS=()
 if [[ "$PRE_PROFILE" == false && "$RELEASE_PROFILE" == false ]]; then
     MISSING_REQUIREMENTS+=("--pre or --release must be specified")
@@ -250,7 +310,11 @@ if [[ "$PRE_PROFILE" == true && "$RELEASE_PROFILE" == true ]]; then
     exit 1
 fi
 
-# Compose build args
+# -----------------------------------------------------------------------------
+# Section: Build Argument Composition
+# Description:
+#   Assemble Maven command arguments according to user options.
+# -----------------------------------------------------------------------------
 CLEAN_ARGS=()
 if [[ "$CLEAN" == true ]]; then
     CLEAN_ARGS+=("clean")
@@ -291,7 +355,9 @@ fi
 MVN_ARGS=("${CLEAN_ARGS[@]}" "${BUILD_ARGS[@]}")
 
 # -----------------------------------------------------------------------------
-# Write build information to auron-build-info.properties
+# Section: Build Info Generation
+# Description:
+#   Generate auron-build-info.properties for build metadata tracking.
 # -----------------------------------------------------------------------------
 BUILD_INFO_FILE="common/src/main/resources/auron-build-info.properties"
 mkdir -p "$(dirname "$BUILD_INFO_FILE")"
@@ -313,9 +379,28 @@ RUST_VERSION=$(rustc --version | awk '{print $2}')
   echo "build.timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
 } > "$BUILD_INFO_FILE"
 
-echo "[INFO] Build info written to $BUILD_INFO_FILE"
+# -----------------------------------------------------------------------------
+# Section: Build Info Display
+# Description:
+#   Output generated build info summary to console.
+# -----------------------------------------------------------------------------
+echo "[INFO] Starting Apache Auron build..."
+if [[ -f "$BUILD_INFO_FILE" ]]; then
+    echo "[INFO] Build configuration (from $BUILD_INFO_FILE):"
+    while IFS='=' read -r key value; do
+        [[ -z "$key" ]] && continue
+        echo "[INFO]   $key : $value"
+    done < "$BUILD_INFO_FILE"
+else
+    echo "[WARN] Build info file not found: $BUILD_INFO_FILE"
+    echo "[INFO] Use '$0 --help' to view usage instructions and supported versions."
+fi
 
-# Execute Maven command
+# -----------------------------------------------------------------------------
+# Section: Build Execution
+# Description:
+#   Execute Maven build either locally or inside Docker container.
+# -----------------------------------------------------------------------------
 if [[ "$USE_DOCKER" == true ]]; then
     echo "[INFO] Compiling inside Docker container using image: $IMAGE_NAME"
     # In Docker mode, use multi-threaded Maven build with -T8 for faster compilation


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Please keep the following tips in mind:
  - Start the PR title with the related issue ID, e.g. '[AURON #XXXX] Short summary...'.
  - Make your PR title clear and descriptive, summarizing what this PR changes.
  - Provide a concise example to reproduce the issue, if possible.
  - Keep the PR description up to date with all changes.
-->

# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1458.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
Currently, the `auron-build.sh` script contains **hardcoded** version checks for multiple components (Spark, Scala, Flink, Celeborn, Uniffle, Paimon, etc.) and separate logic for outputting build information. 

This approach makes maintenance harder and is prone to inconsistencies when adding new supported versions.


# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
1. Centralize supported versions

    * Introduced arrays at the top of the script for all components, e.g.: 
      ```
      SUPPORTED_OS_IMAGES=("centos7" "ubuntu24" "rockylinux8" "debian11")
      SUPPORTED_SPARK_VERSIONS=("3.0" "3.1" "3.2" "3.3" "3.4" "3.5")
      SUPPORTED_SCALA_VERSIONS=("2.12" "2.13")
      SUPPORTED_CELEBORN_VERSIONS=("0.5" "0.6")
      SUPPORTED_UNIFFLE_VERSIONS=("0.10")
      SUPPORTED_PAIMON_VERSIONS=("1.2")
      SUPPORTED_FLINK_VERSIONS=("1.18")
      ```
      All version checks now reference these arrays, removing scattered hardcoded values.
    * Simplify version validation
      Introduced a generic `check_supported_version` function to validate any component against its supported versions.
      Added a reusable `print_invalid_option_error` function to provide consistent, clear error messages when an unsupported value is passed.
    * Unify build info output
      Centralized writing to auron-build-info.properties with all relevant versions and timestamps.
      Unified logging format for build information ([INFO] key : value), making it easier to read and parse.
    * Minor improvements
      Made help and error messages consistent and more informative.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

Yes.

Renamed the command-line option `--flink` option to `--flinkver`, consistent with `--sparkver`.

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

# How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Manual testing.