### PR TITLE
[AURON #1650] Override nodeName for NativeEmptyExec

### DIFF
--- a/spark-extension/src/main/scala/org/apache/spark/sql/auron/AuronConverters.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/auron/AuronConverters.scala
@@ -1115,6 +1115,8 @@ object AuronConverters extends Logging {
           },
           friendlyName = "NativeRDD.Empty")
       }
+
+      override val nodeName: String = s"NativeEmpty"
     }
     NativeEmptyExec(output, outputPartitioning, outputOrdering)
   }


### PR DESCRIPTION
 
# Which issue does this PR close?

Closes #1650 .

 # Rationale for this change
 
# What changes are included in this PR?
override nodeName for `NativeEmptyExec`

# Are there any user-facing changes?

 

# How was this patch tested?

