### PR TITLE
[AURON #1985] Optimize native metrics retrieval by passing keys directly

### DIFF
--- a/spark-extension-shims-spark/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeShuffleExchangeExec.scala
+++ b/spark-extension-shims-spark/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeShuffleExchangeExec.scala
@@ -47,16 +47,17 @@ case class NativeShuffleExchangeExec(
     SQLShuffleWriteMetricsReporter.createShuffleWriteMetrics(sparkContext) ++
     mutable.LinkedHashMap(
       NativeHelper
-        .getDefaultNativeMetrics(sparkContext)
-        .filterKeys(Set(
-          "stage_id",
-          "mem_spill_count",
-          "mem_spill_size",
-          "mem_spill_iotime",
-          "disk_spill_size",
-          "disk_spill_iotime",
-          "shuffle_write_total_time",
-          "shuffle_read_total_time"))
+        .getDefaultNativeMetrics(
+          sparkContext,
+          Set(
+            "stage_id",
+            "mem_spill_count",
+            "mem_spill_size",
+            "mem_spill_iotime",
+            "disk_spill_size",
+            "disk_spill_iotime",
+            "shuffle_write_total_time",
+            "shuffle_read_total_time"))
         .toSeq: _*)).toMap
 
   lazy val readMetrics: Map[String, SQLMetric] =

--- a/spark-extension/src/main/scala/org/apache/spark/sql/auron/NativeHelper.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/auron/NativeHelper.scala
@@ -208,7 +208,7 @@ object NativeHelper extends Logging {
         keys -- Set("input_batch_count", "input_row_count", "input_batch_mem_size")
       }
 
-    TreeMap[String, SQLMetric]() ++ enabledKeys.flatMap { key =>
+    TreeMap[String, SQLMetric]() ++ enabledKeys.iterator.flatMap { key =>
       defaultNativeMetricCreators.get(key).map(f => key -> f(sc))
     }
   }

--- a/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/plan/ConvertToNativeBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/plan/ConvertToNativeBase.scala
@@ -52,8 +52,7 @@ abstract class ConvertToNativeBase(override val child: SparkPlan)
 
   override lazy val metrics: Map[String, SQLMetric] = SortedMap[String, SQLMetric]() ++ Map(
     NativeHelper
-      .getDefaultNativeMetrics(sparkContext)
-      .filterKeys(Set("stage_id", "output_rows", "elapsed_compute"))
+      .getDefaultNativeMetrics(sparkContext, Set("stage_id", "output_rows", "elapsed_compute"))
       .toSeq :+
       ("size", SQLMetrics.createSizeMetric(sparkContext, "Native.batch_bytes_size")): _*)
 

--- a/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeAggBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeAggBase.scala
@@ -73,19 +73,20 @@ abstract class NativeAggBase(
 
   override lazy val metrics: Map[String, SQLMetric] = SortedMap[String, SQLMetric]() ++ Map(
     NativeHelper
-      .getDefaultNativeMetrics(sparkContext)
-      .filterKeys(Set(
-        "stage_id",
-        "output_rows",
-        "elapsed_compute",
-        "mem_spill_count",
-        "mem_spill_size",
-        "mem_spill_iotime",
-        "disk_spill_size",
-        "disk_spill_iotime",
-        "input_batch_count",
-        "input_batch_mem_size",
-        "input_row_count"))
+      .getDefaultNativeMetrics(
+        sparkContext,
+        Set(
+          "stage_id",
+          "output_rows",
+          "elapsed_compute",
+          "mem_spill_count",
+          "mem_spill_size",
+          "mem_spill_iotime",
+          "disk_spill_size",
+          "disk_spill_iotime",
+          "input_batch_count",
+          "input_batch_mem_size",
+          "input_row_count"))
       .toSeq: _*) ++
     Map(
       "hashing_time" -> SQLMetrics.createNanoTimingMetric(sparkContext, "Native.hashing_time")) ++

--- a/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeBroadcastExchangeBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeBroadcastExchangeBase.scala
@@ -85,7 +85,29 @@ abstract class NativeBroadcastExchangeBase(mode: BroadcastMode, override val chi
   def getRunId: UUID
   override lazy val metrics: Map[String, SQLMetric] = SortedMap[String, SQLMetric]() ++ Map(
     NativeHelper
-      .getDefaultNativeMetrics(sparkContext)
+      .getDefaultNativeMetrics(
+        sparkContext,
+        Set(
+          "stage_id",
+          "output_rows",
+          "output_batches",
+          "elapsed_compute",
+          "build_hash_map_time",
+          "probed_side_hash_time",
+          "probed_side_search_time",
+          "probed_side_compare_time",
+          "build_output_time",
+          "fallback_sort_merge_join_time",
+          "mem_spill_count",
+          "mem_spill_size",
+          "mem_spill_iotime",
+          "disk_spill_size",
+          "disk_spill_iotime",
+          "shuffle_write_total_time",
+          "shuffle_read_total_time",
+          "input_batch_count",
+          "input_row_count",
+          "input_batch_mem_size"))
       .toSeq :+
       ("dataSize", SQLMetrics.createSizeMetric(sparkContext, "data size")) :+
       ("numOutputRows", SQLMetrics.createMetric(sparkContext, "number of output rows")) :+

--- a/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeBroadcastJoinBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeBroadcastJoinBase.scala
@@ -60,19 +60,20 @@ abstract class NativeBroadcastJoinBase(
 
   override lazy val metrics: Map[String, SQLMetric] = SortedMap[String, SQLMetric]() ++ Map(
     NativeHelper
-      .getDefaultNativeMetrics(sparkContext)
-      .filterKeys(Set(
-        "stage_id",
-        "output_rows",
-        "elapsed_compute",
-        "probed_side_hash_time",
-        "probed_side_search_time",
-        "probed_side_compare_time",
-        "build_output_time",
-        "fallback_sort_merge_join_time",
-        "input_batch_count",
-        "input_batch_mem_size",
-        "input_row_count"))
+      .getDefaultNativeMetrics(
+        sparkContext,
+        Set(
+          "stage_id",
+          "output_rows",
+          "elapsed_compute",
+          "probed_side_hash_time",
+          "probed_side_search_time",
+          "probed_side_compare_time",
+          "build_output_time",
+          "fallback_sort_merge_join_time",
+          "input_batch_count",
+          "input_batch_mem_size",
+          "input_row_count"))
       .toSeq: _*)
 
   {

--- a/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeExpandBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeExpandBase.scala
@@ -45,8 +45,8 @@ abstract class NativeExpandBase(
 
   override lazy val metrics: Map[String, SQLMetric] = SortedMap[String, SQLMetric]() ++ Map(
     NativeHelper
-      .getDefaultNativeMetrics(sparkContext)
-      .filterKeys(
+      .getDefaultNativeMetrics(
+        sparkContext,
         Set(
           "stage_id",
           "output_rows",

--- a/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeFilterBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeFilterBase.scala
@@ -46,8 +46,8 @@ abstract class NativeFilterBase(condition: Expression, override val child: Spark
 
   override lazy val metrics: Map[String, SQLMetric] = SortedMap[String, SQLMetric]() ++ Map(
     NativeHelper
-      .getDefaultNativeMetrics(sparkContext)
-      .filterKeys(
+      .getDefaultNativeMetrics(
+        sparkContext,
         Set(
           "stage_id",
           "output_rows",

--- a/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeGenerateBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeGenerateBase.scala
@@ -57,8 +57,8 @@ abstract class NativeGenerateBase(
 
   override lazy val metrics: Map[String, SQLMetric] = SortedMap[String, SQLMetric]() ++ Map(
     NativeHelper
-      .getDefaultNativeMetrics(sparkContext)
-      .filterKeys(
+      .getDefaultNativeMetrics(
+        sparkContext,
         Set(
           "stage_id",
           "output_rows",

--- a/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeGlobalLimitBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeGlobalLimitBase.scala
@@ -41,8 +41,7 @@ abstract class NativeGlobalLimitBase(limit: Int, offset: Int, override val child
 
   override lazy val metrics: Map[String, SQLMetric] = SortedMap[String, SQLMetric]() ++ Map(
     NativeHelper
-      .getDefaultNativeMetrics(sparkContext)
-      .filterKeys(Set("stage_id", "output_rows"))
+      .getDefaultNativeMetrics(sparkContext, Set("stage_id", "output_rows"))
       .toSeq: _*)
 
   override def output: Seq[Attribute] = child.output

--- a/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeLocalLimitBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeLocalLimitBase.scala
@@ -39,8 +39,7 @@ abstract class NativeLocalLimitBase(limit: Int, override val child: SparkPlan)
 
   override lazy val metrics: Map[String, SQLMetric] = SortedMap[String, SQLMetric]() ++ Map(
     NativeHelper
-      .getDefaultNativeMetrics(sparkContext)
-      .filterKeys(Set("stage_id", "output_rows"))
+      .getDefaultNativeMetrics(sparkContext, Set("stage_id", "output_rows"))
       .toSeq: _*)
 
   override def output: Seq[Attribute] = child.output

--- a/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeParquetInsertIntoHiveTableBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeParquetInsertIntoHiveTableBase.scala
@@ -65,8 +65,7 @@ abstract class NativeParquetInsertIntoHiveTableBase(
     BasicWriteJobStatsTracker.metrics ++
     Map(
       NativeHelper
-        .getDefaultNativeMetrics(sparkContext)
-        .filterKeys(Set("stage_id", "output_rows", "elapsed_compute"))
+        .getDefaultNativeMetrics(sparkContext, Set("stage_id", "output_rows", "elapsed_compute"))
         .toSeq
         :+ ("io_time", SQLMetrics.createNanoTimingMetric(sparkContext, "Native.io_time"))
         :+ ("bytes_written",

--- a/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeProjectBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeProjectBase.scala
@@ -47,8 +47,8 @@ abstract class NativeProjectBase(projectList: Seq[NamedExpression], override val
 
   override lazy val metrics: Map[String, SQLMetric] = SortedMap[String, SQLMetric]() ++ Map(
     NativeHelper
-      .getDefaultNativeMetrics(sparkContext)
-      .filterKeys(
+      .getDefaultNativeMetrics(
+        sparkContext,
         Set(
           "stage_id",
           "output_rows",

--- a/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeShuffledHashJoinBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeShuffledHashJoinBase.scala
@@ -47,20 +47,21 @@ abstract class NativeShuffledHashJoinBase(
 
   override lazy val metrics: Map[String, SQLMetric] = SortedMap[String, SQLMetric]() ++ Map(
     NativeHelper
-      .getDefaultNativeMetrics(sparkContext)
-      .filterKeys(Set(
-        "stage_id",
-        "output_rows",
-        "elapsed_compute",
-        "build_hash_map_time",
-        "probed_side_hash_time",
-        "probed_side_search_time",
-        "probed_side_compare_time",
-        "build_output_time",
-        "fallback_sort_merge_join_time",
-        "input_batch_count",
-        "input_batch_mem_size",
-        "input_row_count"))
+      .getDefaultNativeMetrics(
+        sparkContext,
+        Set(
+          "stage_id",
+          "output_rows",
+          "elapsed_compute",
+          "build_hash_map_time",
+          "probed_side_hash_time",
+          "probed_side_search_time",
+          "probed_side_compare_time",
+          "build_output_time",
+          "fallback_sort_merge_join_time",
+          "input_batch_count",
+          "input_batch_mem_size",
+          "input_row_count"))
       .toSeq: _*)
 
   private def nativeSchema = Util.getNativeSchema(output)

--- a/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeSortBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeSortBase.scala
@@ -51,19 +51,20 @@ abstract class NativeSortBase(
 
   override lazy val metrics: Map[String, SQLMetric] = SortedMap[String, SQLMetric]() ++ Map(
     NativeHelper
-      .getDefaultNativeMetrics(sparkContext)
-      .filterKeys(Set(
-        "stage_id",
-        "output_rows",
-        "elapsed_compute",
-        "mem_spill_count",
-        "mem_spill_size",
-        "mem_spill_iotime",
-        "disk_spill_size",
-        "disk_spill_iotime",
-        "input_batch_count",
-        "input_batch_mem_size",
-        "input_row_count"))
+      .getDefaultNativeMetrics(
+        sparkContext,
+        Set(
+          "stage_id",
+          "output_rows",
+          "elapsed_compute",
+          "mem_spill_count",
+          "mem_spill_size",
+          "mem_spill_iotime",
+          "disk_spill_size",
+          "disk_spill_iotime",
+          "input_batch_count",
+          "input_batch_mem_size",
+          "input_row_count"))
       .toSeq: _*)
 
   override def output: Seq[Attribute] = child.output

--- a/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeSortMergeJoinBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeSortMergeJoinBase.scala
@@ -54,8 +54,8 @@ abstract class NativeSortMergeJoinBase(
 
   override lazy val metrics: Map[String, SQLMetric] = SortedMap[String, SQLMetric]() ++ Map(
     NativeHelper
-      .getDefaultNativeMetrics(sparkContext)
-      .filterKeys(
+      .getDefaultNativeMetrics(
+        sparkContext,
         Set(
           "stage_id",
           "output_rows",

--- a/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeTakeOrderedBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeTakeOrderedBase.scala
@@ -56,8 +56,7 @@ abstract class NativeTakeOrderedBase(
 
   override lazy val metrics: Map[String, SQLMetric] = SortedMap[String, SQLMetric]() ++ Map(
     NativeHelper
-      .getDefaultNativeMetrics(sparkContext)
-      .filterKeys(Set("stage_id", "output_rows", "elapsed_compute"))
+      .getDefaultNativeMetrics(sparkContext, Set("stage_id", "output_rows", "elapsed_compute"))
       .toSeq: _*)
 
   override def output: Seq[Attribute] = child.output

--- a/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeUnionBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeUnionBase.scala
@@ -46,8 +46,7 @@ abstract class NativeUnionBase(
 
   override lazy val metrics: Map[String, SQLMetric] = SortedMap[String, SQLMetric]() ++ Map(
     NativeHelper
-      .getDefaultNativeMetrics(sparkContext)
-      .filterKeys(Set("stage_id", "output_rows"))
+      .getDefaultNativeMetrics(sparkContext, Set("stage_id", "output_rows"))
       .toSeq: _*)
 
   override def doExecuteNative(): NativeRDD = {

--- a/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeWindowBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeWindowBase.scala
@@ -67,8 +67,7 @@ abstract class NativeWindowBase(
 
   override lazy val metrics: Map[String, SQLMetric] = SortedMap[String, SQLMetric]() ++ Map(
     NativeHelper
-      .getDefaultNativeMetrics(sparkContext)
-      .filterKeys(Set("stage_id", "output_rows", "elapsed_compute"))
+      .getDefaultNativeMetrics(sparkContext, Set("stage_id", "output_rows", "elapsed_compute"))
       .toSeq: _*)
 
   override def output: Seq[Attribute] = groupLimit match {


### PR DESCRIPTION
# Which issue does this PR close?
Closes #1985 

# Rationale for this change
 The previous native metrics retrieval fetched all default metrics for every operator. This changes allows specific operators to request only the relevant metric keys, reducing unnecessary overhead.

# What changes are included in this PR?
 Updated `getDefaultNativeMetrics` to accept a `Set[String]` of metric keys instead of returning a fixed map.

# Are there any user-facing changes?
No

# How was this patch tested?
