### PR TITLE
[AURON #1659]  Remove ubuntu-22.04-arm runner

### DIFF
--- a/.github/workflows/build-arm-releases.yml
+++ b/.github/workflows/build-arm-releases.yml
@@ -41,7 +41,7 @@ jobs:
         auronver: [7.0.0-SNAPSHOT]
         scalaver: [2.12, 2.13]
         javaver: [ 8, 21 ]
-        runner: [ubuntu-22.04-arm, ubuntu-24.04-arm ]
+        runner: [ ubuntu-24.04-arm ]
         exclude:
           # Only build on scala-2.13 for spark-3.5
           - sparkver: spark-3.0


### PR DESCRIPTION

# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1659

 # Rationale for this change


https://github.com/apache/auron/actions/runs/19596884366/job/56122677089

ubuntu-22.04-arm
```
[INFO] [main]   process didn't exit successfully: `/home/runner/work/auron/auron/target/debug/build/blake3-efb5e344151b28f2/build-script-build` (exit status: 1)
[INFO] [main]   --- stderr
[INFO] [main]   /home/runner/work/auron/auron/target/debug/build/blake3-efb5e344151b28f2/build-script-build: /lib/aarch64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found (required by /home/runner/work/auron/auron/target/debug/build/blake3-efb5e344151b28f2/build-script-build)
```


# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

# How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
