### PR TITLE
[AURON #1442] Fix FileNotFoundException in BuildinfoInSparkUISuite by properly configuring temp event log dir

### DIFF
--- a/spark-extension-shims-spark/src/test/scala/org/apache/spark/sql/auron/BuildinfoInSparkUISuite.scala
+++ b/spark-extension-shims-spark/src/test/scala/org/apache/spark/sql/auron/BuildinfoInSparkUISuite.scala
@@ -16,11 +16,11 @@
  */
 package org.apache.spark.sql.auron
 
+import java.io.File
+
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.execution.ui.AuronSQLAppStatusListener
 import org.apache.spark.util.Utils
-
-import java.io.File
 
 class BuildinfoInSparkUISuite
     extends org.apache.spark.sql.QueryTest
@@ -34,7 +34,7 @@ class BuildinfoInSparkUISuite
   }
 
   override protected def beforeAll(): Unit = {
-    testDir =  Utils.createTempDir(namePrefix = "spark-events")
+    testDir = Utils.createTempDir(namePrefix = "spark-events")
     super.beforeAll()
   }
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1442 .

 # Rationale for this change
The original `beforeAll()` called `super.beforeAll()` first, which initializes the `SparkSession` (and thus the `SparkContext`). Spark’s `EventLoggingListener` starts during `SparkContext` construction and immediately validates `spark.eventLog.dir`.
The subsequent line `val eventLogDir = Utils.createTempDir("/tmp/spark-events")` creates the directory after the listener has already failed with:  
```
An exception or error caused a run to abort: File file:/private/tmp/spark-events does not exist 
java.io.FileNotFoundException: File file:/private/tmp/spark-events does not exist
	at org.apache.hadoop.fs.RawLocalFileSystem.deprecatedGetFileStatus(RawLocalFileSystem.java:980)
	at org.apache.hadoop.fs.RawLocalFileSystem.getFileLinkStatusInternal(RawLocalFileSystem.java:1301)
	at org.apache.hadoop.fs.RawLocalFileSystem.getFileStatus(RawLocalFileSystem.java:970)
	at org.apache.hadoop.fs.FilterFileSystem.getFileStatus(FilterFileSystem.java:462)
	at org.apache.spark.deploy.history.EventLogFileWriter.requireLogBaseDirAsDirectory(EventLogFileWriters.scala:77)
	at org.apache.spark.deploy.history.SingleEventLogFileWriter.start(EventLogFileWriters.scala:221)
	at org.apache.spark.scheduler.EventLoggingListener.start(EventLoggingListener.scala:83)
	at org.apache.spark.SparkContext.<init>(SparkContext.scala:622)
```

This PR creates a proper temporary directory before the `SparkSession` is initialized, configures it via `sparkConf`, and cleans it up afterward.

 
# What changes are included in this PR?


# Are there any user-facing changes?
No.

# How was this patch tested?
Verified the test passed.
