### PR TITLE
[AURON #1644] Fix build-native.sh ensure native lib cache takes effect

### DIFF
--- a/dev/mvn-build-helper/build-native.sh
+++ b/dev/mvn-build-helper/build-native.sh
@@ -45,8 +45,9 @@ else
 fi
 
 cache_dir="native-engine/_build/$profile"
-cache_libpath="$build_dir/$libname.$libsuffix"
-build_libpath="target/$profile/$libname.$libsuffix"
+cache_libpath="$cache_dir/$libname.$libsuffix"
+cache_checksum_file="./.build-checksum.$profile.$libname.$libsuffix.cache"
+cargo_libpath="target/$profile/$libname.$libsuffix"
 
 checksum() {
     # Determine whether to use md5sum or md5
@@ -67,9 +68,8 @@ checksum() {
         $hash_cmd | awk '{print $1}'
 }
 
-checksum_cache_file="./.build-checksum_$profile-"$libsuffix".cache"
 if [ -f "$cache_libpath" ]; then
-  old_checksum="$(cat "$checksum_cache_file" 2>&1 || true)"
+  old_checksum="$(cat "$cache_checksum_file" 2>&1 || true)"
   new_checksum="$(checksum)"
 
   echo -e "old build-checksum: \n$old_checksum\n========"
@@ -88,11 +88,11 @@ if [ ! -f "$cache_libpath" ] || [ "$new_checksum" != "$old_checksum" ]; then
     cargo build --profile="$profile" $features_arg --verbose --locked --frozen 2>&1
 
     mkdir -p "$cache_dir"
-    cp -f "$build_libpath" "$cache_libpath"
+    cp -f "$cargo_libpath" "$cache_libpath"
 
     new_checksum="$(checksum)"
     echo "build-checksum updated: $new_checksum"
-    echo "$new_checksum" >"$checksum_cache_file"
+    echo "$new_checksum" >"$cache_checksum_file"
 else
     echo "native-engine source code and built libraries not modified, no need to rebuild"
 fi


### PR DESCRIPTION
 

# Which issue does this PR close?

 
Closes #1644 .

 # Rationale for this change
 The native lib is cached under `libpath=target/$profile/`. However, each time `auron-build.sh` runs, it invokes `mvn` with the `clean` phase by default. This removes everything under `target/`, which wipes out the native lib cache. As a result, the native lib has to be rebuilt on every run.  

# What changes are included in this PR?
 

# Are there any user-facing changes?
 No.

# How was this patch tested?
Master:    
<img width="826" height="557" alt="Pasted Graphic 3" src="https://github.com/user-attachments/assets/fd3d02cb-9c56-4c69-a219-d6555c7c193d" />


PR:   
echo "native-engine source code and built libraries not modified, no need to rebuild"  
<img width="820" height="592" alt="Pasted Graphic 4" src="https://github.com/user-attachments/assets/6f4cb9f3-6761-433a-b58f-7cfe3f670b5b" />


