### PR TITLE
[AURON #1850] Introduce Flink RowData to Arrow conversion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ common/src/main/resources/auron-build-info.properties
 
 .flattened-pom.xml
 dependency-reduced-pom.xml
+
+#lsp
+*.prefs

--- a/auron-flink-extension/auron-flink-runtime/pom.xml
+++ b/auron-flink-extension/auron-flink-runtime/pom.xml
@@ -38,6 +38,41 @@
       <artifactId>proto</artifactId>
       <version>${project.version}</version>
     </dependency>
+
+    <!-- Arrow dependencies -->
+    <dependency>
+      <groupId>org.apache.arrow</groupId>
+      <artifactId>arrow-c-data</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.arrow</groupId>
+      <artifactId>arrow-memory-unsafe</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.arrow</groupId>
+      <artifactId>arrow-vector</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.flink</groupId>
+      <artifactId>flink-table-common</artifactId>
+      <version>${flink.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- Test dependencies -->
+    <dependency>
+      <groupId>org.apache.auron</groupId>
+      <artifactId>auron-core</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>${junit.jupiter.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/auron-flink-extension/auron-flink-runtime/src/main/java/org/apache/auron/flink/arrow/FlinkArrowFFIExporter.java
+++ b/auron-flink-extension/auron-flink-runtime/src/main/java/org/apache/auron/flink/arrow/FlinkArrowFFIExporter.java
@@ -1,0 +1,284 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.auron.flink.arrow;
+
+import java.util.Iterator;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import org.apache.arrow.c.ArrowArray;
+import org.apache.arrow.c.ArrowSchema;
+import org.apache.arrow.c.Data;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.dictionary.DictionaryProvider;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.apache.auron.arrowio.AuronArrowFFIExporter;
+import org.apache.auron.configuration.AuronConfiguration;
+import org.apache.auron.jni.AuronAdaptor;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.logical.RowType;
+
+/**
+ * Exports Flink RowData to Arrow format via FFI (Foreign Function Interface)
+ * for consumption by native code.
+ *
+ * <p>This exporter uses an asynchronous producer-consumer model with double
+ * queues to ensure safe resource management. The producer thread creates
+ * batches ahead of time while the consumer (native side) processes them.
+ * Resources are only cleaned up after the consumer confirms it has finished
+ * using the previous batch.
+ *
+ * <p>Key design points:
+ * <ul>
+ *   <li>Producer thread pre-creates batches and puts them in outputQueue</li>
+ *   <li>Consumer takes batches and signals via processingQueue when done</li>
+ *   <li>Previous batch resources are cleaned up only after consumer confirms</li>
+ *   <li>No TaskContext in Flink, so cancellation uses closed flag + thread interrupt</li>
+ * </ul>
+ */
+public class FlinkArrowFFIExporter extends AuronArrowFFIExporter {
+
+    /** Queue state representing a data batch ready for export. */
+    private static final class NextBatch {
+        final VectorSchemaRoot root;
+        final BufferAllocator allocator;
+
+        NextBatch(VectorSchemaRoot root, BufferAllocator allocator) {
+            this.root = root;
+            this.allocator = allocator;
+        }
+    }
+
+    /** Queue state representing end of data or an error. */
+    private static final class Finished {
+        final Throwable error; // null means normal completion
+
+        Finished(Throwable error) {
+            this.error = error;
+        }
+    }
+
+    private final Iterator<RowData> rowIterator;
+    private final RowType rowType;
+    private final Schema arrowSchema;
+    private final DictionaryProvider.MapDictionaryProvider emptyDictionaryProvider;
+    private final int maxBatchNumRows;
+    private final long maxBatchMemorySize;
+
+    // Double queue synchronization (capacity 4, smaller than Spark's 16 for streaming)
+    private final BlockingQueue<Object> outputQueue;
+    private final BlockingQueue<Object> processingQueue;
+
+    // Previous batch resources (cleaned up after consumer confirms)
+    private VectorSchemaRoot previousRoot;
+    private BufferAllocator previousAllocator;
+
+    // Producer thread
+    private final Thread producerThread;
+    private volatile boolean closed = false;
+
+    /**
+     * Creates a new FlinkArrowFFIExporter.
+     *
+     * @param rowIterator Iterator over RowData to export
+     * @param rowType     The Flink row type
+     */
+    public FlinkArrowFFIExporter(Iterator<RowData> rowIterator, RowType rowType) {
+        this.rowIterator = rowIterator;
+        this.rowType = rowType;
+        this.arrowSchema = FlinkArrowUtils.toArrowSchema(rowType);
+        this.emptyDictionaryProvider = new DictionaryProvider.MapDictionaryProvider();
+
+        // Get configuration
+        AuronConfiguration config = AuronAdaptor.getInstance().getAuronConfiguration();
+        this.maxBatchNumRows = config.getInteger(AuronConfiguration.BATCH_SIZE);
+        this.maxBatchMemorySize = 8 * 1024 * 1024; // 8MB default, same as Spark
+
+        this.outputQueue = new ArrayBlockingQueue<>(4);
+        this.processingQueue = new ArrayBlockingQueue<>(4);
+
+        this.producerThread = startProducerThread();
+    }
+
+    /**
+     * Starts the producer thread that creates batches asynchronously.
+     */
+    private Thread startProducerThread() {
+        Thread thread = new Thread(
+                () -> {
+                    try {
+                        while (!closed && !Thread.currentThread().isInterrupted()) {
+                            if (!rowIterator.hasNext()) {
+                                outputQueue.put(new Finished(null));
+                                return;
+                            }
+
+                            // Create a new batch
+                            BufferAllocator allocator =
+                                    FlinkArrowUtils.createChildAllocator("FlinkArrowFFIExporter-producer");
+                            VectorSchemaRoot root = VectorSchemaRoot.create(arrowSchema, allocator);
+                            FlinkArrowWriter writer = FlinkArrowWriter.create(root, rowType);
+
+                            // Fill the batch with data
+                            while (!closed
+                                    && rowIterator.hasNext()
+                                    && allocator.getAllocatedMemory() < maxBatchMemorySize
+                                    && writer.currentCount() < maxBatchNumRows) {
+                                writer.write(rowIterator.next());
+                            }
+                            writer.finish();
+
+                            // Put batch in output queue for consumer
+                            outputQueue.put(new NextBatch(root, allocator));
+
+                            // Wait for consumer to confirm it's done with previous batch
+                            // This is critical for safe resource management!
+                            processingQueue.take();
+                        }
+                        outputQueue.put(new Finished(null));
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        // Normal interruption, not an error
+                    } catch (Throwable e) {
+                        outputQueue.clear();
+                        try {
+                            outputQueue.put(new Finished(e));
+                        } catch (InterruptedException ignored) {
+                            Thread.currentThread().interrupt();
+                        }
+                    }
+                },
+                "FlinkArrowFFIExporter-producer");
+
+        thread.setDaemon(true);
+        thread.setUncaughtExceptionHandler((t, e) -> {
+            outputQueue.clear();
+            try {
+                outputQueue.put(new Finished(e));
+            } catch (InterruptedException ignored) {
+                // Ignore
+            }
+        });
+        thread.start();
+        return thread;
+    }
+
+    /**
+     * Exports the Arrow schema to the native side.
+     *
+     * @param exportArrowSchemaPtr Pointer to the Arrow C Data Interface schema
+     *                             structure
+     */
+    public void exportSchema(long exportArrowSchemaPtr) {
+        try (ArrowSchema exportSchema = ArrowSchema.wrap(exportArrowSchemaPtr)) {
+            Data.exportSchema(FlinkArrowUtils.ROOT_ALLOCATOR, arrowSchema, emptyDictionaryProvider, exportSchema);
+        }
+    }
+
+    /**
+     * Exports the next batch of data to the native side.
+     *
+     * <p>This method takes a batch from the producer thread and exports it
+     * via the Arrow C Data Interface. The previous batch's resources are
+     * cleaned up before taking the new batch (after consumer confirms).
+     *
+     * @param exportArrowArrayPtr Pointer to the Arrow C Data Interface array
+     *                            structure
+     * @return true if a batch was exported, false if no more data is available
+     */
+    @Override
+    public boolean exportNextBatch(long exportArrowArrayPtr) {
+        // Clean up previous batch resources (consumer has confirmed it's done)
+        cleanupPreviousBatch();
+
+        if (closed) {
+            return false;
+        }
+
+        // Wait for producer to provide next batch
+        Object state;
+        try {
+            state = outputQueue.take();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return false;
+        }
+
+        if (state instanceof Finished) {
+            Finished finished = (Finished) state;
+            if (finished.error != null) {
+                throw new RuntimeException("Producer thread error", finished.error);
+            }
+            return false;
+        }
+
+        NextBatch batch = (NextBatch) state;
+
+        // Export data via Arrow FFI
+        try (ArrowArray exportArray = ArrowArray.wrap(exportArrowArrayPtr)) {
+            Data.exportVectorSchemaRoot(
+                    FlinkArrowUtils.ROOT_ALLOCATOR, batch.root, emptyDictionaryProvider, exportArray);
+        }
+
+        // Save references for cleanup on next call
+        previousRoot = batch.root;
+        previousAllocator = batch.allocator;
+
+        // Signal producer that it can continue (we've taken the batch)
+        try {
+            processingQueue.put(new Object());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+
+        return true;
+    }
+
+    /**
+     * Cleans up resources from the previous batch.
+     */
+    private void cleanupPreviousBatch() {
+        if (previousRoot != null) {
+            previousRoot.close();
+            previousRoot = null;
+        }
+        if (previousAllocator != null) {
+            previousAllocator.close();
+            previousAllocator = null;
+        }
+    }
+
+    @Override
+    public void close() {
+        if (closed) {
+            return;
+        }
+        closed = true;
+        producerThread.interrupt();
+        cleanupPreviousBatch();
+
+        // Drain any remaining batches in the queue to prevent resource leaks
+        Object state;
+        while ((state = outputQueue.poll()) != null) {
+            if (state instanceof NextBatch) {
+                NextBatch batch = (NextBatch) state;
+                batch.root.close();
+                batch.allocator.close();
+            }
+        }
+    }
+}

--- a/auron-flink-extension/auron-flink-runtime/src/main/java/org/apache/auron/flink/arrow/FlinkArrowFieldWriter.java
+++ b/auron-flink-extension/auron-flink-runtime/src/main/java/org/apache/auron/flink/arrow/FlinkArrowFieldWriter.java
@@ -1,0 +1,688 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.auron.flink.arrow;
+
+import org.apache.arrow.vector.BigIntVector;
+import org.apache.arrow.vector.BitVector;
+import org.apache.arrow.vector.DateDayVector;
+import org.apache.arrow.vector.DecimalVector;
+import org.apache.arrow.vector.Float4Vector;
+import org.apache.arrow.vector.Float8Vector;
+import org.apache.arrow.vector.IntVector;
+import org.apache.arrow.vector.NullVector;
+import org.apache.arrow.vector.SmallIntVector;
+import org.apache.arrow.vector.TimeMicroVector;
+import org.apache.arrow.vector.TimeStampMicroTZVector;
+import org.apache.arrow.vector.TimeStampMicroVector;
+import org.apache.arrow.vector.TinyIntVector;
+import org.apache.arrow.vector.ValueVector;
+import org.apache.arrow.vector.VarBinaryVector;
+import org.apache.arrow.vector.VarCharVector;
+import org.apache.arrow.vector.complex.ListVector;
+import org.apache.arrow.vector.complex.MapVector;
+import org.apache.arrow.vector.complex.StructVector;
+import org.apache.flink.table.data.ArrayData;
+import org.apache.flink.table.data.DecimalData;
+import org.apache.flink.table.data.MapData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.TimestampData;
+
+/**
+ * Base class for Arrow field writers that convert Flink RowData fields to Arrow
+ * vectors. Supports reading from both RowData and ArrayData for nested
+ * structures.
+ */
+public abstract class FlinkArrowFieldWriter {
+
+    protected final ValueVector valueVector;
+    protected int count = 0;
+
+    protected FlinkArrowFieldWriter(ValueVector valueVector) {
+        this.valueVector = valueVector;
+    }
+
+    /**
+     * Writes a field value from RowData at the specified position.
+     *
+     * @param row     The RowData containing the field
+     * @param ordinal The position of the field in the row
+     */
+    public void write(RowData row, int ordinal) {
+        if (row.isNullAt(ordinal)) {
+            setNull();
+        } else {
+            setValue(row, ordinal);
+        }
+        count++;
+    }
+
+    /**
+     * Writes an element value from ArrayData at the specified position.
+     * Used for array elements and map keys/values.
+     *
+     * @param array   The ArrayData containing the element
+     * @param ordinal The position of the element in the array
+     */
+    public void writeFromArray(ArrayData array, int ordinal) {
+        if (array.isNullAt(ordinal)) {
+            setNull();
+        } else {
+            setValueFromArray(array, ordinal);
+        }
+        count++;
+    }
+
+    /** Sets a null value at the current position. */
+    protected abstract void setNull();
+
+    /**
+     * Sets a non-null value from RowData at the current position.
+     *
+     * @param row     The RowData containing the field
+     * @param ordinal The position of the field in the row
+     */
+    protected abstract void setValue(RowData row, int ordinal);
+
+    /**
+     * Sets a non-null value from ArrayData at the current position.
+     *
+     * @param array   The ArrayData containing the element
+     * @param ordinal The position of the element in the array
+     */
+    protected abstract void setValueFromArray(ArrayData array, int ordinal);
+
+    /** Finalizes the writing process for the current batch. */
+    public void finish() {
+        valueVector.setValueCount(count);
+    }
+
+    /** Resets the writer for a new batch. */
+    public void reset() {
+        valueVector.reset();
+        count = 0;
+    }
+
+    public int getCount() {
+        return count;
+    }
+
+    /** NullWriter for writing null values. */
+    public static class NullWriter extends FlinkArrowFieldWriter {
+        public NullWriter(NullVector vector) {
+            super(vector);
+        }
+
+        @Override
+        protected void setNull() {}
+
+        @Override
+        protected void setValue(RowData row, int ordinal) {}
+
+        @Override
+        protected void setValueFromArray(ArrayData array, int ordinal) {}
+    }
+
+    /** BooleanWriter for writing boolean values. */
+    public static class BooleanWriter extends FlinkArrowFieldWriter {
+        private final BitVector vector;
+
+        public BooleanWriter(BitVector vector) {
+            super(vector);
+            this.vector = vector;
+        }
+
+        @Override
+        protected void setNull() {
+            vector.setNull(count);
+        }
+
+        @Override
+        protected void setValue(RowData row, int ordinal) {
+            vector.setSafe(count, row.getBoolean(ordinal) ? 1 : 0);
+        }
+
+        @Override
+        protected void setValueFromArray(ArrayData array, int ordinal) {
+            vector.setSafe(count, array.getBoolean(ordinal) ? 1 : 0);
+        }
+    }
+
+    /** TinyIntWriter for writing byte values. */
+    public static class TinyIntWriter extends FlinkArrowFieldWriter {
+        private final TinyIntVector vector;
+
+        public TinyIntWriter(TinyIntVector vector) {
+            super(vector);
+            this.vector = vector;
+        }
+
+        @Override
+        protected void setNull() {
+            vector.setNull(count);
+        }
+
+        @Override
+        protected void setValue(RowData row, int ordinal) {
+            vector.setSafe(count, row.getByte(ordinal));
+        }
+
+        @Override
+        protected void setValueFromArray(ArrayData array, int ordinal) {
+            vector.setSafe(count, array.getByte(ordinal));
+        }
+    }
+
+    /** SmallIntWriter for writing short values. */
+    public static class SmallIntWriter extends FlinkArrowFieldWriter {
+        private final SmallIntVector vector;
+
+        public SmallIntWriter(SmallIntVector vector) {
+            super(vector);
+            this.vector = vector;
+        }
+
+        @Override
+        protected void setNull() {
+            vector.setNull(count);
+        }
+
+        @Override
+        protected void setValue(RowData row, int ordinal) {
+            vector.setSafe(count, row.getShort(ordinal));
+        }
+
+        @Override
+        protected void setValueFromArray(ArrayData array, int ordinal) {
+            vector.setSafe(count, array.getShort(ordinal));
+        }
+    }
+
+    /** IntWriter for writing integer values. */
+    public static class IntWriter extends FlinkArrowFieldWriter {
+        private final IntVector vector;
+
+        public IntWriter(IntVector vector) {
+            super(vector);
+            this.vector = vector;
+        }
+
+        @Override
+        protected void setNull() {
+            vector.setNull(count);
+        }
+
+        @Override
+        protected void setValue(RowData row, int ordinal) {
+            vector.setSafe(count, row.getInt(ordinal));
+        }
+
+        @Override
+        protected void setValueFromArray(ArrayData array, int ordinal) {
+            vector.setSafe(count, array.getInt(ordinal));
+        }
+    }
+
+    /** BigIntWriter for writing long values. */
+    public static class BigIntWriter extends FlinkArrowFieldWriter {
+        private final BigIntVector vector;
+
+        public BigIntWriter(BigIntVector vector) {
+            super(vector);
+            this.vector = vector;
+        }
+
+        @Override
+        protected void setNull() {
+            vector.setNull(count);
+        }
+
+        @Override
+        protected void setValue(RowData row, int ordinal) {
+            vector.setSafe(count, row.getLong(ordinal));
+        }
+
+        @Override
+        protected void setValueFromArray(ArrayData array, int ordinal) {
+            vector.setSafe(count, array.getLong(ordinal));
+        }
+    }
+
+    /** FloatWriter for writing float values. */
+    public static class FloatWriter extends FlinkArrowFieldWriter {
+        private final Float4Vector vector;
+
+        public FloatWriter(Float4Vector vector) {
+            super(vector);
+            this.vector = vector;
+        }
+
+        @Override
+        protected void setNull() {
+            vector.setNull(count);
+        }
+
+        @Override
+        protected void setValue(RowData row, int ordinal) {
+            vector.setSafe(count, row.getFloat(ordinal));
+        }
+
+        @Override
+        protected void setValueFromArray(ArrayData array, int ordinal) {
+            vector.setSafe(count, array.getFloat(ordinal));
+        }
+    }
+
+    /** DoubleWriter for writing double values. */
+    public static class DoubleWriter extends FlinkArrowFieldWriter {
+        private final Float8Vector vector;
+
+        public DoubleWriter(Float8Vector vector) {
+            super(vector);
+            this.vector = vector;
+        }
+
+        @Override
+        protected void setNull() {
+            vector.setNull(count);
+        }
+
+        @Override
+        protected void setValue(RowData row, int ordinal) {
+            vector.setSafe(count, row.getDouble(ordinal));
+        }
+
+        @Override
+        protected void setValueFromArray(ArrayData array, int ordinal) {
+            vector.setSafe(count, array.getDouble(ordinal));
+        }
+    }
+
+    /** StringWriter for writing string values. */
+    public static class StringWriter extends FlinkArrowFieldWriter {
+        private final VarCharVector vector;
+
+        public StringWriter(VarCharVector vector) {
+            super(vector);
+            this.vector = vector;
+        }
+
+        @Override
+        protected void setNull() {
+            vector.setNull(count);
+        }
+
+        @Override
+        protected void setValue(RowData row, int ordinal) {
+            byte[] bytes = row.getString(ordinal).toBytes();
+            vector.setSafe(count, bytes);
+        }
+
+        @Override
+        protected void setValueFromArray(ArrayData array, int ordinal) {
+            byte[] bytes = array.getString(ordinal).toBytes();
+            vector.setSafe(count, bytes);
+        }
+    }
+
+    /** BinaryWriter for writing binary values. */
+    public static class BinaryWriter extends FlinkArrowFieldWriter {
+        private final VarBinaryVector vector;
+
+        public BinaryWriter(VarBinaryVector vector) {
+            super(vector);
+            this.vector = vector;
+        }
+
+        @Override
+        protected void setNull() {
+            vector.setNull(count);
+        }
+
+        @Override
+        protected void setValue(RowData row, int ordinal) {
+            byte[] bytes = row.getBinary(ordinal);
+            vector.setSafe(count, bytes);
+        }
+
+        @Override
+        protected void setValueFromArray(ArrayData array, int ordinal) {
+            byte[] bytes = array.getBinary(ordinal);
+            vector.setSafe(count, bytes);
+        }
+    }
+
+    /** DecimalWriter for writing decimal values. */
+    public static class DecimalWriter extends FlinkArrowFieldWriter {
+        private final DecimalVector vector;
+        private final int precision;
+        private final int scale;
+
+        public DecimalWriter(DecimalVector vector, int precision, int scale) {
+            super(vector);
+            this.vector = vector;
+            this.precision = precision;
+            this.scale = scale;
+        }
+
+        @Override
+        protected void setNull() {
+            vector.setNull(count);
+        }
+
+        @Override
+        protected void setValue(RowData row, int ordinal) {
+            DecimalData decimal = row.getDecimal(ordinal, precision, scale);
+            vector.setSafe(count, decimal.toBigDecimal());
+        }
+
+        @Override
+        protected void setValueFromArray(ArrayData array, int ordinal) {
+            DecimalData decimal = array.getDecimal(ordinal, precision, scale);
+            vector.setSafe(count, decimal.toBigDecimal());
+        }
+    }
+
+    /** DateWriter for writing date values. */
+    public static class DateWriter extends FlinkArrowFieldWriter {
+        private final DateDayVector vector;
+
+        public DateWriter(DateDayVector vector) {
+            super(vector);
+            this.vector = vector;
+        }
+
+        @Override
+        protected void setNull() {
+            vector.setNull(count);
+        }
+
+        @Override
+        protected void setValue(RowData row, int ordinal) {
+            vector.setSafe(count, row.getInt(ordinal));
+        }
+
+        @Override
+        protected void setValueFromArray(ArrayData array, int ordinal) {
+            vector.setSafe(count, array.getInt(ordinal));
+        }
+    }
+
+    /** TimestampWriter for writing timestamp values. */
+    public static class TimestampWriter extends FlinkArrowFieldWriter {
+        private final TimeStampMicroVector vector;
+        private final int precision;
+
+        public TimestampWriter(TimeStampMicroVector vector, int precision) {
+            super(vector);
+            this.vector = vector;
+            this.precision = precision;
+        }
+
+        @Override
+        protected void setNull() {
+            vector.setNull(count);
+        }
+
+        @Override
+        protected void setValue(RowData row, int ordinal) {
+            TimestampData timestamp = row.getTimestamp(ordinal, precision);
+            // Convert to microseconds: milliseconds * 1000 + nanoseconds / 1000
+            long micros = timestamp.getMillisecond() * 1000L + timestamp.getNanoOfMillisecond() / 1000;
+            vector.setSafe(count, micros);
+        }
+
+        @Override
+        protected void setValueFromArray(ArrayData array, int ordinal) {
+            TimestampData timestamp = array.getTimestamp(ordinal, precision);
+            long micros = timestamp.getMillisecond() * 1000L + timestamp.getNanoOfMillisecond() / 1000;
+            vector.setSafe(count, micros);
+        }
+    }
+
+    /** TimeWriter for writing time values. */
+    public static class TimeWriter extends FlinkArrowFieldWriter {
+        private final TimeMicroVector vector;
+
+        public TimeWriter(TimeMicroVector vector) {
+            super(vector);
+            this.vector = vector;
+        }
+
+        @Override
+        protected void setNull() {
+            vector.setNull(count);
+        }
+
+        @Override
+        protected void setValue(RowData row, int ordinal) {
+            // Flink TimeType stores time as milliseconds (int), convert to microseconds
+            int millis = row.getInt(ordinal);
+            vector.setSafe(count, millis * 1000L);
+        }
+
+        @Override
+        protected void setValueFromArray(ArrayData array, int ordinal) {
+            int millis = array.getInt(ordinal);
+            vector.setSafe(count, millis * 1000L);
+        }
+    }
+
+    /** LocalZonedTimestampWriter for writing local-zoned timestamp values with UTC timezone. */
+    public static class LocalZonedTimestampWriter extends FlinkArrowFieldWriter {
+        private final TimeStampMicroTZVector vector;
+        private final int precision;
+
+        public LocalZonedTimestampWriter(TimeStampMicroTZVector vector, int precision) {
+            super(vector);
+            this.vector = vector;
+            this.precision = precision;
+        }
+
+        @Override
+        protected void setNull() {
+            vector.setNull(count);
+        }
+
+        @Override
+        protected void setValue(RowData row, int ordinal) {
+            TimestampData timestamp = row.getTimestamp(ordinal, precision);
+            // Convert to microseconds: milliseconds * 1000 + nanoseconds / 1000
+            long micros = timestamp.getMillisecond() * 1000L + timestamp.getNanoOfMillisecond() / 1000;
+            vector.setSafe(count, micros);
+        }
+
+        @Override
+        protected void setValueFromArray(ArrayData array, int ordinal) {
+            TimestampData timestamp = array.getTimestamp(ordinal, precision);
+            long micros = timestamp.getMillisecond() * 1000L + timestamp.getNanoOfMillisecond() / 1000;
+            vector.setSafe(count, micros);
+        }
+    }
+
+    /** ArrayWriter for writing array values using recursive field writers. */
+    public static class ArrayWriter extends FlinkArrowFieldWriter {
+        private final ListVector vector;
+        private final FlinkArrowFieldWriter elementWriter;
+
+        public ArrayWriter(ListVector vector, FlinkArrowFieldWriter elementWriter) {
+            super(vector);
+            this.vector = vector;
+            this.elementWriter = elementWriter;
+        }
+
+        @Override
+        protected void setNull() {
+            vector.setNull(count);
+        }
+
+        @Override
+        protected void setValue(RowData row, int ordinal) {
+            ArrayData array = row.getArray(ordinal);
+            vector.startNewValue(count);
+            for (int i = 0; i < array.size(); i++) {
+                elementWriter.writeFromArray(array, i);
+            }
+            vector.endValue(count, array.size());
+        }
+
+        @Override
+        protected void setValueFromArray(ArrayData arrayData, int ordinal) {
+            ArrayData array = arrayData.getArray(ordinal);
+            vector.startNewValue(count);
+            for (int i = 0; i < array.size(); i++) {
+                elementWriter.writeFromArray(array, i);
+            }
+            vector.endValue(count, array.size());
+        }
+
+        @Override
+        public void finish() {
+            super.finish();
+            elementWriter.finish();
+        }
+
+        @Override
+        public void reset() {
+            super.reset();
+            elementWriter.reset();
+        }
+    }
+
+    /** MapWriter for writing map values using recursive field writers. */
+    public static class MapWriter extends FlinkArrowFieldWriter {
+        private final MapVector vector;
+        private final StructVector structVector;
+        private final FlinkArrowFieldWriter keyWriter;
+        private final FlinkArrowFieldWriter valueWriter;
+
+        public MapWriter(
+                MapVector vector,
+                StructVector structVector,
+                FlinkArrowFieldWriter keyWriter,
+                FlinkArrowFieldWriter valueWriter) {
+            super(vector);
+            this.vector = vector;
+            this.structVector = structVector;
+            this.keyWriter = keyWriter;
+            this.valueWriter = valueWriter;
+        }
+
+        @Override
+        protected void setNull() {
+            vector.setNull(count);
+        }
+
+        @Override
+        protected void setValue(RowData row, int ordinal) {
+            MapData map = row.getMap(ordinal);
+            ArrayData keys = map.keyArray();
+            ArrayData values = map.valueArray();
+
+            vector.startNewValue(count);
+            for (int i = 0; i < map.size(); i++) {
+                structVector.setIndexDefined(keyWriter.getCount());
+                keyWriter.writeFromArray(keys, i);
+                valueWriter.writeFromArray(values, i);
+            }
+            vector.endValue(count, map.size());
+        }
+
+        @Override
+        protected void setValueFromArray(ArrayData arrayData, int ordinal) {
+            MapData map = arrayData.getMap(ordinal);
+            ArrayData keys = map.keyArray();
+            ArrayData values = map.valueArray();
+
+            vector.startNewValue(count);
+            for (int i = 0; i < map.size(); i++) {
+                structVector.setIndexDefined(keyWriter.getCount());
+                keyWriter.writeFromArray(keys, i);
+                valueWriter.writeFromArray(values, i);
+            }
+            vector.endValue(count, map.size());
+        }
+
+        @Override
+        public void finish() {
+            super.finish();
+            keyWriter.finish();
+            valueWriter.finish();
+        }
+
+        @Override
+        public void reset() {
+            super.reset();
+            keyWriter.reset();
+            valueWriter.reset();
+        }
+    }
+
+    /** RowWriter for writing row/struct values using recursive field writers. */
+    public static class RowWriter extends FlinkArrowFieldWriter {
+        private final StructVector vector;
+        private final FlinkArrowFieldWriter[] fieldWriters;
+
+        public RowWriter(StructVector vector, FlinkArrowFieldWriter[] fieldWriters) {
+            super(vector);
+            this.vector = vector;
+            this.fieldWriters = fieldWriters;
+        }
+
+        @Override
+        protected void setNull() {
+            for (FlinkArrowFieldWriter writer : fieldWriters) {
+                writer.setNull();
+                writer.count++;
+            }
+            vector.setNull(count);
+        }
+
+        @Override
+        protected void setValue(RowData row, int ordinal) {
+            RowData nestedRow = row.getRow(ordinal, fieldWriters.length);
+            vector.setIndexDefined(count);
+            for (int i = 0; i < fieldWriters.length; i++) {
+                fieldWriters[i].write(nestedRow, i);
+            }
+        }
+
+        @Override
+        protected void setValueFromArray(ArrayData array, int ordinal) {
+            RowData nestedRow = array.getRow(ordinal, fieldWriters.length);
+            vector.setIndexDefined(count);
+            for (int i = 0; i < fieldWriters.length; i++) {
+                fieldWriters[i].write(nestedRow, i);
+            }
+        }
+
+        @Override
+        public void finish() {
+            super.finish();
+            for (FlinkArrowFieldWriter writer : fieldWriters) {
+                writer.finish();
+            }
+        }
+
+        @Override
+        public void reset() {
+            super.reset();
+            for (FlinkArrowFieldWriter writer : fieldWriters) {
+                writer.reset();
+            }
+        }
+    }
+}

--- a/auron-flink-extension/auron-flink-runtime/src/main/java/org/apache/auron/flink/arrow/FlinkArrowUtils.java
+++ b/auron-flink-extension/auron-flink-runtime/src/main/java/org/apache/auron/flink/arrow/FlinkArrowUtils.java
@@ -1,0 +1,190 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.auron.flink.arrow;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.complex.MapVector;
+import org.apache.arrow.vector.types.DateUnit;
+import org.apache.arrow.vector.types.FloatingPointPrecision;
+import org.apache.arrow.vector.types.TimeUnit;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.apache.flink.table.types.logical.ArrayType;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.BinaryType;
+import org.apache.flink.table.types.logical.BooleanType;
+import org.apache.flink.table.types.logical.CharType;
+import org.apache.flink.table.types.logical.DateType;
+import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.DoubleType;
+import org.apache.flink.table.types.logical.FloatType;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LocalZonedTimestampType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.MapType;
+import org.apache.flink.table.types.logical.NullType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.SmallIntType;
+import org.apache.flink.table.types.logical.TimeType;
+import org.apache.flink.table.types.logical.TimestampType;
+import org.apache.flink.table.types.logical.TinyIntType;
+import org.apache.flink.table.types.logical.VarBinaryType;
+import org.apache.flink.table.types.logical.VarCharType;
+
+/** Utility class for converting between Flink LogicalType and Arrow types. */
+public class FlinkArrowUtils {
+
+    /** Root allocator for Arrow memory management. */
+    public static final RootAllocator ROOT_ALLOCATOR = new RootAllocator(Long.MAX_VALUE);
+
+    static {
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> ROOT_ALLOCATOR.close()));
+    }
+
+    /**
+     * Creates a child allocator from the root allocator.
+     *
+     * @param name Name for the child allocator
+     * @return A new child allocator
+     */
+    public static BufferAllocator createChildAllocator(String name) {
+        return ROOT_ALLOCATOR.newChildAllocator(name, 0, Long.MAX_VALUE);
+    }
+
+    /**
+     * Converts a Flink LogicalType to Arrow ArrowType.
+     *
+     * @param logicalType The Flink logical type
+     * @return The corresponding Arrow type
+     * @throws UnsupportedOperationException if the type is not supported
+     */
+    public static ArrowType toArrowType(LogicalType logicalType) {
+        if (logicalType instanceof NullType) {
+            return ArrowType.Null.INSTANCE;
+        } else if (logicalType instanceof BooleanType) {
+            return ArrowType.Bool.INSTANCE;
+        } else if (logicalType instanceof TinyIntType) {
+            return new ArrowType.Int(8, true);
+        } else if (logicalType instanceof SmallIntType) {
+            return new ArrowType.Int(16, true);
+        } else if (logicalType instanceof IntType) {
+            return new ArrowType.Int(32, true);
+        } else if (logicalType instanceof BigIntType) {
+            return new ArrowType.Int(64, true);
+        } else if (logicalType instanceof FloatType) {
+            return new ArrowType.FloatingPoint(FloatingPointPrecision.SINGLE);
+        } else if (logicalType instanceof DoubleType) {
+            return new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE);
+        } else if (logicalType instanceof VarCharType || logicalType instanceof CharType) {
+            return ArrowType.Utf8.INSTANCE;
+        } else if (logicalType instanceof VarBinaryType || logicalType instanceof BinaryType) {
+            return ArrowType.Binary.INSTANCE;
+        } else if (logicalType instanceof DecimalType) {
+            DecimalType decimalType = (DecimalType) logicalType;
+            // Note: Arrow Java only has DecimalVector (128-bit) and Decimal256Vector (256-bit).
+            // There's no Decimal64Vector, so we always use 128-bit to match the actual storage.
+            // Setting bitWidth=64 would cause FFI export issues since the actual data is 128-bit.
+            return new ArrowType.Decimal(decimalType.getPrecision(), decimalType.getScale(), 128);
+        } else if (logicalType instanceof DateType) {
+            return new ArrowType.Date(DateUnit.DAY);
+        } else if (logicalType instanceof TimeType) {
+            // Flink TimeType stores time as milliseconds (int), convert to Arrow Time64 (microseconds)
+            return new ArrowType.Time(TimeUnit.MICROSECOND, 64);
+        } else if (logicalType instanceof TimestampType) {
+            return new ArrowType.Timestamp(TimeUnit.MICROSECOND, null);
+        } else if (logicalType instanceof LocalZonedTimestampType) {
+            // LocalZonedTimestampType is similar to TimestampType but with UTC timezone
+            return new ArrowType.Timestamp(TimeUnit.MICROSECOND, "UTC");
+        } else {
+            throw new UnsupportedOperationException("Unsupported Flink type: " + logicalType.asSummaryString());
+        }
+    }
+
+    /**
+     * Converts a Flink LogicalType to an Arrow Field.
+     *
+     * @param name        The field name
+     * @param logicalType The Flink logical type
+     * @param nullable    Whether the field is nullable
+     * @return The corresponding Arrow Field
+     */
+    public static Field toArrowField(String name, LogicalType logicalType, boolean nullable) {
+        if (logicalType instanceof ArrayType) {
+            ArrayType arrayType = (ArrayType) logicalType;
+            LogicalType elementType = arrayType.getElementType();
+            FieldType fieldType = new FieldType(nullable, ArrowType.List.INSTANCE, null);
+            Field elementField = toArrowField("element", elementType, elementType.isNullable());
+            List<Field> children = new ArrayList<>();
+            children.add(elementField);
+            return new Field(name, fieldType, children);
+        } else if (logicalType instanceof RowType) {
+            RowType rowType = (RowType) logicalType;
+            FieldType fieldType = new FieldType(nullable, ArrowType.Struct.INSTANCE, null);
+            List<Field> children = new ArrayList<>();
+            for (RowType.RowField field : rowType.getFields()) {
+                children.add(toArrowField(
+                        field.getName(), field.getType(), field.getType().isNullable()));
+            }
+            return new Field(name, fieldType, children);
+        } else if (logicalType instanceof MapType) {
+            MapType mapType = (MapType) logicalType;
+            LogicalType keyType = mapType.getKeyType();
+            LogicalType valueType = mapType.getValueType();
+
+            // Create entries field (struct<key, value>)
+            FieldType entriesFieldType = new FieldType(false, ArrowType.Struct.INSTANCE, null);
+            List<Field> entriesChildren = new ArrayList<>();
+            entriesChildren.add(toArrowField(MapVector.KEY_NAME, keyType, false));
+            entriesChildren.add(toArrowField(MapVector.VALUE_NAME, valueType, valueType.isNullable()));
+            Field entriesField = new Field(MapVector.DATA_VECTOR_NAME, entriesFieldType, entriesChildren);
+
+            // Create map field
+            FieldType mapFieldType = new FieldType(nullable, new ArrowType.Map(false), null);
+            List<Field> mapChildren = new ArrayList<>();
+            mapChildren.add(entriesField);
+            return new Field(name, mapFieldType, mapChildren);
+        } else {
+            ArrowType arrowType = toArrowType(logicalType);
+            FieldType fieldType = new FieldType(nullable, arrowType, null);
+            return new Field(name, fieldType, new ArrayList<>());
+        }
+    }
+
+    /**
+     * Converts a Flink RowType to an Arrow Schema.
+     *
+     * @param rowType The Flink row type
+     * @return The corresponding Arrow Schema
+     */
+    public static Schema toArrowSchema(RowType rowType) {
+        List<Field> fields = new ArrayList<>();
+        for (RowType.RowField field : rowType.getFields()) {
+            fields.add(toArrowField(
+                    field.getName(), field.getType(), field.getType().isNullable()));
+        }
+        return new Schema(fields);
+    }
+
+    private FlinkArrowUtils() {
+        // Utility class
+    }
+}

--- a/auron-flink-extension/auron-flink-runtime/src/main/java/org/apache/auron/flink/arrow/FlinkArrowWriter.java
+++ b/auron-flink-extension/auron-flink-runtime/src/main/java/org/apache/auron/flink/arrow/FlinkArrowWriter.java
@@ -1,0 +1,245 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.auron.flink.arrow;
+
+import java.util.List;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.ValueVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.complex.ListVector;
+import org.apache.arrow.vector.complex.MapVector;
+import org.apache.arrow.vector.complex.StructVector;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.logical.ArrayType;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.BinaryType;
+import org.apache.flink.table.types.logical.BooleanType;
+import org.apache.flink.table.types.logical.CharType;
+import org.apache.flink.table.types.logical.DateType;
+import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.DoubleType;
+import org.apache.flink.table.types.logical.FloatType;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LocalZonedTimestampType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.MapType;
+import org.apache.flink.table.types.logical.NullType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.SmallIntType;
+import org.apache.flink.table.types.logical.TimeType;
+import org.apache.flink.table.types.logical.TimestampType;
+import org.apache.flink.table.types.logical.TinyIntType;
+import org.apache.flink.table.types.logical.VarBinaryType;
+import org.apache.flink.table.types.logical.VarCharType;
+
+/** Writer that converts Flink RowData to Arrow VectorSchemaRoot. */
+public class FlinkArrowWriter {
+
+    private final VectorSchemaRoot root;
+    private final FlinkArrowFieldWriter[] fieldWriters;
+
+    private FlinkArrowWriter(VectorSchemaRoot root, FlinkArrowFieldWriter[] fieldWriters) {
+        this.root = root;
+        this.fieldWriters = fieldWriters;
+    }
+
+    /**
+     * Creates a FlinkArrowWriter from a Flink RowType.
+     *
+     * @param rowType The Flink row type
+     * @return A new FlinkArrowWriter instance
+     */
+    public static FlinkArrowWriter create(RowType rowType) {
+        Schema arrowSchema = FlinkArrowUtils.toArrowSchema(rowType);
+        VectorSchemaRoot root = VectorSchemaRoot.create(arrowSchema, FlinkArrowUtils.ROOT_ALLOCATOR);
+        return create(root, rowType);
+    }
+
+    /**
+     * Creates a FlinkArrowWriter from a Flink RowType with a custom allocator.
+     *
+     * @param rowType   The Flink row type
+     * @param allocator The buffer allocator to use
+     * @return A new FlinkArrowWriter instance
+     */
+    public static FlinkArrowWriter create(RowType rowType, BufferAllocator allocator) {
+        Schema arrowSchema = FlinkArrowUtils.toArrowSchema(rowType);
+        VectorSchemaRoot root = VectorSchemaRoot.create(arrowSchema, allocator);
+        return create(root, rowType);
+    }
+
+    /**
+     * Creates a FlinkArrowWriter from an existing VectorSchemaRoot and RowType.
+     *
+     * @param root    The Arrow VectorSchemaRoot
+     * @param rowType The Flink row type
+     * @return A new FlinkArrowWriter instance
+     */
+    public static FlinkArrowWriter create(VectorSchemaRoot root, RowType rowType) {
+        List<RowType.RowField> fields = rowType.getFields();
+        List<FieldVector> vectors = root.getFieldVectors();
+
+        if (fields.size() != vectors.size()) {
+            throw new IllegalArgumentException("Field count mismatch: RowType has "
+                    + fields.size()
+                    + " fields but VectorSchemaRoot has "
+                    + vectors.size()
+                    + " vectors");
+        }
+
+        // Initialize vectors with small initial capacity
+        for (FieldVector vector : vectors) {
+            vector.setInitialCapacity(16);
+            vector.allocateNew();
+        }
+
+        // Create field writers
+        FlinkArrowFieldWriter[] writers = new FlinkArrowFieldWriter[fields.size()];
+        for (int i = 0; i < fields.size(); i++) {
+            writers[i] = createFieldWriter(vectors.get(i), fields.get(i).getType());
+        }
+
+        return new FlinkArrowWriter(root, writers);
+    }
+
+    /**
+     * Creates a field writer for the given vector and logical type.
+     *
+     * @param vector      The Arrow vector
+     * @param logicalType The Flink logical type
+     * @return A FlinkArrowFieldWriter instance
+     */
+    private static FlinkArrowFieldWriter createFieldWriter(ValueVector vector, LogicalType logicalType) {
+        if (logicalType instanceof NullType) {
+            return new FlinkArrowFieldWriter.NullWriter((org.apache.arrow.vector.NullVector) vector);
+        } else if (logicalType instanceof BooleanType) {
+            return new FlinkArrowFieldWriter.BooleanWriter((org.apache.arrow.vector.BitVector) vector);
+        } else if (logicalType instanceof TinyIntType) {
+            return new FlinkArrowFieldWriter.TinyIntWriter((org.apache.arrow.vector.TinyIntVector) vector);
+        } else if (logicalType instanceof SmallIntType) {
+            return new FlinkArrowFieldWriter.SmallIntWriter((org.apache.arrow.vector.SmallIntVector) vector);
+        } else if (logicalType instanceof IntType) {
+            return new FlinkArrowFieldWriter.IntWriter((org.apache.arrow.vector.IntVector) vector);
+        } else if (logicalType instanceof BigIntType) {
+            return new FlinkArrowFieldWriter.BigIntWriter((org.apache.arrow.vector.BigIntVector) vector);
+        } else if (logicalType instanceof FloatType) {
+            return new FlinkArrowFieldWriter.FloatWriter((org.apache.arrow.vector.Float4Vector) vector);
+        } else if (logicalType instanceof DoubleType) {
+            return new FlinkArrowFieldWriter.DoubleWriter((org.apache.arrow.vector.Float8Vector) vector);
+        } else if (logicalType instanceof VarCharType || logicalType instanceof CharType) {
+            return new FlinkArrowFieldWriter.StringWriter((org.apache.arrow.vector.VarCharVector) vector);
+        } else if (logicalType instanceof VarBinaryType || logicalType instanceof BinaryType) {
+            return new FlinkArrowFieldWriter.BinaryWriter((org.apache.arrow.vector.VarBinaryVector) vector);
+        } else if (logicalType instanceof DecimalType) {
+            DecimalType decimalType = (DecimalType) logicalType;
+            return new FlinkArrowFieldWriter.DecimalWriter(
+                    (org.apache.arrow.vector.DecimalVector) vector, decimalType.getPrecision(), decimalType.getScale());
+        } else if (logicalType instanceof DateType) {
+            return new FlinkArrowFieldWriter.DateWriter((org.apache.arrow.vector.DateDayVector) vector);
+        } else if (logicalType instanceof TimeType) {
+            return new FlinkArrowFieldWriter.TimeWriter((org.apache.arrow.vector.TimeMicroVector) vector);
+        } else if (logicalType instanceof TimestampType) {
+            TimestampType timestampType = (TimestampType) logicalType;
+            return new FlinkArrowFieldWriter.TimestampWriter(
+                    (org.apache.arrow.vector.TimeStampMicroVector) vector, timestampType.getPrecision());
+        } else if (logicalType instanceof LocalZonedTimestampType) {
+            LocalZonedTimestampType lzType = (LocalZonedTimestampType) logicalType;
+            return new FlinkArrowFieldWriter.LocalZonedTimestampWriter(
+                    (org.apache.arrow.vector.TimeStampMicroTZVector) vector, lzType.getPrecision());
+        } else if (logicalType instanceof ArrayType) {
+            ArrayType arrayType = (ArrayType) logicalType;
+            ListVector listVector = (ListVector) vector;
+            // Use recursive createFieldWriter for nested types support
+            FlinkArrowFieldWriter elementWriter =
+                    createFieldWriter(listVector.getDataVector(), arrayType.getElementType());
+            return new FlinkArrowFieldWriter.ArrayWriter(listVector, elementWriter);
+        } else if (logicalType instanceof MapType) {
+            MapType mapType = (MapType) logicalType;
+            MapVector mapVector = (MapVector) vector;
+            StructVector structVector = (StructVector) mapVector.getDataVector();
+            // Use recursive createFieldWriter for nested types support
+            FlinkArrowFieldWriter keyWriter = createFieldWriter(
+                    structVector.getChild(org.apache.arrow.vector.complex.MapVector.KEY_NAME), mapType.getKeyType());
+            FlinkArrowFieldWriter valueWriter = createFieldWriter(
+                    structVector.getChild(org.apache.arrow.vector.complex.MapVector.VALUE_NAME),
+                    mapType.getValueType());
+            return new FlinkArrowFieldWriter.MapWriter(mapVector, structVector, keyWriter, valueWriter);
+        } else if (logicalType instanceof RowType) {
+            RowType rowType = (RowType) logicalType;
+            StructVector structVector = (StructVector) vector;
+            List<RowType.RowField> fields = rowType.getFields();
+            FlinkArrowFieldWriter[] fieldWriters = new FlinkArrowFieldWriter[fields.size()];
+            for (int i = 0; i < fields.size(); i++) {
+                fieldWriters[i] = createFieldWriter(
+                        structVector.getChildByOrdinal(i), fields.get(i).getType());
+            }
+            return new FlinkArrowFieldWriter.RowWriter(structVector, fieldWriters);
+        } else {
+            throw new UnsupportedOperationException("Unsupported Flink type: " + logicalType.asSummaryString());
+        }
+    }
+
+    /**
+     * Writes a single RowData to the Arrow vectors.
+     *
+     * @param row The RowData to write
+     */
+    public void write(RowData row) {
+        for (int i = 0; i < fieldWriters.length; i++) {
+            fieldWriters[i].write(row, i);
+        }
+    }
+
+    /**
+     * Returns the current number of rows written.
+     *
+     * @return The row count
+     */
+    public int currentCount() {
+        return fieldWriters.length > 0 ? fieldWriters[0].getCount() : 0;
+    }
+
+    /**
+     * Finalizes the writing process for the current batch.
+     */
+    public void finish() {
+        for (FlinkArrowFieldWriter writer : fieldWriters) {
+            writer.finish();
+        }
+        root.setRowCount(currentCount());
+    }
+
+    /**
+     * Resets the writer for a new batch.
+     */
+    public void reset() {
+        for (FlinkArrowFieldWriter writer : fieldWriters) {
+            writer.reset();
+        }
+    }
+
+    /**
+     * Gets the underlying VectorSchemaRoot.
+     *
+     * @return The VectorSchemaRoot
+     */
+    public VectorSchemaRoot getRoot() {
+        return root;
+    }
+}

--- a/auron-flink-extension/auron-flink-runtime/src/test/java/org/apache/auron/flink/arrow/FlinkArrowFFIExporterTest.java
+++ b/auron-flink-extension/auron-flink-runtime/src/test/java/org/apache/auron/flink/arrow/FlinkArrowFFIExporterTest.java
@@ -1,0 +1,365 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.auron.flink.arrow;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import org.apache.arrow.c.ArrowArray;
+import org.apache.arrow.c.ArrowSchema;
+import org.apache.arrow.c.Data;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.IntVector;
+import org.apache.arrow.vector.VarCharVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.VarCharType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for FlinkArrowFFIExporter. */
+public class FlinkArrowFFIExporterTest {
+
+    private BufferAllocator testAllocator;
+    private static Boolean nativeLibrariesAvailable;
+
+    /**
+     * Check if Arrow FFI native libraries are available.
+     * FFI operations require JNI, which needs native libraries.
+     */
+    private static boolean isNativeLibraryAvailable() {
+        if (nativeLibrariesAvailable == null) {
+            try {
+                // Try to load the JNI library - JniWrapper.get() triggers ensureLoaded()
+                org.apache.arrow.c.jni.JniWrapper.get();
+                nativeLibrariesAvailable = true;
+            } catch (Throwable e) {
+                // Catch all throwables including IllegalStateException, UnsatisfiedLinkError, etc.
+                nativeLibrariesAvailable = false;
+            }
+        }
+        return nativeLibrariesAvailable;
+    }
+
+    @BeforeEach
+    public void setUp() {
+        testAllocator = new RootAllocator(Long.MAX_VALUE);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        testAllocator.close();
+    }
+
+    @Test
+    public void testExportSchemaCreatesExporter() {
+        RowType rowType =
+                RowType.of(new LogicalType[] {new IntType(), new VarCharType(100)}, new String[] {"id", "name"});
+
+        Iterator<RowData> emptyIter = Collections.emptyIterator();
+
+        try (FlinkArrowFFIExporter exporter = new FlinkArrowFFIExporter(emptyIter, rowType)) {
+            assertNotNull(exporter);
+        }
+    }
+
+    @Test
+    public void testExporterWithEmptyIterator() {
+        RowType rowType = RowType.of(new LogicalType[] {new IntType()}, new String[] {"id"});
+        Iterator<RowData> emptyIter = Collections.emptyIterator();
+
+        try (FlinkArrowFFIExporter exporter = new FlinkArrowFFIExporter(emptyIter, rowType)) {
+            assertNotNull(exporter);
+        }
+    }
+
+    @Test
+    public void testExporterWithMultipleRows() {
+        RowType rowType = RowType.of(new LogicalType[] {new IntType()}, new String[] {"id"});
+
+        GenericRowData row1 = new GenericRowData(1);
+        row1.setField(0, 1);
+        GenericRowData row2 = new GenericRowData(1);
+        row2.setField(0, 2);
+
+        Iterator<RowData> iter = Arrays.asList((RowData) row1, row2).iterator();
+
+        try (FlinkArrowFFIExporter exporter = new FlinkArrowFFIExporter(iter, rowType)) {
+            assertNotNull(exporter);
+        }
+    }
+
+    @Test
+    public void testExporterWithComplexTypes() {
+        RowType rowType =
+                RowType.of(new LogicalType[] {new IntType(), new VarCharType(100)}, new String[] {"id", "name"});
+
+        GenericRowData row = new GenericRowData(2);
+        row.setField(0, 42);
+        row.setField(1, StringData.fromString("test"));
+
+        Iterator<RowData> iter = Collections.singletonList((RowData) row).iterator();
+
+        try (FlinkArrowFFIExporter exporter = new FlinkArrowFFIExporter(iter, rowType)) {
+            assertNotNull(exporter);
+        }
+    }
+
+    @Test
+    public void testExporterCloseIsIdempotent() {
+        RowType rowType = RowType.of(new LogicalType[] {new IntType()}, new String[] {"id"});
+        Iterator<RowData> emptyIter = Collections.emptyIterator();
+
+        FlinkArrowFFIExporter exporter = new FlinkArrowFFIExporter(emptyIter, rowType);
+        exporter.close();
+        exporter.close();
+    }
+
+    @Test
+    public void testExportSchemaWithArrowFFI() {
+        assumeTrue(isNativeLibraryAvailable(), "Skipping test: Arrow FFI native libraries not available");
+
+        RowType rowType =
+                RowType.of(new LogicalType[] {new IntType(), new VarCharType(100)}, new String[] {"id", "name"});
+
+        try (FlinkArrowFFIExporter exporter = new FlinkArrowFFIExporter(Collections.emptyIterator(), rowType);
+                ArrowSchema arrowSchema = ArrowSchema.allocateNew(testAllocator)) {
+
+            exporter.exportSchema(arrowSchema.memoryAddress());
+
+            org.apache.arrow.vector.types.pojo.Schema schema = Data.importSchema(testAllocator, arrowSchema, null);
+            assertEquals(2, schema.getFields().size());
+            assertEquals("id", schema.getFields().get(0).getName());
+            assertEquals("name", schema.getFields().get(1).getName());
+        }
+    }
+
+    @Test
+    public void testExportNextBatchEndToEnd() {
+        assumeTrue(isNativeLibraryAvailable(), "Skipping test: Arrow FFI native libraries not available");
+
+        RowType rowType =
+                RowType.of(new LogicalType[] {new IntType(), new VarCharType(100)}, new String[] {"id", "name"});
+
+        List<RowData> rows = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            GenericRowData row = new GenericRowData(2);
+            row.setField(0, i);
+            row.setField(1, StringData.fromString("value" + i));
+            rows.add(row);
+        }
+
+        try (FlinkArrowFFIExporter exporter = new FlinkArrowFFIExporter(rows.iterator(), rowType);
+                ArrowArray arrowArray = ArrowArray.allocateNew(testAllocator);
+                ArrowSchema arrowSchema = ArrowSchema.allocateNew(testAllocator)) {
+
+            // Export schema
+            exporter.exportSchema(arrowSchema.memoryAddress());
+
+            // Export batch
+            assertTrue(exporter.exportNextBatch(arrowArray.memoryAddress()));
+
+            // Import and verify - use ArrowSchema directly
+            try (VectorSchemaRoot root = Data.importVectorSchemaRoot(testAllocator, arrowArray, arrowSchema, null)) {
+                assertTrue(root.getRowCount() > 0);
+
+                // Verify data
+                IntVector idVector = (IntVector) root.getVector("id");
+                VarCharVector nameVector = (VarCharVector) root.getVector("name");
+
+                assertEquals(0, idVector.get(0));
+                assertEquals("value0", new String(nameVector.get(0)));
+            }
+        }
+    }
+
+    @Test
+    public void testExportEmptyIteratorReturnsFalse() {
+        assumeTrue(isNativeLibraryAvailable(), "Skipping test: Arrow FFI native libraries not available");
+
+        RowType rowType = RowType.of(new LogicalType[] {new IntType()}, new String[] {"id"});
+
+        try (FlinkArrowFFIExporter exporter = new FlinkArrowFFIExporter(Collections.emptyIterator(), rowType);
+                ArrowArray arrowArray = ArrowArray.allocateNew(testAllocator)) {
+
+            // Empty iterator should return false on first call
+            assertFalse(exporter.exportNextBatch(arrowArray.memoryAddress()));
+        }
+    }
+
+    @Test
+    public void testExportMultipleBatches() {
+        assumeTrue(isNativeLibraryAvailable(), "Skipping test: Arrow FFI native libraries not available");
+
+        RowType rowType = RowType.of(new LogicalType[] {new IntType()}, new String[] {"id"});
+
+        // Create enough rows to potentially span multiple batches
+        List<RowData> rows = new ArrayList<>();
+        for (int i = 0; i < 100; i++) {
+            GenericRowData row = new GenericRowData(1);
+            row.setField(0, i);
+            rows.add(row);
+        }
+
+        int totalRowsExported = 0;
+
+        try (FlinkArrowFFIExporter exporter = new FlinkArrowFFIExporter(rows.iterator(), rowType);
+                ArrowSchema arrowSchema = ArrowSchema.allocateNew(testAllocator)) {
+
+            exporter.exportSchema(arrowSchema.memoryAddress());
+
+            // Export all batches
+            while (true) {
+                try (ArrowArray arrowArray = ArrowArray.allocateNew(testAllocator);
+                        ArrowSchema batchSchema = ArrowSchema.allocateNew(testAllocator)) {
+                    // Re-export schema for each batch since ArrowSchema is consumed
+                    exporter.exportSchema(batchSchema.memoryAddress());
+
+                    if (!exporter.exportNextBatch(arrowArray.memoryAddress())) {
+                        break;
+                    }
+
+                    try (VectorSchemaRoot root =
+                            Data.importVectorSchemaRoot(testAllocator, arrowArray, batchSchema, null)) {
+                        totalRowsExported += root.getRowCount();
+                    }
+                }
+            }
+        }
+
+        assertEquals(100, totalRowsExported);
+    }
+
+    @Test
+    public void testProducerExceptionPropagation() {
+        assumeTrue(isNativeLibraryAvailable(), "Skipping test: Arrow FFI native libraries not available");
+
+        RowType rowType = RowType.of(new LogicalType[] {new IntType()}, new String[] {"id"});
+
+        // Create an iterator that throws an exception
+        Iterator<RowData> failingIterator = new Iterator<RowData>() {
+            private int count = 0;
+
+            @Override
+            public boolean hasNext() {
+                return count < 5;
+            }
+
+            @Override
+            public RowData next() {
+                if (count >= 3) {
+                    throw new RuntimeException("Simulated error");
+                }
+                GenericRowData row = new GenericRowData(1);
+                row.setField(0, count++);
+                return row;
+            }
+        };
+
+        try (FlinkArrowFFIExporter exporter = new FlinkArrowFFIExporter(failingIterator, rowType);
+                ArrowArray arrowArray = ArrowArray.allocateNew(testAllocator)) {
+
+            // First batch might succeed if it doesn't hit the error
+            // Eventually we should get a RuntimeException
+            assertThrows(RuntimeException.class, () -> {
+                for (int i = 0; i < 10; i++) {
+                    if (!exporter.exportNextBatch(arrowArray.memoryAddress())) {
+                        break;
+                    }
+                }
+            });
+        }
+    }
+
+    @Test
+    public void testCloseWhileProducerIsRunning() throws InterruptedException {
+        assumeTrue(isNativeLibraryAvailable(), "Skipping test: Arrow FFI native libraries not available");
+
+        RowType rowType = RowType.of(new LogicalType[] {new IntType()}, new String[] {"id"});
+
+        // Create a slow iterator to ensure producer is still running when we close
+        Iterator<RowData> slowIterator = new Iterator<RowData>() {
+            private int count = 0;
+
+            @Override
+            public boolean hasNext() {
+                return count < 1000;
+            }
+
+            @Override
+            public RowData next() {
+                if (!hasNext()) {
+                    throw new NoSuchElementException();
+                }
+                try {
+                    Thread.sleep(10); // Slow down the iterator
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+                GenericRowData row = new GenericRowData(1);
+                row.setField(0, count++);
+                return row;
+            }
+        };
+
+        FlinkArrowFFIExporter exporter = new FlinkArrowFFIExporter(slowIterator, rowType);
+
+        // Export one batch to start producer
+        try (ArrowArray arrowArray = ArrowArray.allocateNew(testAllocator)) {
+            exporter.exportNextBatch(arrowArray.memoryAddress());
+        }
+
+        // Close while producer might still be running
+        exporter.close();
+
+        // Subsequent calls should return false
+        try (ArrowArray arrowArray = ArrowArray.allocateNew(testAllocator)) {
+            assertFalse(exporter.exportNextBatch(arrowArray.memoryAddress()));
+        }
+    }
+
+    @Test
+    public void testExportAfterClose() {
+        assumeTrue(isNativeLibraryAvailable(), "Skipping test: Arrow FFI native libraries not available");
+
+        RowType rowType = RowType.of(new LogicalType[] {new IntType()}, new String[] {"id"});
+
+        GenericRowData row = new GenericRowData(1);
+        row.setField(0, 1);
+        Iterator<RowData> iter = Collections.singletonList((RowData) row).iterator();
+
+        FlinkArrowFFIExporter exporter = new FlinkArrowFFIExporter(iter, rowType);
+        exporter.close();
+
+        try (ArrowArray arrowArray = ArrowArray.allocateNew(testAllocator)) {
+            assertFalse(exporter.exportNextBatch(arrowArray.memoryAddress()));
+        }
+    }
+}

--- a/auron-flink-extension/auron-flink-runtime/src/test/java/org/apache/auron/flink/arrow/FlinkArrowUtilsTest.java
+++ b/auron-flink-extension/auron-flink-runtime/src/test/java/org/apache/auron/flink/arrow/FlinkArrowUtilsTest.java
@@ -1,0 +1,202 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.auron.flink.arrow;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.apache.arrow.vector.types.DateUnit;
+import org.apache.arrow.vector.types.FloatingPointPrecision;
+import org.apache.arrow.vector.types.TimeUnit;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.apache.flink.api.common.typeutils.base.StringSerializer;
+import org.apache.flink.table.types.logical.ArrayType;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.BinaryType;
+import org.apache.flink.table.types.logical.BooleanType;
+import org.apache.flink.table.types.logical.CharType;
+import org.apache.flink.table.types.logical.DateType;
+import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.DoubleType;
+import org.apache.flink.table.types.logical.FloatType;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LocalZonedTimestampType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.MapType;
+import org.apache.flink.table.types.logical.RawType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.SmallIntType;
+import org.apache.flink.table.types.logical.TimeType;
+import org.apache.flink.table.types.logical.TimestampType;
+import org.apache.flink.table.types.logical.TinyIntType;
+import org.apache.flink.table.types.logical.VarBinaryType;
+import org.apache.flink.table.types.logical.VarCharType;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for FlinkArrowUtils. */
+public class FlinkArrowUtilsTest {
+
+    @Test
+    public void testBasicTypeConversion() {
+        // Boolean
+        assertEquals(ArrowType.Bool.INSTANCE, FlinkArrowUtils.toArrowType(new BooleanType()));
+
+        // Integer types
+        assertEquals(new ArrowType.Int(8, true), FlinkArrowUtils.toArrowType(new TinyIntType()));
+        assertEquals(new ArrowType.Int(16, true), FlinkArrowUtils.toArrowType(new SmallIntType()));
+        assertEquals(new ArrowType.Int(32, true), FlinkArrowUtils.toArrowType(new IntType()));
+        assertEquals(new ArrowType.Int(64, true), FlinkArrowUtils.toArrowType(new BigIntType()));
+
+        // Floating point types
+        assertEquals(
+                new ArrowType.FloatingPoint(FloatingPointPrecision.SINGLE),
+                FlinkArrowUtils.toArrowType(new FloatType()));
+        assertEquals(
+                new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE),
+                FlinkArrowUtils.toArrowType(new DoubleType()));
+
+        // String and binary types
+        assertEquals(ArrowType.Utf8.INSTANCE, FlinkArrowUtils.toArrowType(new VarCharType(100)));
+        assertEquals(ArrowType.Utf8.INSTANCE, FlinkArrowUtils.toArrowType(new CharType(10)));
+        assertEquals(ArrowType.Binary.INSTANCE, FlinkArrowUtils.toArrowType(new VarBinaryType(100)));
+        assertEquals(ArrowType.Binary.INSTANCE, FlinkArrowUtils.toArrowType(new BinaryType(10)));
+
+        // Decimal type
+        DecimalType decimalType = new DecimalType(10, 2);
+        ArrowType arrowDecimal = FlinkArrowUtils.toArrowType(decimalType);
+        assertTrue(arrowDecimal instanceof ArrowType.Decimal);
+        assertEquals(10, ((ArrowType.Decimal) arrowDecimal).getPrecision());
+        assertEquals(2, ((ArrowType.Decimal) arrowDecimal).getScale());
+
+        // Date and timestamp types
+        assertEquals(new ArrowType.Date(DateUnit.DAY), FlinkArrowUtils.toArrowType(new DateType()));
+        assertEquals(
+                new ArrowType.Timestamp(TimeUnit.MICROSECOND, null), FlinkArrowUtils.toArrowType(new TimestampType(3)));
+    }
+
+    @Test
+    public void testArrayTypeConversion() {
+        ArrayType arrayType = new ArrayType(new IntType());
+        Field field = FlinkArrowUtils.toArrowField("test_array", arrayType, true);
+
+        assertEquals("test_array", field.getName());
+        assertTrue(field.isNullable());
+        assertTrue(field.getType() instanceof ArrowType.List);
+        assertEquals(1, field.getChildren().size());
+
+        Field elementField = field.getChildren().get(0);
+        assertEquals("element", elementField.getName());
+        assertTrue(elementField.getType() instanceof ArrowType.Int);
+    }
+
+    @Test
+    public void testRowTypeConversion() {
+        RowType rowType =
+                RowType.of(new LogicalType[] {new IntType(), new VarCharType(100)}, new String[] {"id", "name"});
+
+        Field field = FlinkArrowUtils.toArrowField("test_row", rowType, false);
+
+        assertEquals("test_row", field.getName());
+        assertFalse(field.isNullable());
+        assertTrue(field.getType() instanceof ArrowType.Struct);
+        assertEquals(2, field.getChildren().size());
+
+        Field idField = field.getChildren().get(0);
+        assertEquals("id", idField.getName());
+        assertTrue(idField.getType() instanceof ArrowType.Int);
+
+        Field nameField = field.getChildren().get(1);
+        assertEquals("name", nameField.getName());
+        assertEquals(ArrowType.Utf8.INSTANCE, nameField.getType());
+    }
+
+    @Test
+    public void testMapTypeConversion() {
+        MapType mapType = new MapType(new VarCharType(100), new IntType());
+        Field field = FlinkArrowUtils.toArrowField("test_map", mapType, true);
+
+        assertEquals("test_map", field.getName());
+        assertTrue(field.isNullable());
+        assertTrue(field.getType() instanceof ArrowType.Map);
+        assertEquals(1, field.getChildren().size());
+
+        Field entriesField = field.getChildren().get(0);
+        assertEquals("entries", entriesField.getName());
+        assertTrue(entriesField.getType() instanceof ArrowType.Struct);
+        assertEquals(2, entriesField.getChildren().size());
+
+        Field keyField = entriesField.getChildren().get(0);
+        assertEquals("key", keyField.getName());
+        assertEquals(ArrowType.Utf8.INSTANCE, keyField.getType());
+
+        Field valueField = entriesField.getChildren().get(1);
+        assertEquals("value", valueField.getName());
+        assertTrue(valueField.getType() instanceof ArrowType.Int);
+    }
+
+    @Test
+    public void testSchemaConversion() {
+        RowType rowType = RowType.of(
+                new LogicalType[] {new IntType(), new VarCharType(100), new DoubleType()},
+                new String[] {"id", "name", "score"});
+
+        Schema schema = FlinkArrowUtils.toArrowSchema(rowType);
+
+        assertEquals(3, schema.getFields().size());
+
+        Field idField = schema.getFields().get(0);
+        assertEquals("id", idField.getName());
+        assertTrue(idField.getType() instanceof ArrowType.Int);
+
+        Field nameField = schema.getFields().get(1);
+        assertEquals("name", nameField.getName());
+        assertEquals(ArrowType.Utf8.INSTANCE, nameField.getType());
+
+        Field scoreField = schema.getFields().get(2);
+        assertEquals("score", scoreField.getName());
+        assertTrue(scoreField.getType() instanceof ArrowType.FloatingPoint);
+    }
+
+    @Test
+    public void testTimeTypeConversion() {
+        TimeType timeType = new TimeType(3);
+        ArrowType arrowType = FlinkArrowUtils.toArrowType(timeType);
+        assertTrue(arrowType instanceof ArrowType.Time);
+        ArrowType.Time timeArrowType = (ArrowType.Time) arrowType;
+        assertEquals(TimeUnit.MICROSECOND, timeArrowType.getUnit());
+        assertEquals(64, timeArrowType.getBitWidth());
+    }
+
+    @Test
+    public void testLocalZonedTimestampTypeConversion() {
+        LocalZonedTimestampType lzType = new LocalZonedTimestampType(6);
+        ArrowType arrowType = FlinkArrowUtils.toArrowType(lzType);
+        assertTrue(arrowType instanceof ArrowType.Timestamp);
+        ArrowType.Timestamp tsType = (ArrowType.Timestamp) arrowType;
+        assertEquals(TimeUnit.MICROSECOND, tsType.getUnit());
+        assertEquals("UTC", tsType.getTimezone());
+    }
+
+    @Test
+    public void testUnsupportedTypeThrowsException() {
+        // RawType is not supported
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> FlinkArrowUtils.toArrowType(new RawType<>(String.class, StringSerializer.INSTANCE)));
+    }
+}

