### PR TITLE
[AURON #1533] Implement native function of lpad, rpad.

### DIFF
--- a/spark-extension-shims-spark/src/test/scala/org/apache/spark/sql/auron/AuronQuerySuite.scala
+++ b/spark-extension-shims-spark/src/test/scala/org/apache/spark/sql/auron/AuronQuerySuite.scala
@@ -286,4 +286,22 @@ class AuronQuerySuite
       }
     }
   }
+
+  test("lpad/rpad basic") {
+    Seq(
+      ("select lpad('abc', 5, '*')", Row("**abc")),
+      ("select rpad('abc', 5, '*')", Row("abc**")),
+      ("select lpad('spark', 2, '0')", Row("sp")),
+      ("select rpad('spark', 2, '0')", Row("sp")),
+      ("select lpad('9', 5, 'ab')", Row("abab9")),
+      ("select rpad('9', 5, 'ab')", Row("9abab")),
+      ("select lpad('hi', 5, '')", Row("hi")),
+      ("select rpad('hi', 5, '')", Row("hi")),
+      ("select lpad('x', 0, 'a')", Row("")),
+      ("select rpad('x', -1, 'a')", Row("")),
+      ("select lpad('Z', 3, '++')", Row("++Z")),
+      ("select rpad('Z', 3, 'AB')", Row("ZAB"))).foreach { case (q, expected) =>
+      checkAnswer(sql(q), Seq(expected))
+    }
+  }
 }

--- a/spark-extension/src/main/scala/org/apache/spark/sql/auron/NativeConverters.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/auron/NativeConverters.scala
@@ -930,6 +930,11 @@ object NativeConverters extends Logging {
         val children = e.children.map(Cast(_, e.dataType))
         buildScalarFunction(pb.ScalarFunction.Coalesce, children, e.dataType)
 
+      case e: StringLPad =>
+        buildScalarFunction(pb.ScalarFunction.Lpad, e.children, StringType)
+      case e: StringRPad =>
+        buildScalarFunction(pb.ScalarFunction.Rpad, e.children, StringType)
+
       case e @ If(predicate, trueValue, falseValue) =>
         val castedTrueValue = trueValue match {
           case t if t.dataType != e.dataType => Cast(t, e.dataType)


### PR DESCRIPTION
### Which issue does this PR close?

Closes #1533.

### Rationale for this change

- `lpad/rpad` are widely used for ID zero-padding, fixed-width alignment, and reporting.
- Without native support they execute on the JVM side, incurring serialization/cross-boundary overhead and preventing full pushdown.
- Implementing native `lpad/rpad` improves performance and keeps behavior aligned with Spark (including `Unicode-safe`, `character-level` semantics).

### What changes are included in this PR?

Catalyst → Auron mapping

- Add cases in NativeConverters.convertExprWithFallback:
- StringLPad → StringLpad (extended/native scalar function)
- StringRPad → StringRpad

### Are there any user-facing changes?

Yes (additive): Users can call lpad/rpad and have them executed natively by Auron.

### How was this patch tested?

Junit Test.