### PR TITLE
[AURON #1516][FOLLOWUP] Use JDK 21 for CentOS 7 release

### DIFF
--- a/.github/workflows/build-arm-releases.yml
+++ b/.github/workflows/build-arm-releases.yml
@@ -108,6 +108,6 @@ jobs:
       - name: Upload auron-${{ matrix.sparkver }}_${{ matrix.scalaver }}
         uses: actions/upload-artifact@v4
         with:
-          name: auron-${{matrix.sparkver}}_${{ matrix.scalaver }}-release-${{ env.osclassfier }}-${{ matrix.auronver }}-${{ matrix.runner }}-${{ steps.commit.outputs.short }}.jar
+          name: auron-${{matrix.sparkver}}_${{ matrix.scalaver }}-${{ matrix.javaver }}-release-${{ env.osclassfier }}-${{ matrix.auronver }}-${{ matrix.runner }}-${{ steps.commit.outputs.short }}.jar
           path: target/auron-${{matrix.sparkver}}_${{ matrix.scalaver }}-release-${{ env.osclassfier }}-${{ matrix.auronver }}.jar
           overwrite: true

--- a/.github/workflows/build-ce7-releases.yml
+++ b/.github/workflows/build-ce7-releases.yml
@@ -39,6 +39,7 @@ jobs:
       matrix:
         sparkver: [spark-3.0, spark-3.1, spark-3.2, spark-3.3, spark-3.4, spark-3.5]
         scalaver: [ 2.12, 2.13 ]
+        javaver: [ 8, 21 ]
         auronver: [7.0.0-SNAPSHOT]
         runner: [ce7]
         exclude:
@@ -53,6 +54,16 @@ jobs:
             scalaver: '2.13'
           - sparkver: spark-3.4
             scalaver: '2.13'
+          - sparkver: spark-3.0
+            javaver: '21'
+          - sparkver: spark-3.1
+            javaver: '21'
+          - sparkver: spark-3.2
+            javaver: '21'
+          - sparkver: spark-3.3
+            javaver: '21'
+          - sparkver: spark-3.4
+            javaver: '21'
 
     steps:
       - uses: actions/checkout@v4
@@ -97,6 +108,6 @@ jobs:
       - name: Upload auron-${{ matrix.sparkver }}_${{ matrix.scalaver }}
         uses: actions/upload-artifact@v4
         with:
-          name: auron-${{matrix.sparkver}}_${{matrix.scalaver}}-release-${{ env.osclassfier }}-${{ matrix.auronver }}-${{ matrix.runner }}-${{ steps.commit.outputs.short }}.jar
+          name: auron-${{matrix.sparkver}}_${{matrix.scalaver}}-${{ matrix.javaver }}-release-${{ env.osclassfier }}-${{ matrix.auronver }}-${{ matrix.runner }}-${{ steps.commit.outputs.short }}.jar
           path: target-docker/auron-${{matrix.sparkver}}_${{matrix.scalaver}}-release-${{ env.osclassfier }}-${{ matrix.auronver }}.jar
           overwrite: true


### PR DESCRIPTION
# Which issue does this PR close?


Closes #1516

 # Rationale for this change

https://github.com/apache/auron/actions/runs/19089849208/job/54537920042

> Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run



# What changes are included in this PR?
1.  Use JDK 21 for CentOS 7 release
2. Avoid artifact name conflict



# Are there any user-facing changes?

# How was this patch tested?

https://github.com/apache/auron/actions/runs/19102288093?pr=1608

https://github.com/apache/auron/actions/runs/19102288065?pr=1608

<img width="732" height="682" alt="image" src="https://github.com/user-attachments/assets/368beaa6-b6e6-4fe6-bacf-7e763f0edab9" />


