### PR TITLE
[AURON #1762] Fix ORC incorrect results from RLEv2 patched base

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2794,7 +2794,7 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 [[package]]
 name = "orc-rust"
 version = "0.7.0"
-source = "git+https://github.com/auron-project/datafusion-orc.git?rev=7ecdbed#7ecdbed691481499e6c480b615082fe885596a13"
+source = "git+https://github.com/auron-project/datafusion-orc.git?rev=919e050#919e0509b2b4b5a3bb70eea4b34633d3a3c933e8"
 dependencies = [
  "arrow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,7 +121,7 @@ datafusion-execution = { git = "https://github.com/auron-project/datafusion.git"
 datafusion-optimizer = { git = "https://github.com/auron-project/datafusion.git", rev = "9034aeffb"}
 datafusion-physical-expr = { git = "https://github.com/auron-project/datafusion.git", rev = "9034aeffb"}
 datafusion-spark = { git = "https://github.com/auron-project/datafusion.git", rev = "9034aeffb"}
-orc-rust = { git = "https://github.com/auron-project/datafusion-orc.git", rev = "7ecdbed"}
+orc-rust = { git = "https://github.com/auron-project/datafusion-orc.git", rev = "919e050"}
 
 # arrow: branch=v55.2.0-blaze
 arrow = { git = "https://github.com/auron-project/arrow-rs.git", rev = "5de02520c"}


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1762

# Rationale for this change
update orc-rust depend

# What changes are included in this PR?
Upgrade orc-rust and fix the issue of [Incorrect results from RLEv2 patched base] in orc-rust, which causes disorder in reading orc files

# Are there any user-facing changes?
no
# How was this patch tested?
Cluster testing
