### PR TITLE
[AURON #1961] Fix Spark 4.0+: unit test catalyst codegen failure due to session artifact isolation

### DIFF
--- a/spark-extension-shims-spark/src/test/scala/org/apache/auron/AuronFunctionSuite.scala
+++ b/spark-extension-shims-spark/src/test/scala/org/apache/auron/AuronFunctionSuite.scala
@@ -20,7 +20,7 @@ import java.text.SimpleDateFormat
 
 import org.apache.spark.sql.{AuronQueryTest, Row}
 
-import org.apache.auron.util.{AuronTestUtils, SparkVersionUtil}
+import org.apache.auron.util.AuronTestUtils
 
 class AuronFunctionSuite extends AuronQueryTest with BaseAuronSQLSuite {
 
@@ -83,9 +83,6 @@ class AuronFunctionSuite extends AuronQueryTest with BaseAuronSQLSuite {
   }
 
   test("spark hash function") {
-    // TODO: Fix flaky codegen cache failures in SPARK-4.x, https://github.com/apache/auron/issues/1961
-    assume(!SparkVersionUtil.isSparkV40OrGreater)
-
     withTable("t1") {
       sql("create table t1 using parquet as select array(1, 2) as arr")
       val functions =
@@ -97,9 +94,6 @@ class AuronFunctionSuite extends AuronQueryTest with BaseAuronSQLSuite {
   }
 
   test("expm1 function") {
-    // TODO: Fix flaky codegen cache failures in SPARK-4.x, https://github.com/apache/auron/issues/1961
-    assume(!SparkVersionUtil.isSparkV40OrGreater)
-
     withTable("t1") {
       sql("create table t1(c1 double) using parquet")
       sql("insert into t1 values(0.0), (1.1), (2.2)")

--- a/spark-extension-shims-spark/src/test/scala/org/apache/auron/AuronQuerySuite.scala
+++ b/spark-extension-shims-spark/src/test/scala/org/apache/auron/AuronQuerySuite.scala
@@ -20,7 +20,7 @@ import org.apache.spark.sql.{AuronQueryTest, Row}
 import org.apache.spark.sql.execution.joins.auron.plan.NativeBroadcastJoinExec
 
 import org.apache.auron.spark.configuration.SparkAuronConfiguration
-import org.apache.auron.util.{AuronTestUtils, SparkVersionUtil}
+import org.apache.auron.util.AuronTestUtils
 
 class AuronQuerySuite extends AuronQueryTest with BaseAuronSQLSuite with AuronSQLTestHelper {
   import testImplicits._
@@ -42,9 +42,6 @@ class AuronQuerySuite extends AuronQueryTest with BaseAuronSQLSuite with AuronSQ
   }
 
   test("test filter with year function") {
-    // TODO: Fix flaky codegen cache failures in SPARK-4.x, https://github.com/apache/auron/issues/1961
-    assume(!SparkVersionUtil.isSparkV40OrGreater)
-
     withTable("t1") {
       sql("create table t1 using parquet as select '2024-12-18' as event_time")
       checkSparkAnswerAndOperator(s"""
@@ -57,9 +54,6 @@ class AuronQuerySuite extends AuronQueryTest with BaseAuronSQLSuite with AuronSQ
   }
 
   test("test select multiple spark ext functions with the same signature") {
-    // TODO: Fix flaky codegen cache failures in SPARK-4.x, https://github.com/apache/auron/issues/1961
-    assume(!SparkVersionUtil.isSparkV40OrGreater)
-
     withTable("t1") {
       sql("create table t1 using parquet as select '2024-12-18' as event_time")
       checkSparkAnswerAndOperator("select year(event_time), month(event_time) from t1")
@@ -177,9 +171,6 @@ class AuronQuerySuite extends AuronQueryTest with BaseAuronSQLSuite with AuronSQ
   }
 
   test("floor function with long input") {
-    // TODO: Fix flaky codegen cache failures in SPARK-4.x, https://github.com/apache/auron/issues/1961
-    assume(!SparkVersionUtil.isSparkV40OrGreater)
-
     withTable("t1") {
       sql("create table t1 using parquet as select 1L as c1, 2.2 as c2")
       checkSparkAnswerAndOperator("select floor(c1), floor(c2) from t1")


### PR DESCRIPTION
<!--
  - Start the PR title with the related issue ID, e.g. '[AURON #XXXX] Short summary...'.
-->
# Which issue does this PR close?

Closes #1961 

# Rationale for this change

Spark 4.0+ enables session artifact isolation by default(Related to https://github.com/apache/spark/pull/48120), a feature entirely absent in Spark 3.x. This mechanism stores Catalyst dynamically generated inline classes (e.g., `org.apache.spark.sql.catalyst.expressions.Object`) in session-specific isolated directories. The `REPL class server` cannot scan these directories, causing class lookup failures and breaking Catalyst codegen in unit tests. Isolation is unnecessary for unit tests (single-session execution, no class conflict risk), so disabling it is a minimal, safe fix.

# What changes are included in this PR?
For Spark 4.0+ only, conditionally set `spark.sql.artifact.isolation.enabled=false` in unit test configurations. This binds Catalyst dynamic codegen classes to the default "default" isolation group, aligning behavior with Spark 3.x.


# Are there any user-facing changes?
No.

# How was this patch tested?
CI