### PR TITLE
[AURON #1493] Remove unused getSparkEnvConfAsString method from JniBridge

### DIFF
--- a/native-engine/auron-jni-bridge/src/jni_bridge.rs
+++ b/native-engine/auron-jni-bridge/src/jni_bridge.rs
@@ -553,8 +553,6 @@ pub struct JniBridge<'a> {
     pub method_getContextClassLoader_ret: ReturnType,
     pub method_setContextClassLoader: JStaticMethodID,
     pub method_setContextClassLoader_ret: ReturnType,
-    pub method_getSparkEnvConfAsString: JStaticMethodID,
-    pub method_getSparkEnvConfAsString_ret: ReturnType,
     pub method_getResource: JStaticMethodID,
     pub method_getResource_ret: ReturnType,
     pub method_getTaskContext: JStaticMethodID,
@@ -598,12 +596,6 @@ impl<'a> JniBridge<'a> {
                 "(Ljava/lang/ClassLoader;)V",
             )?,
             method_setContextClassLoader_ret: ReturnType::Primitive(Primitive::Void),
-            method_getSparkEnvConfAsString: env.get_static_method_id(
-                class,
-                "getSparkEnvConfAsString",
-                "(Ljava/lang/String;)Ljava/lang/String;",
-            )?,
-            method_getSparkEnvConfAsString_ret: ReturnType::Object,
             method_getResource: env.get_static_method_id(
                 class,
                 "getResource",

--- a/spark-extension/src/main/java/org/apache/spark/sql/auron/JniBridge.java
+++ b/spark-extension/src/main/java/org/apache/spark/sql/auron/JniBridge.java
@@ -56,10 +56,6 @@ public class JniBridge {
         Thread.currentThread().setContextClassLoader(cl);
     }
 
-    public static String getSparkEnvConfAsString(String key) {
-        return SparkEnv.get().conf().get(key);
-    }
-
     public static Object getResource(String key) {
         return resourcesMap.remove(key);
     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Please keep the following tips in mind:
  - Start the PR title with the related issue ID, e.g. '[AURON #XXXX] Short summary...'.
  - Make your PR title clear and descriptive, summarizing what this PR changes.
  - Provide a concise example to reproduce the issue, if possible.
  - Keep the PR description up to date with all changes.
-->

# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1493.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

The `getSparkEnvConfAsString` API is tightly coupled with Spark and unused, so we need remove it from JniBridge.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

# How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
