### PR TITLE
[AURON #1538] Implement native function of `reverse`.

### DIFF
--- a/spark-extension-shims-spark/src/test/scala/org/apache/spark/sql/auron/AuronQuerySuite.scala
+++ b/spark-extension-shims-spark/src/test/scala/org/apache/spark/sql/auron/AuronQuerySuite.scala
@@ -304,4 +304,17 @@ class AuronQuerySuite
       checkAnswer(sql(q), Seq(expected))
     }
   }
+
+  test("reverse basic") {
+    Seq(
+      ("select reverse('abc')", Row("cba")),
+      ("select reverse('spark')", Row("kraps")),
+      ("select reverse('hello world')", Row("dlrow olleh")),
+      ("select reverse('12345')", Row("54321")),
+      ("select reverse('a')", Row("a")), // Edge case: single character
+      ("select reverse('')", Row("")), // Edge case: empty string
+      ("select reverse('hello' || ' world')", Row("dlrow olleh"))).foreach { case (q, expected) =>
+      checkAnswer(sql(q), Seq(expected))
+    }
+  }
 }

--- a/spark-extension/src/main/scala/org/apache/spark/sql/auron/NativeConverters.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/auron/NativeConverters.scala
@@ -846,6 +846,8 @@ object NativeConverters extends Logging {
         buildExtScalarFunction("NullIf", left :: right :: Nil, e.dataType)
       case Md5(_1) =>
         buildScalarFunction(pb.ScalarFunction.MD5, Seq(unpackBinaryTypeCast(_1)), StringType)
+      case Reverse(_1) =>
+        buildScalarFunction(pb.ScalarFunction.Reverse, Seq(unpackBinaryTypeCast(_1)), StringType)
       case Sha2(_1, Literal(224, _)) =>
         buildExtScalarFunction("Sha224", Seq(unpackBinaryTypeCast(_1)), StringType)
       case Sha2(_1, Literal(0, _)) =>


### PR DESCRIPTION
### Which issue does this PR close?

Closes #1538.

### Rationale for this change

The rationale behind this change is to implement a native `reverse` function for better compatibility with Spark SQL and to reduce dependency on UDFs. This function supports string inputs and ensures consistent behavior with Spark’s built-in functions.

### What changes are included in this PR?

This PR introduces a new native scalar function `reverse(expr)`, which supports `Utf8` string types, as well as mixed scalar and column vector inputs. It also ensures that the Null semantics align with Spark’s behavior.

### Are there any user-facing changes?

Yes, users will now have access to the native reverse function for strings

### How was this patch tested?

CI & Junit Test.