### PR TITLE
[AURON #1610] Handle case-insensitive columns in NativeHiveTableScanBase

### DIFF
--- a/spark-extension/src/main/scala/org/apache/spark/sql/hive/execution/auron/plan/NativeHiveTableScanBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/hive/execution/auron/plan/NativeHiveTableScanBase.scala
@@ -70,7 +70,7 @@ abstract class NativeHiveTableScanBase(basedHiveScan: HiveTableScanExec)
   // should not include partition columns
   protected def nativeFileSchema: pb.Schema =
     NativeConverters.convertSchema(StructType(relation.tableMeta.dataSchema.map {
-      case field if basedHiveScan.requestedAttributes.exists(_.name == field.name) =>
+      case field if output.exists(_.name == field.name) =>
         field.copy(nullable = true)
       case field =>
         // avoid converting unsupported type in non-used fields


### PR DESCRIPTION
# Which issue does this PR close?
Closes #1610

 # Rationale for this change
Make `NativeFileSourceScanBase.nativeFileSchema` can handle uppercase column name.

# What changes are included in this PR?
Use `output` instead of `requestedAttributes` to match.

# Are there any user-facing changes?
no

# How was this patch tested?
manually
