### PR TITLE
[AURON #1780] Fix the ORC table written by Hive to read null uppercase fields

### DIFF
--- a/native-engine/auron-jni-bridge/src/conf.rs
+++ b/native-engine/auron-jni-bridge/src/conf.rs
@@ -57,7 +57,7 @@ define_conf!(IntConf, SUGGESTED_BATCH_MEM_SIZE);
 define_conf!(IntConf, SUGGESTED_BATCH_MEM_SIZE_KWAY_MERGE);
 define_conf!(BooleanConf, ORC_FORCE_POSITIONAL_EVOLUTION);
 define_conf!(BooleanConf, ORC_TIMESTAMP_USE_MICROSECOND);
-define_conf!(BooleanConf, ORC_SCHEMA_ISCASE_SENSITIVE);
+define_conf!(BooleanConf, ORC_SCHEMA_CASE_SENSITIVE);
 define_conf!(IntConf, UDAF_FALLBACK_NUM_UDAFS_TRIGGER_SORT_AGG);
 define_conf!(BooleanConf, PARSE_JSON_ERROR_FALLBACK);
 define_conf!(StringConf, NATIVE_LOG_LEVEL);

--- a/native-engine/datafusion-ext-plans/src/orc_exec.rs
+++ b/native-engine/datafusion-ext-plans/src/orc_exec.rs
@@ -160,7 +160,7 @@ impl ExecutionPlan for OrcExec {
 
         let force_positional_evolution = conf::ORC_FORCE_POSITIONAL_EVOLUTION.value()?;
         let use_microsecond_precision = conf::ORC_TIMESTAMP_USE_MICROSECOND.value()?;
-        let is_case_sensitive = conf::ORC_SCHEMA_ISCASE_SENSITIVE.value()?;
+        let is_case_sensitive = conf::ORC_SCHEMA_CASE_SENSITIVE.value()?;
 
         let opener: Arc<dyn FileOpener> = Arc::new(OrcOpener {
             projection,

--- a/spark-extension/src/main/java/org/apache/auron/spark/configuration/SparkAuronConfiguration.java
+++ b/spark-extension/src/main/java/org/apache/auron/spark/configuration/SparkAuronConfiguration.java
@@ -237,7 +237,7 @@ public class SparkAuronConfiguration extends AuronConfiguration {
             .description("use microsecond precision when reading ORC timestamp columns. ")
             .booleanType()
             .defaultValue(false);
-    public static final ConfigOption<Boolean> ORC_SCHEMA_ISCASE_SENSITIVE = ConfigOptions.key(
+    public static final ConfigOption<Boolean> ORC_SCHEMA_CASE_SENSITIVE = ConfigOptions.key(
                     "auron.orc.schema.caseSensitive.enable")
             .description("whether ORC file schema matching distinguishes between uppercase and lowercase. ")
             .booleanType()

--- a/spark-extension/src/main/java/org/apache/spark/sql/auron/AuronConf.java
+++ b/spark-extension/src/main/java/org/apache/spark/sql/auron/AuronConf.java
@@ -139,7 +139,7 @@ public enum AuronConf {
     // use microsecond precision when reading ORC timestamp columns
     ORC_TIMESTAMP_USE_MICROSECOND("spark.auron.orc.timestamp.use.microsecond", false),
 
-    ORC_SCHEMA_ISCASE_SENSITIVE("spark.auron.orc.schema.caseSensitive.enable", false),
+    ORC_SCHEMA_CASE_SENSITIVE("spark.auron.orc.schema.caseSensitive.enable", false),
 
     NATIVE_LOG_LEVEL("spark.auron.native.log.level", "info");
 


### PR DESCRIPTION
<!--
  - Start the PR title with the related issue ID, e.g. '[AURON #XXXX] Short summary...'.
-->
# Which issue does this PR close?

Closes #1780 

# Rationale for this change
Fix the issue of reading null ORC files written by Hive
# What changes are included in this PR?
Modify the matching field logic of the ORC file
# Are there any user-facing changes?
no
# How was this patch tested?
cluster test