### PR TITLE
[AURON #1978] Enforce code formatting during PR check

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Check for formatting changes
         run: |
           if [[ -n $(git status --porcelain) ]]; then
-            echo "Code style issues found. Please run './dev/reformat' locally and commit the changes."
+            echo "Code format issues found. Please run './dev/reformat' locally and commit the changes."
             echo ""
             echo "Files with formatting issues:"
             git status


### PR DESCRIPTION
<!--
  - Start the PR title with the related issue ID, e.g. '[AURON #XXXX] Short summary...'.
-->
# Which issue does this PR close?

Closes #1978

# Rationale for this change
This ensures the formatting is enforced. This will keep the master branch in a clean state so a build never causes auto-format changes.

# What changes are included in this PR?
It runs the formatter and checks if there are any changes that aren't checked in

# Are there any user-facing changes?
No, CI only

# How was this patch tested?
Manual testing
