### PR TITLE
[AURON #1746] Introduce NativeTakeOrderedAndProjectExec to fuse TakeOrdered + Project

### DIFF
--- a/spark-extension-shims-spark/src/main/scala/org/apache/spark/sql/auron/ShimsImpl.scala
+++ b/spark-extension-shims-spark/src/main/scala/org/apache/spark/sql/auron/ShimsImpl.scala
@@ -87,8 +87,8 @@ import org.apache.spark.sql.execution.auron.plan.NativeShuffleExchangeBase
 import org.apache.spark.sql.execution.auron.plan.NativeShuffleExchangeExec
 import org.apache.spark.sql.execution.auron.plan.NativeSortBase
 import org.apache.spark.sql.execution.auron.plan.NativeSortExec
-import org.apache.spark.sql.execution.auron.plan.NativeTakeOrderedBase
-import org.apache.spark.sql.execution.auron.plan.NativeTakeOrderedExec
+import org.apache.spark.sql.execution.auron.plan.NativeTakeOrderedAndProjectBase
+import org.apache.spark.sql.execution.auron.plan.NativeTakeOrderedAndProjectExec
 import org.apache.spark.sql.execution.auron.plan.NativeUnionBase
 import org.apache.spark.sql.execution.auron.plan.NativeUnionExec
 import org.apache.spark.sql.execution.auron.plan.NativeWindowBase
@@ -328,17 +328,18 @@ class ShimsImpl extends Shims with Logging {
       child: SparkPlan): NativeSortBase =
     NativeSortExec(sortOrder, global, child)
 
-  override def createNativeTakeOrderedExec(
+  override def createNativeTakeOrderedAndProjectExec(
       limit: Long,
       sortOrder: Seq[SortOrder],
-      child: SparkPlan): NativeTakeOrderedBase =
-    NativeTakeOrderedExec(limit, sortOrder, child)
+      projectList: Seq[NamedExpression],
+      child: SparkPlan): NativeTakeOrderedAndProjectBase =
+    NativeTakeOrderedAndProjectExec(limit, sortOrder, projectList, child)
 
   override def createNativePartialTakeOrderedExec(
       limit: Long,
       sortOrder: Seq[SortOrder],
       child: SparkPlan,
-      metrics: Map[String, SQLMetric]): NativePartialTakeOrderedBase =
+      metrics: Map[String, SQLMetric]): NativePartialTakeOrderedAndProjectBase =
     NativePartialTakeOrderedExec(limit, sortOrder, child, metrics)
 
   override def createNativeUnionExec(

--- a/spark-extension-shims-spark/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativePartialTakeOrderedExec.scala
+++ b/spark-extension-shims-spark/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativePartialTakeOrderedExec.scala
@@ -27,7 +27,7 @@ case class NativePartialTakeOrderedExec(
     sortOrder: Seq[SortOrder],
     override val child: SparkPlan,
     override val metrics: Map[String, SQLMetric])
-    extends NativePartialTakeOrderedBase(limit, sortOrder, child, metrics) {
+    extends NativePartialTakeOrderedAndProjectBase(limit, sortOrder, child, metrics) {
 
   @sparkver("3.2 / 3.3 / 3.4 / 3.5")
   override protected def withNewChildInternal(newChild: SparkPlan): SparkPlan =

--- a/spark-extension-shims-spark/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeTakeOrderedAndProjectExec.scala
+++ b/spark-extension-shims-spark/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeTakeOrderedAndProjectExec.scala
@@ -16,16 +16,17 @@
  */
 package org.apache.spark.sql.execution.auron.plan
 
-import org.apache.spark.sql.catalyst.expressions.SortOrder
+import org.apache.spark.sql.catalyst.expressions.{NamedExpression, SortOrder}
 import org.apache.spark.sql.execution.SparkPlan
 
 import org.apache.auron.sparkver
 
-case class NativeTakeOrderedExec(
+case class NativeTakeOrderedAndProjectExec(
     limit: Long,
     sortOrder: Seq[SortOrder],
+    projectList: Seq[NamedExpression],
     override val child: SparkPlan)
-    extends NativeTakeOrderedBase(limit, sortOrder, child) {
+    extends NativeTakeOrderedAndProjectBase(limit, sortOrder, projectList, child) {
 
   @sparkver("3.2 / 3.3 / 3.4 / 3.5")
   override protected def withNewChildInternal(newChild: SparkPlan): SparkPlan =

--- a/spark-extension-shims-spark/src/test/scala/org.apache.auron/AuronExecSuite.scala
+++ b/spark-extension-shims-spark/src/test/scala/org.apache.auron/AuronExecSuite.scala
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.auron
+
+import org.apache.spark.sql.AuronQueryTest
+import org.apache.spark.sql.execution.auron.plan.{NativeFilterExec, NativeTakeOrderedAndProjectExec}
+
+class AuronExecSuite extends AuronQueryTest with BaseAuronSQLSuite {
+
+  test("TakeOrderedAndProject") {
+    withTempView("t1") {
+      sql("create table t1(id INT, name STRING) using parquet")
+      sql("insert into t1 values(1, 'a'),(2, 'b'),(3, 'c'),(3, 'c'),(4, 'd'),(5, 'e')")
+
+      // executeCollect (collect rows directly to driver)
+      var df = checkSparkAnswerAndOperator(
+        "SELECT id + 42, name, length(name) FROM t1 order by id limit 4")
+      val firstNode = collect(stripAQEPlan(df.queryExecution.executedPlan)) { case exec =>
+        exec
+      }.head
+      assert(firstNode.isInstanceOf[NativeTakeOrderedAndProjectExec])
+
+      // doExecuteNative
+      df = checkSparkAnswerAndOperator(
+        "select * from (SELECT id, id + 42, length(name) FROM t1 order by id limit 4) where id > 1")
+      assert(collectFirst(df.queryExecution.executedPlan) {
+        case f: NativeFilterExec if f.child.isInstanceOf[NativeTakeOrderedAndProjectExec] => true
+      }.isDefined)
+    }
+  }
+}

--- a/spark-extension/src/main/scala/org/apache/spark/sql/auron/AuronConverters.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/auron/AuronConverters.scala
@@ -783,17 +783,11 @@ object AuronConverters extends Logging {
 
   def convertTakeOrderedAndProjectExec(exec: TakeOrderedAndProjectExec): SparkPlan = {
     logDebugPlanConversion(exec)
-    val nativeTakeOrdered = Shims.get.createNativeTakeOrderedExec(
+    Shims.get.createNativeTakeOrderedAndProjectExec(
       exec.limit,
       exec.sortOrder,
+      exec.projectList,
       addRenameColumnsExec(convertToNative(exec.child)))
-
-    if (exec.projectList != exec.child.output) {
-      val project = ProjectExec(exec.projectList, nativeTakeOrdered)
-      tryConvert(project, convertProjectExec)
-    } else {
-      nativeTakeOrdered
-    }
   }
 
   def convertHashAggregateExec(exec: HashAggregateExec): SparkPlan = {

--- a/spark-extension/src/main/scala/org/apache/spark/sql/auron/Shims.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/auron/Shims.scala
@@ -149,16 +149,17 @@ abstract class Shims {
       global: Boolean,
       child: SparkPlan): NativeSortBase
 
-  def createNativeTakeOrderedExec(
+  def createNativeTakeOrderedAndProjectExec(
       limit: Long,
       sortOrder: Seq[SortOrder],
-      child: SparkPlan): NativeTakeOrderedBase
+      projectList: Seq[NamedExpression],
+      child: SparkPlan): NativeTakeOrderedAndProjectBase
 
   def createNativePartialTakeOrderedExec(
       limit: Long,
       sortOrder: Seq[SortOrder],
       child: SparkPlan,
-      metrics: Map[String, SQLMetric]): NativePartialTakeOrderedBase
+      metrics: Map[String, SQLMetric]): NativePartialTakeOrderedAndProjectBase
 
   def createNativeUnionExec(children: Seq[SparkPlan], output: Seq[Attribute]): NativeUnionBase
 


### PR DESCRIPTION

<!--
  - Start the PR title with the related issue ID, e.g. '[AURON #XXXX] Short summary...'.
-->
# Which issue does this PR close?

Closes #1746 

# Rationale for this change

# What changes are included in this PR?

# Are there any user-facing changes?

# How was this patch tested?
