### PR TITLE
[AURON #1593] Add Spark prefix for log option key

### DIFF
--- a/spark-extension/src/main/java/org/apache/auron/spark/configuration/SparkAuronConfiguration.java
+++ b/spark-extension/src/main/java/org/apache/auron/spark/configuration/SparkAuronConfiguration.java
@@ -35,6 +35,8 @@ import scala.collection.immutable.List$;
  */
 public class SparkAuronConfiguration extends AuronConfiguration {
 
+    // When using getOptional, the prefix will be automatically completed. If you only need to print the Option key,
+    // please manually add the prefix.
     public static final String SPARK_PREFIX = "spark.";
 
     public static final ConfigOption<Boolean> UI_ENABLED = ConfigOptions.key("auron.ui.enabled")

--- a/spark-extension/src/main/scala/org/apache/spark/sql/auron/NativeConverters.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/auron/NativeConverters.scala
@@ -1217,7 +1217,8 @@ object NativeConverters extends Logging {
           aggBuilder.addAllChildren(convertedChildren.keys.asJava)
         } else {
           throw new NotImplementedError(s"Unsupported aggregate expression: (${e.getClass})," +
-            s" set ${SparkAuronConfiguration.UDAF_FALLBACK_ENABLE.key} to true to enable UDAF fallbacking.")
+            s" set ${SparkAuronConfiguration.SPARK_PREFIX}${SparkAuronConfiguration.UDAF_FALLBACK_ENABLE.key}" +
+            s" to true to enable UDAF fallbacking.")
         }
 
     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Please keep the following tips in mind:
  - Start the PR title with the related issue ID, e.g. '[AURON #XXXX] Short summary...'.
  - Make your PR title clear and descriptive, summarizing what this PR changes.
  - Provide a concise example to reproduce the issue, if possible.
  - Keep the PR description up to date with all changes.
-->

# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1593.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

To facilitate reusing Auron's common configurations across multiple engines, such as the BATCH_SIZE option which uses different prefixes in Spark and Flink, we removed the spark. prefix from all options when introducing SparkAuronConfiguration. The prefix is automatically supplemented via getOptional.
We found that prefix are missing when only print option key.

This PR addresses the issue of missing prefixes in print options.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

NativeConverters add the spark prefix when referencing the UDAF_FALLBACK_ENABLE option key.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
No
<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

# How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
No need test, because only modify log