### PR TITLE
Bump byte-buddy from 1.12.10 to 1.14.11.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <project.version>7.0.0-SNAPSHOT</project.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <arrowVersion>16.0.0</arrowVersion>
-    <bytebuddyVersion>1.12.10</bytebuddyVersion>
+    <bytebuddyVersion>1.14.11</bytebuddyVersion>
     <hadoopVersion>3.4.2</hadoopVersion>
     <protobufVersion>3.25.5</protobufVersion>
 


### PR DESCRIPTION
### Which issue does this PR close?

Only update the JAR version without submitting an issue.

### Rationale for this change

During local testing under JDK 21, we encountered the following runtime error:

```
Caused by: java.lang.IllegalArgumentException:
Java 21 (65) is not supported by the current version of Byte Buddy
which officially supports Java 19 (63)
- update Byte Buddy or set net.bytebuddy.experimental as a VM property
```

After investigation, we found that Byte Buddy added official `JDK 21` support starting from version `1.14.9`, so upgrading to `1.14.11` provides stable compatibility with `JDK 21` and prevents runtime failures when using Java’s latest versions.

Changes included:

- Bump net.bytebuddy:byte-buddy to 1.14.1
- Verified successful build and runtime under JDK 21
- No other dependency changes required

https://bugs.launchpad.net/ubuntu/+source/byte-buddy/+bug/2051752

<img width="1465" height="365" alt="image" src="https://github.com/user-attachments/assets/ceabf41f-17c5-4984-b999-8ae909f945b7" />

### Are there any user-facing changes?

No.

### How was this patch tested?

CI.