### PR TITLE
[AURON #1665] Override verboseStringWithOperatorId in NativeFileSourceScanBase

### DIFF
--- a/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeFileSourceScanBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeFileSourceScanBase.scala
@@ -32,13 +32,13 @@ import org.apache.spark.sql.auron.Shims
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.expressions.Literal
 import org.apache.spark.sql.catalyst.plans.physical.Partitioning
-import org.apache.spark.sql.execution.{ExplainUtils, FileSourceScanExec, LeafExecNode, SparkPlan}
+import org.apache.spark.sql.execution.{FileSourceScanExec, LeafExecNode, SparkPlan}
 import org.apache.spark.sql.execution.datasources.FilePartition
 import org.apache.spark.sql.execution.datasources.FileScanRDD
 import org.apache.spark.sql.execution.datasources.PartitionedFile
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.types.{DecimalType, NullType, StructField, StructType}
-import org.apache.spark.util.{SerializableConfiguration, Utils}
+import org.apache.spark.util.SerializableConfiguration
 
 import org.apache.auron.{protobuf => pb}
 import org.apache.auron.jni.JniBridge


### PR DESCRIPTION
# Which issue does this PR close?
Close #1665.

# Rationale for this change
- Align NativeFileSourceScanBase verbose string output with Spark to improve readability and debugging.

# What changes are included in this PR?
- Override verboseStringWithOperatorId in NativeFileSourceScanBase, mirroring Spark’s formatting: [DataSourceScanExec.scala#L426-L449](https://github.com/apache/spark/blob/65c3d1cb18c45528d8090ac905d87a8dcd779aa7/sql/core/src/main/scala/org/apache/spark/sql/execution/DataSourceScanExec.scala#L426-L449)  

# Are there any user-facing changes?
- Yes: operator verbose string output aligns with Spark.

# How was this patch tested?
- Manual checks on sample queries.
- Future work: introduce a TPCH/TPCDS plan stability suite to continuously validate formatting stability. 

Vanilla Spark： 
<img width="1090" height="137" alt="image" src="https://github.com/user-attachments/assets/37939532-257f-437d-ae76-03236dbd9abb" />


Master:
<img width="1469" height="123" alt="Pasted Graphic 2" src="https://github.com/user-attachments/assets/36bed994-9166-4093-ab4e-924dc78a0d2c" />

PR:
<img width="1111" height="130" alt="Pasted Graphic 1" src="https://github.com/user-attachments/assets/2259c4ce-aac2-4ce7-b9fe-6b90e9c23b14" />


