### PR TITLE
[AURON #1665] Override verboseStringWithOperatorId in NativeProjectBase

### DIFF
--- a/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeProjectBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeProjectBase.scala
@@ -31,8 +31,7 @@ import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.expressions.NamedExpression
 import org.apache.spark.sql.catalyst.expressions.SortOrder
 import org.apache.spark.sql.catalyst.plans.physical.Partitioning
-import org.apache.spark.sql.execution.SparkPlan
-import org.apache.spark.sql.execution.UnaryExecNode
+import org.apache.spark.sql.execution.{ExplainUtils, SparkPlan, UnaryExecNode}
 import org.apache.spark.sql.execution.auron.plan.NativeProjectBase.getNativeProjectBuilder
 import org.apache.spark.sql.execution.metric.SQLMetric
 
@@ -88,6 +87,14 @@ abstract class NativeProjectBase(projectList: Seq[NamedExpression], override val
         PhysicalPlanNode.newBuilder().setProjection(nativeProjectExec).build()
       },
       friendlyName = "NativeRDD.Project")
+  }
+
+  override def verboseStringWithOperatorId(): String = {
+    s"""
+       |$formattedNodeName
+       |${ExplainUtils.generateFieldString("Output", projectList)}
+       |${ExplainUtils.generateFieldString("Input", child.output)}
+       |""".stripMargin
   }
 }
 


### PR DESCRIPTION
# Which issue does this PR close?
Close https://github.com/apache/auron/issues/1665.

# Rationale for this change
Align NativeProjectBase verbose string output with Spark to improve readability and debugging.

# What changes are included in this PR?
Override verboseStringWithOperatorId in NativeProjectBase, mirroring Spark’s formatting: (https://github.com/apache/spark/blob/65c3d1cb18c45528d8090ac905d87a8dcd779aa7/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala#L109-L115)  

# Are there any user-facing changes?
Yes: operator verbose string output aligns with Spark.

# How was this patch tested?
Manual checks on sample queries.  
