### PR TITLE
[AURON #1757] Add cleanup logic to prevent flaky tests caused by leftover locations

### DIFF
--- a/spark-extension-shims-spark/src/test/scala/org/apache/auron/BaseAuronSQLSuite.scala
+++ b/spark-extension-shims-spark/src/test/scala/org/apache/auron/BaseAuronSQLSuite.scala
@@ -16,10 +16,37 @@
  */
 package org.apache.auron
 
+import java.io.File
+
+import org.apache.commons.io.FileUtils
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.test.SharedSparkSession
 
 trait BaseAuronSQLSuite extends SharedSparkSession {
+  protected val suiteWorkspace: String = getClass.getResource("/").getPath + "auron-tests-workdir"
+  protected val warehouseDir: String = suiteWorkspace + "/spark-warehouse"
+  protected val metastoreDir: String = suiteWorkspace + "/meta"
+
+  protected def resetSuiteWorkspace(): Unit = {
+    val workdir = new File(suiteWorkspace)
+    if (workdir.exists()) {
+      FileUtils.forceDelete(workdir)
+    }
+    FileUtils.forceMkdir(workdir)
+    FileUtils.forceMkdir(new File(warehouseDir))
+    FileUtils.forceMkdir(new File(metastoreDir))
+  }
+
+  override def beforeAll(): Unit = {
+    // Prepare a clean workspace before SparkSession initialization
+    resetSuiteWorkspace()
+    super.beforeAll()
+    spark.sparkContext.setLogLevel("WARN")
+  }
+
+  override def afterAll(): Unit = {
+    super.afterAll()
+  }
 
   override protected def sparkConf: SparkConf = {
     super.sparkConf
@@ -30,6 +57,6 @@ trait BaseAuronSQLSuite extends SharedSparkSession {
       .set("spark.memory.offHeap.enabled", "false")
       .set("spark.auron.enable", "true")
       .set("spark.ui.enabled", "false")
+      .set("spark.sql.warehouse.dir", warehouseDir)
   }
-
 }

--- a/spark-extension-shims-spark/src/test/scala/org/apache/spark/sql/execution/BuildInfoInSparkUISuite.scala
+++ b/spark-extension-shims-spark/src/test/scala/org/apache/spark/sql/execution/BuildInfoInSparkUISuite.scala
@@ -33,12 +33,12 @@ class BuildInfoInSparkUISuite extends AuronQueryTest with BaseAuronSQLSuite {
     super.sparkConf.set("spark.eventLog.dir", testDir.toString)
   }
 
-  override protected def beforeAll(): Unit = {
+  override def beforeAll(): Unit = {
     testDir = Utils.createTempDir(namePrefix = "spark-events")
     super.beforeAll()
   }
 
-  override protected def afterAll(): Unit = {
+  override def afterAll(): Unit = {
     Utils.deleteRecursively(testDir)
   }
 


### PR DESCRIPTION
<!--
  - Start the PR title with the related issue ID, e.g. '[AURON #XXXX] Short summary...'.
-->
# Which issue does this PR close?

Closes #1757

# Rationale for this change

# What changes are included in this PR?
BaseAuronSQLSuite: reset suite workspace  and set spark.sql.warehouse.dir 

# Are there any user-facing changes?

# How was this patch tested?
