### PR TITLE
[AURON #1720] Exclude temp file: auron-build-info.properties from apache-rat plugin

### DIFF
--- a/.rat-excludes
+++ b/.rat-excludes
@@ -32,3 +32,4 @@
 NOTICE*
 docs/**
 build/apache-maven-*/**
+src/main/resources/auron-build-info.properties


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #1720 .

 # Rationale for this change

Excluded the temp file: auron-build-info.properties which is causing the issue.

# What changes are included in this PR?

Some exclude rules.

# Are there any user-facing changes?

No.

# How was this patch tested?

Manual test.
