### PR TITLE
[AURON #1771] build-native.sh set -e

### DIFF
--- a/dev/mvn-build-helper/build-native.sh
+++ b/dev/mvn-build-helper/build-native.sh
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-set -o pipefail
+set -eo pipefail
 
 # Preserve the calling directory
 _CALLING_DIR="$(pwd)"


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1771

# Rationale for this change

# What changes are included in this PR?

# Are there any user-facing changes?

# How was this patch tested?

Current
```bash
[INFO] [main] warning: build failed, waiting for other jobs to finish...
[ERROR] [main] cp: target/pre/libauron.dylib: No such file or directory
[INFO] [main] build-checksum updated: 702989478eabd7003d4354a0b19ad24d
[INFO] [main] Native build completed successfully
```

PR
```bash
[INFO] [main] warning: build failed, waiting for other jobs to finish...
[ERROR] Command execution failed.
org.apache.commons.exec.ExecuteException: Process exited with an error: 101 (Exit value: 101)
```
