### PR TITLE
[AURON #1674] Fix: route Upper to Spark_StringUpper

### DIFF
--- a/native-engine/datafusion-ext-functions/src/spark_strings.rs
+++ b/native-engine/datafusion-ext-functions/src/spark_strings.rs
@@ -52,7 +52,7 @@ pub fn string_upper(args: &[ColumnarValue]) -> Result<ColumnarValue> {
         ColumnarValue::Scalar(ScalarValue::Utf8(Some(str))) => Ok(ColumnarValue::Scalar(
             ScalarValue::Utf8(Some(str.to_uppercase())),
         )),
-        _ => df_execution_err!("string_lower only supports literal utf8"),
+        _ => df_execution_err!("string_upper only supports literal utf8"),
     }
 }
 

--- a/spark-extension-shims-spark/src/test/scala/org.apache.auron/AuronFunctionSuite.scala
+++ b/spark-extension-shims-spark/src/test/scala/org.apache.auron/AuronFunctionSuite.scala
@@ -443,4 +443,26 @@ class AuronFunctionSuite extends AuronQueryTest with BaseAuronSQLSuite {
       checkSparkAnswerAndOperator(functions)
     }
   }
+
+  test("upper and lower functions") {
+    withSQLConf() {
+      withTable("t1") {
+        sql(s"CREATE TABLE t1(id INT, name STRING) USING parquet")
+        sql(s"""
+             |INSERT INTO t1 VALUES
+             | (1, 'fooBar'),
+             | (2, 'foo Bar foo-bar FOO-BAR foO-barR'),
+             | (3, 'straße'),
+             | (4, 'CAFÉ'),
+             | (5, '世界'),
+             | (6, '世 界'),
+             | (7, ''),
+             | (8, NULL)
+            """.stripMargin)
+
+        checkSparkAnswerAndOperator(
+          s"SELECT id, name, UPPER(name) AS up, LOWER(name) AS low FROM t1")
+      }
+    }
+  }
 }

--- a/spark-extension/src/main/scala/org/apache/spark/sql/auron/NativeConverters.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/auron/NativeConverters.scala
@@ -853,7 +853,7 @@ object NativeConverters extends Logging {
         buildExtScalarFunction("Spark_StringLower", e.children, e.dataType)
       case e: Upper
           if sparkAuronConfig.getBoolean(SparkAuronConfiguration.CASE_CONVERT_FUNCTIONS_ENABLE) =>
-        buildExtScalarFunction("Spark_StringLower", e.children, e.dataType)
+        buildExtScalarFunction("Spark_StringUpper", e.children, e.dataType)
 
       case e: StringTrim =>
         buildScalarFunction(pb.ScalarFunction.Trim, e.srcStr +: e.trimStr.toSeq, e.dataType)


### PR DESCRIPTION
 
# Which issue does this PR close?


Closes #1674 .

 # Rationale for this change
Upper was incorrectly wired to the Lower implementation in `NativeConverters`, causing lowercase output. Correct wiring restores expected uppercase behavior.  

# What changes are included in this PR?

# Are there any user-facing changes?
Yes. UPPER(...) now returns uppercase as expected.


# How was this patch tested?
unit tests. 
