### PR TITLE
[AURON #1999] Add Apache-2.0 license declaration to all native-engine Cargo.toml files.

### DIFF
--- a/native-engine/auron-jni-bridge/Cargo.toml
+++ b/native-engine/auron-jni-bridge/Cargo.toml
@@ -18,9 +18,9 @@
 [package]
 name = "auron-jni-bridge"
 version = "0.1.0"
+license = "Apache-2.0"
 edition = "2024"
 resolver = "1"
-
 [lints]
 workspace = true
 

--- a/native-engine/auron-memmgr/Cargo.toml
+++ b/native-engine/auron-memmgr/Cargo.toml
@@ -18,8 +18,8 @@
 [package]
 name = "auron-memmgr"
 version = "0.1.0"
+license = "Apache-2.0"
 edition = "2024"
-
 [lints]
 workspace = true
 

--- a/native-engine/auron-planner/Cargo.toml
+++ b/native-engine/auron-planner/Cargo.toml
@@ -18,8 +18,8 @@
 [package]
 name = "auron-planner"
 version = "0.1.0"
+license = "Apache-2.0"
 edition = "2024"
-
 [lints]
 workspace = true
 

--- a/native-engine/auron/Cargo.toml
+++ b/native-engine/auron/Cargo.toml
@@ -18,9 +18,9 @@
 [package]
 name = "auron"
 version = "0.1.0"
+license = "Apache-2.0"
 edition = "2024"
 resolver = "1"
-
 [lints]
 workspace = true
 

--- a/native-engine/datafusion-ext-commons/Cargo.toml
+++ b/native-engine/datafusion-ext-commons/Cargo.toml
@@ -18,9 +18,9 @@
 [package]
 name = "datafusion-ext-commons"
 version = "0.1.0"
+license = "Apache-2.0"
 edition = "2024"
 resolver = "1"
-
 [lints]
 workspace = true
 

--- a/native-engine/datafusion-ext-exprs/Cargo.toml
+++ b/native-engine/datafusion-ext-exprs/Cargo.toml
@@ -18,9 +18,9 @@
 [package]
 name = "datafusion-ext-exprs"
 version = "0.1.0"
+license = "Apache-2.0"
 edition = "2024"
 resolver = "1"
-
 [lints]
 workspace = true
 

--- a/native-engine/datafusion-ext-functions/Cargo.toml
+++ b/native-engine/datafusion-ext-functions/Cargo.toml
@@ -18,9 +18,9 @@
 [package]
 name = "datafusion-ext-functions"
 version = "0.1.0"
+license = "Apache-2.0"
 edition = "2024"
 resolver = "1"
-
 [lints]
 workspace = true
 

--- a/native-engine/datafusion-ext-plans/Cargo.toml
+++ b/native-engine/datafusion-ext-plans/Cargo.toml
@@ -18,9 +18,9 @@
 [package]
 name = "datafusion-ext-plans"
 version = "0.1.0"
+license = "Apache-2.0"
 edition = "2024"
 resolver = "1"
-
 [lints]
 workspace = true
 


### PR DESCRIPTION
### Which issue does this PR close?

Closes #1999

### Rationale for this change

Currently, the native-engine subproject Cargo.toml files lack explicit license declarations. This PR adds `license = "Apache-2.0"` to all native-engine packages to:
- Improve project compliance with open-source licensing best practices
- Maintain consistency across all workspace members
- Make license information machine-readable for dependency scanners and tools

### What changes are included in this PR?

Added `license = "Apache-2.0"` field to the `[package]` section of the following Cargo.toml files

### Are there any user-facing changes?

No.

### How was this patch tested?

- Verified all Cargo.toml files are syntactically valid with `cargo check`