### PR TITLE
[AURON #1732] Add maven repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -270,6 +270,57 @@
     </dependency>
   </dependencies>
 
+  <repositories>
+    <repository>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <id>gcs-maven-central-mirror</id>
+      <name>GCS Maven Central mirror Asia Pacific</name>
+      <url>https://maven-central-asia.storage-download.googleapis.com/maven2/</url>
+    </repository>
+
+    <repository>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <id>central</id>
+      <name>Maven Repository</name>
+      <url>https://repo.maven.apache.org/maven2</url>
+    </repository>
+  </repositories>
+
+  <pluginRepositories>
+    <pluginRepository>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <id>gcs-maven-central-mirror</id>
+      <name>GCS Maven Central mirror Asia Pacific</name>
+      <url>https://maven-central-asia.storage-download.googleapis.com/maven2/</url>
+    </pluginRepository>
+
+    <pluginRepository>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <id>central</id>
+      <url>https://repo.maven.apache.org/maven2</url>
+    </pluginRepository>
+  </pluginRepositories>
+
   <build>
     <plugins>
       <!-- compile java -->


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1732

# Rationale for this change

Now Maven uses `repo.maven.apache.org`, sometimes CI is not stable, let's try GCS.

# What changes are included in this PR?

# Are there any user-facing changes?

# How was this patch tested?
