### PR TITLE
[AURON #1665] Override verboseStringWithOperatorId in NativeFilterBase

### DIFF
--- a/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeFilterBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeFilterBase.scala
@@ -32,9 +32,7 @@ import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.expressions.IsNotNull
 import org.apache.spark.sql.catalyst.expressions.SortOrder
 import org.apache.spark.sql.catalyst.plans.physical.Partitioning
-import org.apache.spark.sql.execution.FilterExec
-import org.apache.spark.sql.execution.SparkPlan
-import org.apache.spark.sql.execution.UnaryExecNode
+import org.apache.spark.sql.execution.{ExplainUtils, FilterExec, SparkPlan, UnaryExecNode}
 import org.apache.spark.sql.execution.metric.SQLMetric
 
 import org.apache.auron.metric.SparkMetricNode
@@ -110,5 +108,13 @@ abstract class NativeFilterBase(condition: Expression, override val child: Spark
         PhysicalPlanNode.newBuilder().setFilter(nativeFilterExec).build()
       },
       friendlyName = "NativeRDD.Filter")
+  }
+
+  override def verboseStringWithOperatorId(): String = {
+    s"""
+       |$formattedNodeName
+       |${ExplainUtils.generateFieldString("Input", child.output)}
+       |Condition : ${condition}
+       |""".stripMargin
   }
 }


### PR DESCRIPTION
# Which issue does this PR close?
Close https://github.com/apache/auron/issues/1665.

# Rationale for this change
Align NativeFilterBase verbose string output with Spark to improve readability and debugging.

# What changes are included in this PR?
Override verboseStringWithOperatorId in NativeFilterBase, mirroring Spark’s formatting: (https://github.com/apache/spark/blob/65c3d1cb18c45528d8090ac905d87a8dcd779aa7/sql/core/src/main/scala/org/apache/spark/sql/execution/basicPhysicalOperators.scala#L291-L297)  

# Are there any user-facing changes?
Yes: operator verbose string output aligns with Spark.

# How was this patch tested?
Manual checks on sample queries.  
