### PR TITLE
[AURON #1745] Add Spark 3.3 ExistenceJoinSuite

### DIFF
--- a/auron-spark-tests/spark33/src/test/scala/org/apache/auron/utils/AuronSparkTestSettings.scala
+++ b/auron-spark-tests/spark33/src/test/scala/org/apache/auron/utils/AuronSparkTestSettings.scala
@@ -17,6 +17,7 @@
 package org.apache.auron.utils
 
 import org.apache.spark.sql._
+import org.apache.spark.sql.execution.joins.AuronExistenceJoinSuite
 
 class AuronSparkTestSettings extends SparkTestSettings {
   {
@@ -27,6 +28,12 @@ class AuronSparkTestSettings extends SparkTestSettings {
   enableSuite[AuronStringFunctionsSuite]
     // See https://github.com/apache/auron/issues/1724
     .exclude("string / binary substring function")
+
+  // Suites for JOINs.
+  enableSuite[AuronExistenceJoinSuite]
+    // See https://github.com/apache/auron/issues/1807
+    .exclude(
+      "test no condition with empty right side for left anti join using BroadcastNestedLoopJoin build left")
 
   // Will be implemented in the future.
   override def getSQLQueryTestSettings = new SQLQueryTestSettings {

--- a/auron-spark-tests/spark33/src/test/scala/org/apache/spark/sql/execution/joins/AuronExistenceJoinSuite.scala
+++ b/auron-spark-tests/spark33/src/test/scala/org/apache/spark/sql/execution/joins/AuronExistenceJoinSuite.scala
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.joins
+
+import org.apache.spark.sql.SparkTestsSharedSessionBase
+
+class AuronExistenceJoinSuite extends ExistenceJoinSuite with SparkTestsSharedSessionBase {}


### PR DESCRIPTION
# Which issue does this PR close?

Add ExistenceJoinSuite. 

We found a correctness issue for LeftAnti + BuildLeft query: https://github.com/apache/auron/issues/1807

# Rationale for this change

N/A.

# What changes are included in this PR?

 N/A.

# Are there any user-facing changes?

N/A.

# How was this patch tested?

N/A.