--- a/auron-flink-extension/auron-flink-runtime/src/test/java/org/apache/auron/flink/arrow/FlinkArrowWriterTest.java
+++ b/auron-flink-extension/auron-flink-runtime/src/test/java/org/apache/auron/flink/arrow/FlinkArrowWriterTest.java
@@ -1,0 +1,376 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.auron.flink.arrow;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.apache.flink.table.data.GenericArrayData;
+import org.apache.flink.table.data.GenericMapData;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.table.types.logical.ArrayType;
+import org.apache.flink.table.types.logical.BooleanType;
+import org.apache.flink.table.types.logical.DoubleType;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LocalZonedTimestampType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.MapType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.TimeType;
+import org.apache.flink.table.types.logical.TimestampType;
+import org.apache.flink.table.types.logical.VarCharType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for FlinkArrowWriter. */
+public class FlinkArrowWriterTest {
+
+    private BufferAllocator allocator;
+
+    @BeforeEach
+    public void setUp() {
+        allocator = FlinkArrowUtils.createChildAllocator("test");
+    }
+
+    @AfterEach
+    public void tearDown() {
+        allocator.close();
+    }
+
+    @Test
+    public void testWriteBasicTypes() {
+        RowType rowType = RowType.of(
+                new LogicalType[] {new IntType(), new VarCharType(100), new DoubleType(), new BooleanType()},
+                new String[] {"id", "name", "score", "active"});
+
+        Schema arrowSchema = FlinkArrowUtils.toArrowSchema(rowType);
+        try (VectorSchemaRoot root = VectorSchemaRoot.create(arrowSchema, allocator)) {
+            FlinkArrowWriter writer = FlinkArrowWriter.create(root, rowType);
+
+            // Write first row
+            GenericRowData row1 = new GenericRowData(4);
+            row1.setField(0, 1);
+            row1.setField(1, StringData.fromString("Alice"));
+            row1.setField(2, 95.5);
+            row1.setField(3, true);
+            writer.write(row1);
+
+            // Write second row
+            GenericRowData row2 = new GenericRowData(4);
+            row2.setField(0, 2);
+            row2.setField(1, StringData.fromString("Bob"));
+            row2.setField(2, 87.3);
+            row2.setField(3, false);
+            writer.write(row2);
+
+            writer.finish();
+
+            assertEquals(2, root.getRowCount());
+            assertEquals(1, root.getVector("id").getObject(0));
+            assertEquals(2, root.getVector("id").getObject(1));
+        }
+    }
+
+    @Test
+    public void testWriteNullValues() {
+        RowType rowType =
+                RowType.of(new LogicalType[] {new IntType(), new VarCharType(100)}, new String[] {"id", "name"});
+
+        Schema arrowSchema = FlinkArrowUtils.toArrowSchema(rowType);
+        try (VectorSchemaRoot root = VectorSchemaRoot.create(arrowSchema, allocator)) {
+            FlinkArrowWriter writer = FlinkArrowWriter.create(root, rowType);
+
+            // Write row with null values
+            GenericRowData row = new GenericRowData(2);
+            row.setField(0, null);
+            row.setField(1, null);
+            writer.write(row);
+
+            writer.finish();
+
+            assertEquals(1, root.getRowCount());
+            assertTrue(root.getVector("id").isNull(0));
+            assertTrue(root.getVector("name").isNull(0));
+        }
+    }
+
+    @Test
+    public void testWriteArrayType() {
+        RowType rowType = RowType.of(new LogicalType[] {new ArrayType(new IntType())}, new String[] {"numbers"});
+
+        Schema arrowSchema = FlinkArrowUtils.toArrowSchema(rowType);
+        try (VectorSchemaRoot root = VectorSchemaRoot.create(arrowSchema, allocator)) {
+            FlinkArrowWriter writer = FlinkArrowWriter.create(root, rowType);
+
+            GenericRowData row = new GenericRowData(1);
+            row.setField(0, new GenericArrayData(new Integer[] {1, 2, 3}));
+            writer.write(row);
+
+            writer.finish();
+
+            assertEquals(1, root.getRowCount());
+        }
+    }
+
+    @Test
+    public void testWriteMapType() {
+        RowType rowType = RowType.of(
+                new LogicalType[] {new MapType(new VarCharType(100), new IntType())}, new String[] {"scores"});
+
+        Schema arrowSchema = FlinkArrowUtils.toArrowSchema(rowType);
+        try (VectorSchemaRoot root = VectorSchemaRoot.create(arrowSchema, allocator)) {
+            FlinkArrowWriter writer = FlinkArrowWriter.create(root, rowType);
+
+            Map<StringData, Integer> mapData = new HashMap<>();
+            mapData.put(StringData.fromString("math"), 90);
+            mapData.put(StringData.fromString("english"), 85);
+
+            GenericRowData row = new GenericRowData(1);
+            row.setField(0, new GenericMapData(mapData));
+            writer.write(row);
+
+            writer.finish();
+
+            assertEquals(1, root.getRowCount());
+        }
+    }
+
+    @Test
+    public void testTimestampPrecision() {
+        RowType rowType = RowType.of(new LogicalType[] {new TimestampType(6)}, new String[] {"ts"});
+
+        Schema arrowSchema = FlinkArrowUtils.toArrowSchema(rowType);
+        try (VectorSchemaRoot root = VectorSchemaRoot.create(arrowSchema, allocator)) {
+            FlinkArrowWriter writer = FlinkArrowWriter.create(root, rowType);
+
+            // Create timestamp with microsecond precision
+            long millis = 1705622400000L; // 2024-01-19 00:00:00.000
+            int nanos = 123456; // 123.456 microseconds
+
+            GenericRowData row = new GenericRowData(1);
+            row.setField(0, TimestampData.fromEpochMillis(millis, nanos));
+            writer.write(row);
+
+            writer.finish();
+
+            assertEquals(1, root.getRowCount());
+            // Verify the timestamp is written in microseconds
+            Object value = root.getVector("ts").getObject(0);
+            assertNotNull(value);
+        }
+    }
+
+    @Test
+    public void testReset() {
+        RowType rowType = RowType.of(new LogicalType[] {new IntType()}, new String[] {"id"});
+
+        Schema arrowSchema = FlinkArrowUtils.toArrowSchema(rowType);
+        try (VectorSchemaRoot root = VectorSchemaRoot.create(arrowSchema, allocator)) {
+            FlinkArrowWriter writer = FlinkArrowWriter.create(root, rowType);
+
+            // Write first batch
+            GenericRowData row1 = new GenericRowData(1);
+            row1.setField(0, 1);
+            writer.write(row1);
+            writer.finish();
+            assertEquals(1, root.getRowCount());
+
+            // Reset and write second batch
+            writer.reset();
+            GenericRowData row2 = new GenericRowData(1);
+            row2.setField(0, 2);
+            writer.write(row2);
+            writer.finish();
+            assertEquals(1, root.getRowCount());
+            assertEquals(2, root.getVector("id").getObject(0));
+        }
+    }
+
+    @Test
+    public void testNestedArrayType() {
+        // Test Array<Array<Int>>
+        RowType rowType = RowType.of(
+                new LogicalType[] {new ArrayType(new ArrayType(new IntType()))}, new String[] {"nested_array"});
+
+        Schema arrowSchema = FlinkArrowUtils.toArrowSchema(rowType);
+        try (VectorSchemaRoot root = VectorSchemaRoot.create(arrowSchema, allocator)) {
+            FlinkArrowWriter writer = FlinkArrowWriter.create(root, rowType);
+
+            // Create nested array: [[1, 2], [3, 4, 5]]
+            GenericArrayData innerArray1 = new GenericArrayData(new Integer[] {1, 2});
+            GenericArrayData innerArray2 = new GenericArrayData(new Integer[] {3, 4, 5});
+            GenericArrayData outerArray = new GenericArrayData(new Object[] {innerArray1, innerArray2});
+
+            GenericRowData row = new GenericRowData(1);
+            row.setField(0, outerArray);
+            writer.write(row);
+            writer.finish();
+
+            assertEquals(1, root.getRowCount());
+            assertNotNull(root.getVector("nested_array").getObject(0));
+        }
+    }
+
+    @Test
+    public void testArrayOfMapType() {
+        // Test Array<Map<String, Int>>
+        MapType mapType = new MapType(new VarCharType(100), new IntType());
+        RowType rowType = RowType.of(new LogicalType[] {new ArrayType(mapType)}, new String[] {"array_of_map"});
+
+        Schema arrowSchema = FlinkArrowUtils.toArrowSchema(rowType);
+        try (VectorSchemaRoot root = VectorSchemaRoot.create(arrowSchema, allocator)) {
+            FlinkArrowWriter writer = FlinkArrowWriter.create(root, rowType);
+
+            // Create array of maps: [{a: 1, b: 2}, {c: 3}]
+            Map<StringData, Integer> map1 = new HashMap<>();
+            map1.put(StringData.fromString("a"), 1);
+            map1.put(StringData.fromString("b"), 2);
+
+            Map<StringData, Integer> map2 = new HashMap<>();
+            map2.put(StringData.fromString("c"), 3);
+
+            GenericMapData genericMap1 = new GenericMapData(map1);
+            GenericMapData genericMap2 = new GenericMapData(map2);
+            GenericArrayData arrayOfMaps = new GenericArrayData(new Object[] {genericMap1, genericMap2});
+
+            GenericRowData row = new GenericRowData(1);
+            row.setField(0, arrayOfMaps);
+            writer.write(row);
+            writer.finish();
+
+            assertEquals(1, root.getRowCount());
+            assertNotNull(root.getVector("array_of_map").getObject(0));
+        }
+    }
+
+    @Test
+    public void testWriteEmptyBatch() {
+        RowType rowType = RowType.of(new LogicalType[] {new IntType()}, new String[] {"id"});
+        Schema arrowSchema = FlinkArrowUtils.toArrowSchema(rowType);
+
+        try (VectorSchemaRoot root = VectorSchemaRoot.create(arrowSchema, allocator)) {
+            FlinkArrowWriter writer = FlinkArrowWriter.create(root, rowType);
+            writer.finish();
+            assertEquals(0, root.getRowCount());
+        }
+    }
+
+    @Test
+    public void testArrayWithNullElements() {
+        RowType rowType = RowType.of(new LogicalType[] {new ArrayType(new IntType())}, new String[] {"numbers"});
+
+        Schema arrowSchema = FlinkArrowUtils.toArrowSchema(rowType);
+        try (VectorSchemaRoot root = VectorSchemaRoot.create(arrowSchema, allocator)) {
+            FlinkArrowWriter writer = FlinkArrowWriter.create(root, rowType);
+
+            // Array with null element: [1, null, 3]
+            GenericRowData row = new GenericRowData(1);
+            row.setField(0, new GenericArrayData(new Integer[] {1, null, 3}));
+            writer.write(row);
+            writer.finish();
+
+            assertEquals(1, root.getRowCount());
+        }
+    }
+
+    @Test
+    public void testNullStruct() {
+        RowType innerType = RowType.of(new LogicalType[] {new IntType()}, new String[] {"value"});
+        RowType rowType = RowType.of(new LogicalType[] {innerType}, new String[] {"struct_field"});
+
+        Schema arrowSchema = FlinkArrowUtils.toArrowSchema(rowType);
+        try (VectorSchemaRoot root = VectorSchemaRoot.create(arrowSchema, allocator)) {
+            FlinkArrowWriter writer = FlinkArrowWriter.create(root, rowType);
+
+            // Row with null struct
+            GenericRowData row = new GenericRowData(1);
+            row.setField(0, null);
+            writer.write(row);
+            writer.finish();
+
+            assertEquals(1, root.getRowCount());
+            assertTrue(root.getVector("struct_field").isNull(0));
+        }
+    }
+
+    @Test
+    public void testWriteTimeType() {
+        RowType rowType = RowType.of(new LogicalType[] {new TimeType(3)}, new String[] {"time"});
+
+        Schema arrowSchema = FlinkArrowUtils.toArrowSchema(rowType);
+        try (VectorSchemaRoot root = VectorSchemaRoot.create(arrowSchema, allocator)) {
+            FlinkArrowWriter writer = FlinkArrowWriter.create(root, rowType);
+
+            // Write time value (milliseconds since midnight)
+            GenericRowData row = new GenericRowData(1);
+            row.setField(0, 43200000); // 12:00:00.000 = 12 hours * 60 * 60 * 1000 ms
+            writer.write(row);
+
+            // Write null time
+            GenericRowData nullRow = new GenericRowData(1);
+            nullRow.setField(0, null);
+            writer.write(nullRow);
+
+            writer.finish();
+
+            assertEquals(2, root.getRowCount());
+            // Verify the time is written in microseconds (43200000 ms * 1000 = 43200000000 us)
+            Object value = root.getVector("time").getObject(0);
+            assertNotNull(value);
+            assertEquals(43200000000L, value);
+            assertTrue(root.getVector("time").isNull(1));
+        }
+    }
+
+    @Test
+    public void testWriteLocalZonedTimestampType() {
+        RowType rowType = RowType.of(new LogicalType[] {new LocalZonedTimestampType(6)}, new String[] {"lz_ts"});
+
+        Schema arrowSchema = FlinkArrowUtils.toArrowSchema(rowType);
+        try (VectorSchemaRoot root = VectorSchemaRoot.create(arrowSchema, allocator)) {
+            FlinkArrowWriter writer = FlinkArrowWriter.create(root, rowType);
+
+            // Create timestamp with microsecond precision
+            long millis = 1705622400000L; // 2024-01-19 00:00:00.000
+            int nanos = 123456; // 123.456 microseconds
+
+            GenericRowData row = new GenericRowData(1);
+            row.setField(0, TimestampData.fromEpochMillis(millis, nanos));
+            writer.write(row);
+
+            // Write null
+            GenericRowData nullRow = new GenericRowData(1);
+            nullRow.setField(0, null);
+            writer.write(nullRow);
+
+            writer.finish();
+
+            assertEquals(2, root.getRowCount());
+            // Verify the timestamp is written in microseconds
+            Object value = root.getVector("lz_ts").getObject(0);
+            assertNotNull(value);
+            assertTrue(root.getVector("lz_ts").isNull(1));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Implement Flink RowData to Arrow format conversion for Auron-Flink integration
- Add FlinkArrowUtils, FlinkArrowWriter, FlinkArrowFieldWriter, and FlinkArrowFFIExporter
- Support all common Flink types including primitives, temporal, and complex types
- Add comprehensive unit tests

## Test plan
- [x] Unit tests for FlinkArrowUtils type conversion
- [x] Unit tests for FlinkArrowWriter data writing
- [x] Unit tests for FlinkArrowFFIExporter (skipped when native libs unavailable)
- [x] Build passes with `./auron-build.sh --pre --sparkver 3.5 --scalaver 2.12 -DskipBuildNative`
- [x] Code formatted with `./dev/reformat`

Closes #1850