### PR TITLE
[AURON #1604] Make MD5 output back to utf8

### DIFF
--- a/native-engine/auron-serde/proto/auron.proto
+++ b/native-engine/auron-serde/proto/auron.proto
@@ -234,7 +234,7 @@ enum ScalarFunction {
   Lpad=32;
   Lower=33;
   Ltrim=34;
-  MD5=35;
+  // MD5=35;
   // NullIf=36;
   OctetLength=37;
   Random=38;

--- a/native-engine/auron-serde/src/from_proto.rs
+++ b/native-engine/auron-serde/src/from_proto.rs
@@ -788,7 +788,7 @@ impl From<protobuf::ScalarFunction> for Arc<ScalarUDF> {
             ScalarFunction::Nvl => f::core::nvl(),
             ScalarFunction::DatePart => f::datetime::date_part(),
             ScalarFunction::DateTrunc => f::datetime::date_trunc(),
-            ScalarFunction::Md5 => f::crypto::md5(),
+            // ScalarFunction::Md5 => f::crypto::md5(),
             // ScalarFunction::Sha224 => f::crypto::sha224(),
             // ScalarFunction::Sha256 => f::crypto::sha256(),
             // ScalarFunction::Sha384 => f::crypto::sha384(),

--- a/native-engine/datafusion-ext-functions/src/lib.rs
+++ b/native-engine/datafusion-ext-functions/src/lib.rs
@@ -20,6 +20,7 @@ use datafusion_ext_commons::df_unimplemented_err;
 
 mod brickhouse;
 mod spark_check_overflow;
+mod spark_crypto;
 mod spark_dates;
 pub mod spark_get_json_object;
 mod spark_hash;
@@ -28,7 +29,6 @@ mod spark_make_decimal;
 mod spark_normalize_nan_and_zero;
 mod spark_null_if;
 mod spark_round;
-mod spark_sha2;
 mod spark_strings;
 mod spark_unscaled_value;
 
@@ -45,10 +45,11 @@ pub fn create_auron_ext_function(name: &str) -> Result<ScalarFunctionImplementat
         "Spark_CheckOverflow" => Arc::new(spark_check_overflow::spark_check_overflow),
         "Spark_Murmur3Hash" => Arc::new(spark_hash::spark_murmur3_hash),
         "Spark_XxHash64" => Arc::new(spark_hash::spark_xxhash64),
-        "Spark_Sha224" => Arc::new(spark_sha2::spark_sha224),
-        "Spark_Sha256" => Arc::new(spark_sha2::spark_sha256),
-        "Spark_Sha384" => Arc::new(spark_sha2::spark_sha384),
-        "Spark_Sha512" => Arc::new(spark_sha2::spark_sha512),
+        "Sha224" => Arc::new(spark_crypto::spark_sha224),
+        "Sha256" => Arc::new(spark_crypto::spark_sha256),
+        "Sha384" => Arc::new(spark_crypto::spark_sha384),
+        "Sha512" => Arc::new(spark_crypto::spark_sha512),
+        "MD5" => Arc::new(spark_crypto::spark_md5),
         "Spark_GetJsonObject" => Arc::new(spark_get_json_object::spark_get_json_object),
         "Spark_GetParsedJsonObject" => {
             Arc::new(spark_get_json_object::spark_get_parsed_json_object)

--- a/spark-extension-shims-spark/src/test/scala/org/apache/spark/sql/auron/AuronFunctionSuite.scala
+++ b/spark-extension-shims-spark/src/test/scala/org/apache/spark/sql/auron/AuronFunctionSuite.scala
@@ -64,6 +64,23 @@ class AuronFunctionSuite
     }
   }
 
+  test("md5 function") {
+    withTable("t1") {
+      sql("create table t1 using parquet as select 'spark' as c1, '3.x' as version")
+      val functions =
+        """
+          |select b.md5
+          |from (
+          |  select c1, version from t1
+          |) a join (
+          |  select md5(concat(c1, version)) as md5 from t1
+          |) b on md5(concat(a.c1, a.version)) = b.md5
+          |""".stripMargin
+      val df = sql(functions)
+      checkAnswer(df, Seq(Row("9ff36a3857e29335d03cf6bef2147119")))
+    }
+  }
+
   test("spark hash function") {
     withTable("t1") {
       sql("create table t1 using parquet as select array(1, 2) as arr")

--- a/spark-extension/src/main/scala/org/apache/spark/sql/auron/NativeConverters.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/auron/NativeConverters.scala
@@ -864,7 +864,7 @@ object NativeConverters extends Logging {
       case e @ NullIf(left, right, _) =>
         buildExtScalarFunction("Spark_NullIf", left :: right :: Nil, e.dataType)
       case Md5(_1) =>
-        buildScalarFunction(pb.ScalarFunction.MD5, Seq(unpackBinaryTypeCast(_1)), StringType)
+        buildExtScalarFunction("MD5", Seq(unpackBinaryTypeCast(_1)), StringType)
       case Reverse(_1) =>
         buildScalarFunction(pb.ScalarFunction.Reverse, Seq(unpackBinaryTypeCast(_1)), StringType)
       case InitCap(_1) =>


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1604.

 # Rationale for this change
make MD5 function as before.

# What changes are included in this PR?
move MD5 to `ext_function` and make the return type back to utf8 instead of using `f::crypto::md5()` in datafusion directly.

# Are there any user-facing changes?
no

# How was this patch tested?
test in `spark-extension-shims-spark/src/test/scala/org/apache/spark/sql/auron/AuronFunctionSuite.scala` and `native-engine/datafusion-ext-functions/src/spark_crypto.rs`
