### PR TITLE
[AURON #1484] Change test-jar dependencies scope to 'test' in spark-extension-shims-spark module

### DIFF
--- a/spark-extension-shims-spark/pom.xml
+++ b/spark-extension-shims-spark/pom.xml
@@ -96,6 +96,7 @@
       <artifactId>auron-common_${scalaVersion}</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1484

# Rationale for this change

`spark-extension-shims-spark` depends on the test jar of `auron-common` but does not declare the test scope. The last released jar packages `log4j2.properties`, which may affect the spark log configuration.

# What changes are included in this PR?

# Are there any user-facing changes?

# How was this patch tested?
local test
