### PR TITLE
[AURON #1548] Install Maven in Dockerfile to avoid downloading it during build

### DIFF
--- a/dev/docker-build/centos7/Dockerfile
+++ b/dev/docker-build/centos7/Dockerfile
@@ -44,3 +44,15 @@ RUN /rustup-init -y --default-toolchain nightly-2025-05-09-x86_64-unknown-linux-
 # install java
 RUN yum install -y java-1.8.0-openjdk java-1.8.0-openjdk-devel
 RUN echo 'export JAVA_HOME="/usr/lib/jvm/java-1.8.0-openjdk"' >> ~/.bashrc
+
+# install maven
+ENV MAVEN_VERSION=3.9.11
+ENV MAVEN_HOME=/usr/lib/maven
+RUN MAVEN_TGZ="/tmp/apache-maven-${MAVEN_VERSION}-bin.tar.gz" && \
+    curl -fsSL "https://www.apache.org/dyn/closer.lua/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz?action=download" \
+         -o ${MAVEN_TGZ} && \
+    tar -xvf ${MAVEN_TGZ} && \
+    mv apache-maven-${MAVEN_VERSION} ${MAVEN_HOME} && \
+    rm -rf ${MAVEN_TGZ}
+RUN echo "export MAVEN_HOME=${MAVEN_HOME}" >> ~/.bashrc && \
+    echo "export PATH=\${MAVEN_HOME}/bin:\${PATH}" >> ~/.bashrc


### PR DESCRIPTION


# Which issue does this PR close?



Closes #1548

 # Rationale for this change
Maven is missing from the Docker image. First `/build/mvn` run downloads it (~1–2 min delay). Pre-installing in Dockerfile eliminates this and speeds up builds.

# What changes are included in this PR?
Add Maven 3.9.11 installation in Dockerfile. 

# Are there any user-facing changes?

No.

# How was this patch tested?  
Built the Docker image locally and ran ./auron-build.sh to build.  
<img width="1023" height="213" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/58530dc5-95dd-4e2c-b0ac-e96ddd1c5ce1" />

