### PR TITLE
[AURON #1988] Fix empty log message in AuronUniffleShuffleReader.

### DIFF
--- a/thirdparty/auron-uniffle/src/main/scala/org/apache/spark/sql/execution/auron/shuffle/uniffle/AuronUniffleShuffleReader.scala
+++ b/thirdparty/auron-uniffle/src/main/scala/org/apache/spark/sql/execution/auron/shuffle/uniffle/AuronUniffleShuffleReader.scala
@@ -165,7 +165,8 @@ class AuronUniffleShuffleReader[K, C](
         }
       }
       if (!emptyPartitionIds.isEmpty) {
-        logInfo(s"Found ${emptyPartitionIds.size()} empty shuffle partitions: ${emptyPartitionIds.asScala.mkString(",")}")
+        logDebug(s"Found ${emptyPartitionIds
+          .size()} empty shuffle partitions: ${emptyPartitionIds.asScala.mkString(",")}")
       }
       iterators = shuffleDataIterList.iterator()
       if (iterators.hasNext) {


### PR DESCRIPTION

### Which issue does this PR close?

Closes #1988

### Rationale for this change

Fix an empty log statement in `AuronUniffleShuffleReader` that provided no useful information when empty shuffle partitions were detected.

### What changes are included in this PR?

The original code had an empty log message (`logInfo(s"")`), which provides no value for debugging or monitoring. This change adds meaningful information including the count and IDs of empty shuffle partitions.

### Are there any user-facing changes?

No, this is an internal logging improvement only.

### How was this patch tested?

No.