### PR TITLE
[AURON #1617] Fix NativeConvertersSuite cast trim-disable test failures

### DIFF
--- a/spark-extension-shims-spark/src/test/scala/org/apache/spark/sql/auron/AuronSQLTestHelper.scala
+++ b/spark-extension-shims-spark/src/test/scala/org/apache/spark/sql/auron/AuronSQLTestHelper.scala
@@ -16,7 +16,6 @@
  */
 package org.apache.spark.sql.auron
 
-import org.apache.spark.SparkEnv
 import org.apache.spark.sql.internal.SQLConf
 
 trait AuronSQLTestHelper {


### PR DESCRIPTION

# Which issue does this PR close?

Closes #1617 .

 # Rationale for this change
Enhances thread safety in `AuronSQLTestHelper.withEnvConf`, allowing independent modification of `SQLConf` for each unit test.



# What changes are included in this PR?
+ Updated `AuronSQLTestHelper.withEnvConf` for thread-safe handling of `SQLConf`.
+ Ensured configuration changes in tests do not interfere with each other.

# Are there any user-facing changes?
No.  

# How was this patch tested?
Ran `mvn test`, passing all unit tests.



