### PR TITLE
[AURON #1525] Fallback outputs the exception stack when the log level is debug

### DIFF
--- a/spark-extension/src/main/scala/org/apache/spark/sql/auron/AuronConverters.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/auron/AuronConverters.scala
@@ -347,7 +347,11 @@ object AuronConverters extends Logging {
 
     } catch {
       case e @ (_: NotImplementedError | _: AssertionError | _: Exception) =>
-        logWarning(s"Falling back exec: ${exec.getClass.getSimpleName}: ${e.getMessage}")
+        if (log.isDebugEnabled()) {
+          logWarning(s"Falling back exec: ${exec.getClass.getSimpleName}: ${e.getMessage}", e)
+        } else {
+          logWarning(s"Falling back exec: ${exec.getClass.getSimpleName}: ${e.getMessage}")
+        }
         val neverConvertReason = e match {
           case _: AssertionError =>
             exec match {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Please keep the following tips in mind:
  - Start the PR title with the related issue ID, e.g. '[AURON #XXXX] Short summary...'.
  - Make your PR title clear and descriptive, summarizing what this PR changes.
  - Provide a concise example to reproduce the issue, if possible.
  - Keep the PR description up to date with all changes.
-->

# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

 # Rationale for this change

Now the call stack of fallback is not very obvious. When the log level is debug, the exception call stack of assert can be output.
```
25/10/26 18:24:46 WARN AuronConverters: Falling back exec: HashAggregateExec: assertion failed: partial AggregateExec is not native
25/10/26 18:24:57 WARN AuronConverters: Falling back exec: HashAggregateExec: assertion failed
25/10/26 18:24:59 WARN AuronConverters: Falling back exec: HashAggregateExec: assertion failed: partial AggregateExec is not native
```

PR test log level is debug
```
25/10/27 12:33:15 WARN AuronConverters: Falling back exec: HashAggregateExec: assertion failed
java.lang.AssertionError: assertion failed
	at scala.Predef$.assert(Predef.scala:208)
	at org.apache.spark.sql.auron.NativeConverters$.convertAggregateExpr(NativeConverters.scala:1080)
	at org.apache.spark.sql.execution.auron.plan.NativeAggBase$.getNativeAggrInfo(NativeAggBase.scala:254)
```



# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

# How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
