### PR TITLE
[AURON #1895] Disable auto-close for stale issues 

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -29,11 +29,9 @@ jobs:
     steps:
       - uses: actions/stale@v10
         with:
-          days-before-issue-stale: 30
-          days-before-issue-close: 14
+          days-before-issue-stale: -1 # disabled
+          days-before-issue-close: -1 # disabled
           stale-issue-label: "stale"
-          stale-issue-message: "This issue is stale because it has been open for 30 days with no activity."
-          close-issue-message: "This issue was closed because it has been inactive for 14 days since being marked as stale."
           days-before-pr-stale: 100
           days-before-pr-close: 0
           stale-pr-message: >


### PR DESCRIPTION
<!--
  - Start the PR title with the related issue ID, e.g. '[AURON #XXXX] Short summary...'.
-->
# Which issue does this PR close?

Closes #1895 

# Rationale for this change
We currently mark issues as stale after 30 days and automatically close them 14 days later:
```
days-before-issue-stale: 30
days-before-issue-close: 14
```

This workflow assumes issues are tracked externally (for example, in JIRA), but we are not using JIRA or any other system to track active issues. As a result, user-reported issues that are still valid but have not received recent activity can be automatically marked stale and closed within ~45 days, even though they may not have been triaged or resolved. This risks losing legitimate issues and negatively impacts visibility into active issues.

# What changes are included in this PR?
Similar to other OSS projects like [Gluten](https://github.com/apache/incubator-gluten/pull/3888), we have disabled the auto-closing of issues.

# Are there any user-facing changes?
N/A

# How was this patch tested?
N/A

