### PR TITLE
[AURON #1875] Minor refactor: move legacy spark version compatibility methods to Shims.scala

### DIFF
--- a/spark-extension-shims-spark/src/main/scala/org/apache/spark/sql/auron/ShimsImpl.scala
+++ b/spark-extension-shims-spark/src/main/scala/org/apache/spark/sql/auron/ShimsImpl.scala
@@ -96,7 +96,7 @@ import org.apache.spark.sql.execution.auron.plan.NativeWindowBase
 import org.apache.spark.sql.execution.auron.plan.NativeWindowExec
 import org.apache.spark.sql.execution.auron.shuffle.{AuronBlockStoreShuffleReaderBase, AuronRssShuffleManagerBase, RssPartitionWriterBase}
 import org.apache.spark.sql.execution.datasources.PartitionedFile
-import org.apache.spark.sql.execution.exchange.{BroadcastExchangeLike, ReusedExchangeExec}
+import org.apache.spark.sql.execution.exchange.{BroadcastExchangeLike, ReusedExchangeExec, ShuffleExchangeExec}
 import org.apache.spark.sql.execution.joins.{BroadcastHashJoinExec, BroadcastNestedLoopJoinExec, ShuffledHashJoinExec}
 import org.apache.spark.sql.execution.joins.auron.plan.NativeBroadcastJoinExec
 import org.apache.spark.sql.execution.joins.auron.plan.NativeShuffledHashJoinExecProvider
@@ -1074,6 +1074,25 @@ class ShimsImpl extends Shims with Logging {
         case _ => false
       })
   }
+
+  @sparkver("3.2 / 3.3 / 3.4 / 3.5")
+  override def getIsSkewJoinFromSHJ(exec: ShuffledHashJoinExec): Boolean = exec.isSkewJoin
+
+  @sparkver("3.0 / 3.1")
+  override def getIsSkewJoinFromSHJ(exec: ShuffledHashJoinExec): Boolean = false
+
+  @sparkver("3.1 / 3.2 / 3.3 / 3.4 / 3.5")
+  override def getShuffleOrigin(exec: ShuffleExchangeExec): Option[Any] = Some(exec.shuffleOrigin)
+
+  @sparkver("3.0")
+  override def getShuffleOrigin(exec: ShuffleExchangeExec): Option[Any] = None
+
+  @sparkver("3.1 / 3.2 / 3.3 / 3.4 / 3.5")
+  override def isNullAwareAntiJoin(exec: BroadcastHashJoinExec): Boolean =
+    exec.isNullAwareAntiJoin
+
+  @sparkver("3.0")
+  override def isNullAwareAntiJoin(exec: BroadcastHashJoinExec): Boolean = false
 }
 
 case class ForceNativeExecutionWrapper(override val child: SparkPlan)

--- a/spark-extension/src/main/scala/org/apache/spark/sql/auron/Shims.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/auron/Shims.scala
@@ -48,7 +48,8 @@ import org.apache.spark.sql.execution.auron.plan.NativeBroadcastJoinBase
 import org.apache.spark.sql.execution.auron.plan.NativeSortMergeJoinBase
 import org.apache.spark.sql.execution.auron.shuffle.RssPartitionWriterBase
 import org.apache.spark.sql.execution.datasources.PartitionedFile
-import org.apache.spark.sql.execution.exchange.BroadcastExchangeLike
+import org.apache.spark.sql.execution.exchange.{BroadcastExchangeLike, ShuffleExchangeExec}
+import org.apache.spark.sql.execution.joins.{BroadcastHashJoinExec, ShuffledHashJoinExec}
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.hive.execution.InsertIntoHiveTable
 import org.apache.spark.sql.types.DataType
@@ -264,6 +265,12 @@ abstract class Shims {
   def getAdaptiveInputPlan(exec: AdaptiveSparkPlanExec): SparkPlan
 
   def getJoinBuildSide(exec: SparkPlan): JoinBuildSide
+
+  def getIsSkewJoinFromSHJ(exec: ShuffledHashJoinExec): Boolean
+
+  def getShuffleOrigin(exec: ShuffleExchangeExec): Option[Any]
+
+  def isNullAwareAntiJoin(exec: BroadcastHashJoinExec): Boolean
 }
 
 object Shims {


### PR DESCRIPTION


<!--
  - Start the PR title with the related issue ID, e.g. '[AURON #XXXX] Short summary...'.
-->
# Which issue does this PR close?

Closes #1875 

# Rationale for this change

# What changes are included in this PR?

# Are there any user-facing changes?

# How was this patch tested?
