### PR TITLE
[AURON #1737] fix Generate index out of bounds

### DIFF
--- a/spark-extension/src/main/scala/org/apache/spark/sql/auron/SparkUDTFWrapperContext.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/auron/SparkUDTFWrapperContext.scala
@@ -149,13 +149,17 @@ case class SparkUDTFWrapperContext(serialized: ByteBuffer) extends Logging {
         // evaluate expression and write to output root
         val reusedOutputRow = new GenericInternalRow(Array[Any](null, null))
         val outputWriter = ArrowWriter.create(outputRoot)
-
+        val lastRowIdx = if (currentRowIdx > 0) {
+          currentRowIdx - 1
+        } else {
+          currentRowIdx
+        }
         while (allocator.getAllocatedMemory < maxBatchMemorySize
           && outputWriter.currentCount < batchSize
           && terminateIter.hasNext) {
 
           val outputRow = terminateIter.next()
-          reusedOutputRow.setInt(0, currentRowIdx)
+          reusedOutputRow.setInt(0, lastRowIdx)
           reusedOutputRow.update(1, outputRow)
           outputWriter.write(reusedOutputRow)
         }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1737

# Rationale for this change

# What changes are included in this PR?

# Are there any user-facing changes?

# How was this patch tested?

```
insert overwrite table test_string select 'abc' from range(15);

add jar https://repo1.maven.org/maven2/org/apache/hive/hive-contrib/2.3.9/hive-contrib-2.3.9.jar;
create temporary function udtfCount2 as 'org.apache.hadoop.hive.contrib.udtf.example.GenericUDTFCount2';
select udtfCount2(c1),c1 from test_string;
```