### PR TITLE
[AURON #1625] Fix disable convert BroadcastExchange to native does not take effect

### DIFF
--- a/spark-extension/src/main/scala/org/apache/spark/sql/auron/AuronConverters.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/auron/AuronConverters.scala
@@ -28,7 +28,7 @@ import org.apache.spark.Partition
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.internal.{config, Logging}
 import org.apache.spark.sql.auron.AuronConvertStrategy.{childOrderingRequiredTag, convertibleTag, convertStrategyTag, convertToNonNativeTag, isNeverConvert, joinSmallerSideTag, neverConvertReasonTag}
-import org.apache.spark.sql.auron.NativeConverters.{roundRobinTypeSupported, scalarTypeSupported, StubExpr}
+import org.apache.spark.sql.auron.NativeConverters.{existTimestampType, roundRobinTypeSupported, scalarTypeSupported, StubExpr}
 import org.apache.spark.sql.auron.util.AuronLogUtils.logDebugPlanConversion
 import org.apache.spark.sql.catalyst.expressions.AggregateWindowFunction
 import org.apache.spark.sql.catalyst.expressions.Alias
@@ -135,8 +135,12 @@ object AuronConverters extends Logging {
     getBooleanConf("spark.auron.enable.data.writing", defaultValue = false)
   def enableScanParquet: Boolean =
     getBooleanConf("spark.auron.enable.scan.parquet", defaultValue = true)
+  def enableScanParquetTimestamp: Boolean =
+    getBooleanConf("spark.auron.enable.scan.parquet.timestamp", defaultValue = true)
   def enableScanOrc: Boolean =
     getBooleanConf("spark.auron.enable.scan.orc", defaultValue = true)
+  def enableScanOrcTimestamp: Boolean =
+    getBooleanConf("spark.auron.enable.scan.orc.timestamp", defaultValue = true)
   def enableBroadcastExchange: Boolean =
     getBooleanConf("spark.auron.enable.broadcastExchange", defaultValue = true)
   def enableShuffleExechange: Boolean =
@@ -191,10 +195,9 @@ object AuronConverters extends Logging {
 
   def convertSparkPlan(exec: SparkPlan): SparkPlan = {
     exec match {
-      case e: ShuffleExchangeExec => tryConvert(e, convertShuffleExchangeExec)
+      case e: ShuffleExchangeExec if enableExchange => tryConvert(e, convertShuffleExchangeExec)
       case e: BroadcastExchangeExec if enableBroadcastExchange =>
         tryConvert(e, convertBroadcastExchangeExec)
-      case e: ShuffleExchangeExec if enableExchange => tryConvert(e, convertShuffleExchangeExec)
       case e: FileSourceScanExec if enableScan => // scan
         tryConvert(e, convertFileSourceScanExec)
       case e: ProjectExec if enableProject => // project
@@ -465,9 +468,25 @@ object AuronConverters extends Logging {
     relation.fileFormat match {
       case p if p.getClass.getName.endsWith("ParquetFileFormat") =>
         assert(enableScanParquet)
+        if (!enableScanParquetTimestamp) {
+          assert(
+            !exec.requiredSchema.exists(e => existTimestampType(e.dataType)),
+            s"Parquet scan with timestamp type is not supported for table: ${tableIdentifier
+              .getOrElse("unknown")}. " +
+              "Set spark.auron.enable.scan.parquet.timestamp=true to enable timestamp support " +
+              "or remove timestamp columns from the query.")
+        }
         addRenameColumnsExec(Shims.get.createNativeParquetScanExec(exec))
       case p if p.getClass.getName.endsWith("OrcFileFormat") =>
         assert(enableScanOrc)
+        if (!enableScanOrcTimestamp) {
+          assert(
+            !exec.requiredSchema.exists(e => existTimestampType(e.dataType)),
+            s"ORC scan with timestamp type is not supported for tableIdentifier: ${tableIdentifier
+              .getOrElse("unknown")}. " +
+              "Set spark.auron.enable.scan.orc.timestamp=true to enable timestamp support " +
+              "or remove timestamp columns from the query.")
+        }
         addRenameColumnsExec(Shims.get.createNativeOrcScanExec(exec))
       case p =>
         throw new NotImplementedError(


### PR DESCRIPTION

# Which issue does this PR close?

Closes #1625.

 # Rationale for this change


# What changes are included in this PR?
1. remove duplicate broadcastExchange conversion logic in `AuronConverters.convertSparkPlan`  
2. fix failing unit test `AuronCheckConvertBroadcastExchangeSuite`  


# Are there any user-facing changes?


# How was this patch tested?

