### PR TITLE
[AURON #1748] ORC check offset overflow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2794,7 +2794,7 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 [[package]]
 name = "orc-rust"
 version = "0.7.0"
-source = "git+https://github.com/auron-project/datafusion-orc.git?rev=8785b99#8785b99323a0269e37d7078818badf0f96a69416"
+source = "git+https://github.com/auron-project/datafusion-orc.git?rev=7ecdbed#7ecdbed691481499e6c480b615082fe885596a13"
 dependencies = [
  "arrow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,7 +121,7 @@ datafusion-execution = { git = "https://github.com/auron-project/datafusion.git"
 datafusion-optimizer = { git = "https://github.com/auron-project/datafusion.git", rev = "9034aeffb"}
 datafusion-physical-expr = { git = "https://github.com/auron-project/datafusion.git", rev = "9034aeffb"}
 datafusion-spark = { git = "https://github.com/auron-project/datafusion.git", rev = "9034aeffb"}
-orc-rust = { git = "https://github.com/auron-project/datafusion-orc.git", rev = "8785b99"}
+orc-rust = { git = "https://github.com/auron-project/datafusion-orc.git", rev = "7ecdbed"}
 
 # arrow: branch=v55.2.0-blaze
 arrow = { git = "https://github.com/auron-project/arrow-rs.git", rev = "5de02520c"}


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1748

# Rationale for this change

# What changes are included in this PR?

Upgrade orc-rust version, prompt batch size before offset overflow error.

# Are there any user-facing changes?

# How was this patch tested?
Production environment verification

```
External error: String/Binary data size (2641110982 bytes) exceeds maximum offset size (2147483647) with current batch size 3000. Please reduce the batch size to avoid offset overflow.
```