### PR TITLE
[AURON #2003] Extract common package configs to workspace Cargo.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -344,7 +344,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "auron"
-version = "0.1.0"
+version = "7.0.0-incubating"
 dependencies = [
  "arrow",
  "auron-jni-bridge",
@@ -373,7 +373,7 @@ dependencies = [
 
 [[package]]
 name = "auron-jni-bridge"
-version = "0.1.0"
+version = "7.0.0-incubating"
 dependencies = [
  "datafusion",
  "jni",
@@ -384,7 +384,7 @@ dependencies = [
 
 [[package]]
 name = "auron-memmgr"
-version = "0.1.0"
+version = "7.0.0-incubating"
 dependencies = [
  "async-trait",
  "auron-jni-bridge",
@@ -401,7 +401,7 @@ dependencies = [
 
 [[package]]
 name = "auron-planner"
-version = "0.1.0"
+version = "7.0.0-incubating"
 dependencies = [
  "arrow",
  "base64",
@@ -1174,7 +1174,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-ext-commons"
-version = "0.1.0"
+version = "7.0.0-incubating"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -1200,7 +1200,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-ext-exprs"
-version = "0.1.0"
+version = "7.0.0-incubating"
 dependencies = [
  "arrow",
  "auron-jni-bridge",
@@ -1215,7 +1215,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-ext-functions"
-version = "0.1.0"
+version = "7.0.0-incubating"
 dependencies = [
  "arrow",
  "auron-jni-bridge",
@@ -1233,7 +1233,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-ext-plans"
-version = "0.1.0"
+version = "7.0.0-incubating"
 dependencies = [
  "arrow",
  "arrow-schema",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -344,7 +344,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "auron"
-version = "7.0.0-incubating"
+version = "8.0.0"
 dependencies = [
  "arrow",
  "auron-jni-bridge",
@@ -373,7 +373,7 @@ dependencies = [
 
 [[package]]
 name = "auron-jni-bridge"
-version = "7.0.0-incubating"
+version = "8.0.0"
 dependencies = [
  "datafusion",
  "jni",
@@ -384,7 +384,7 @@ dependencies = [
 
 [[package]]
 name = "auron-memmgr"
-version = "7.0.0-incubating"
+version = "8.0.0"
 dependencies = [
  "async-trait",
  "auron-jni-bridge",
@@ -401,7 +401,7 @@ dependencies = [
 
 [[package]]
 name = "auron-planner"
-version = "7.0.0-incubating"
+version = "8.0.0"
 dependencies = [
  "arrow",
  "base64",
@@ -1174,7 +1174,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-ext-commons"
-version = "7.0.0-incubating"
+version = "8.0.0"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -1200,7 +1200,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-ext-exprs"
-version = "7.0.0-incubating"
+version = "8.0.0"
 dependencies = [
  "arrow",
  "auron-jni-bridge",
@@ -1215,7 +1215,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-ext-functions"
-version = "7.0.0-incubating"
+version = "8.0.0"
 dependencies = [
  "arrow",
  "auron-jni-bridge",
@@ -1233,7 +1233,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-ext-plans"
-version = "7.0.0-incubating"
+version = "8.0.0"
 dependencies = [
  "arrow",
  "arrow-schema",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ members = [
 ]
 
 [workspace.package]
-version = "7.0.0-incubating"
+version = "8.0.0"
 license = "Apache-2.0"
 edition = "2024"
 
@@ -162,35 +162,38 @@ base64 = "0.22.1"
 bigdecimal = "0.4.10"
 bitvec = "1.0.1"
 byteorder = "1.5.0"
-bytes = "1.11.0"
+bytes = "1.11.1"
 bytesize = "2.3.1"
-chrono = "0.4.43"
+chrono = "0.4.44"
 count-write = "0.1.0"
 foldhash = "0.2.0"
 futures = "0.3"
-futures-util = "0.3.31"
+futures-util = "0.3.32"
 hashbrown = "0.14.5"
 itertools = "0.14.0"
 jni = "0.20.0"
 log = "0.4.29"
-lz4_flex = "0.12.0"
+lz4_flex = "0.13.0"
 num = "0.4.2"
 object_store = "0.12.4"
-once_cell = "1.21.3"
+once_cell = "1.21.4"
 panic-message = "0.3.0"
 parking_lot = "0.12.5"
 paste = "1.0.15"
 procfs = "0.18.0"
 prost = "0.14.3"
+prost-types = "0.14.3"
+prost-reflect = "0.16.3"
 rand = "0.9.2"
 smallvec = "2.0.0-alpha.11"
-sonic-rs = "0.5.6"
+sonic-rs = "0.5.7"
 tempfile = "3"
-tokio = "1.49.0"
+tokio = "1.51.0"
 tonic-build = "0.13.1"
 transpose = "0.2.3"
 unchecked-index = "0.2.2"
 zstd = "0.13.3"
+rdkafka = { version = "0.36.0", features = ["tokio"] }
 
 [patch.crates-io]
 # datafusion: branch=v49.0.0-blaze
@@ -203,7 +206,7 @@ datafusion-execution = { git = "https://github.com/auron-project/datafusion.git"
 datafusion-optimizer = { git = "https://github.com/auron-project/datafusion.git", rev = "9034aeffb"}
 datafusion-physical-expr = { git = "https://github.com/auron-project/datafusion.git", rev = "9034aeffb"}
 datafusion-spark = { git = "https://github.com/auron-project/datafusion.git", rev = "9034aeffb"}
-orc-rust = { git = "https://github.com/auron-project/datafusion-orc.git", rev = "17f7012"}
+orc-rust = { git = "https://github.com/auron-project/datafusion-orc.git", rev = "9beb12c"}
 
 # arrow: branch=v55.2.0-blaze
 arrow = { git = "https://github.com/auron-project/arrow-rs.git", rev = "5de02520c"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,8 @@ members = [
 ]
 
 [workspace.package]
+version = "0.1.0"
+license = "Apache-2.0"
 edition = "2024"
 
 [workspace.lints.rust]
@@ -160,38 +162,35 @@ base64 = "0.22.1"
 bigdecimal = "0.4.10"
 bitvec = "1.0.1"
 byteorder = "1.5.0"
-bytes = "1.11.1"
+bytes = "1.11.0"
 bytesize = "2.3.1"
-chrono = "0.4.44"
+chrono = "0.4.43"
 count-write = "0.1.0"
 foldhash = "0.2.0"
 futures = "0.3"
-futures-util = "0.3.32"
+futures-util = "0.3.31"
 hashbrown = "0.14.5"
 itertools = "0.14.0"
 jni = "0.20.0"
 log = "0.4.29"
-lz4_flex = "0.13.0"
+lz4_flex = "0.12.0"
 num = "0.4.2"
 object_store = "0.12.4"
-once_cell = "1.21.4"
+once_cell = "1.21.3"
 panic-message = "0.3.0"
 parking_lot = "0.12.5"
 paste = "1.0.15"
 procfs = "0.18.0"
 prost = "0.14.3"
-prost-types = "0.14.3"
-prost-reflect = "0.16.3"
 rand = "0.9.2"
 smallvec = "2.0.0-alpha.11"
-sonic-rs = "0.5.7"
+sonic-rs = "0.5.6"
 tempfile = "3"
-tokio = "1.51.0"
+tokio = "1.49.0"
 tonic-build = "0.13.1"
 transpose = "0.2.3"
 unchecked-index = "0.2.2"
 zstd = "0.13.3"
-rdkafka = { version = "0.36.0", features = ["tokio"] }
 
 [patch.crates-io]
 # datafusion: branch=v49.0.0-blaze
@@ -204,7 +203,7 @@ datafusion-execution = { git = "https://github.com/auron-project/datafusion.git"
 datafusion-optimizer = { git = "https://github.com/auron-project/datafusion.git", rev = "9034aeffb"}
 datafusion-physical-expr = { git = "https://github.com/auron-project/datafusion.git", rev = "9034aeffb"}
 datafusion-spark = { git = "https://github.com/auron-project/datafusion.git", rev = "9034aeffb"}
-orc-rust = { git = "https://github.com/auron-project/datafusion-orc.git", rev = "9beb12c"}
+orc-rust = { git = "https://github.com/auron-project/datafusion-orc.git", rev = "17f7012"}
 
 # arrow: branch=v55.2.0-blaze
 arrow = { git = "https://github.com/auron-project/arrow-rs.git", rev = "5de02520c"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.0"
+version = "7.0.0-incubating"
 license = "Apache-2.0"
 edition = "2024"
 

--- a/native-engine/auron-jni-bridge/Cargo.toml
+++ b/native-engine/auron-jni-bridge/Cargo.toml
@@ -17,10 +17,10 @@
 
 [package]
 name = "auron-jni-bridge"
-version = "0.1.0"
-license = "Apache-2.0"
-edition.workspace = true
-
+version = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+resolver = "1"
 [lints]
 workspace = true
 

--- a/native-engine/auron-jni-bridge/Cargo.toml
+++ b/native-engine/auron-jni-bridge/Cargo.toml
@@ -20,7 +20,7 @@ name = "auron-jni-bridge"
 version = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
-resolver = "1"
+
 [lints]
 workspace = true
 

--- a/native-engine/auron-memmgr/Cargo.toml
+++ b/native-engine/auron-memmgr/Cargo.toml
@@ -20,7 +20,7 @@ name = "auron-memmgr"
 version = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
-resolver = "1"
+
 [lints]
 workspace = true
 

--- a/native-engine/auron-memmgr/Cargo.toml
+++ b/native-engine/auron-memmgr/Cargo.toml
@@ -17,10 +17,10 @@
 
 [package]
 name = "auron-memmgr"
-version = "0.1.0"
-license = "Apache-2.0"
-edition.workspace = true
-
+version = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+resolver = "1"
 [lints]
 workspace = true
 

--- a/native-engine/auron-planner/Cargo.toml
+++ b/native-engine/auron-planner/Cargo.toml
@@ -17,10 +17,10 @@
 
 [package]
 name = "auron-planner"
-version = "0.1.0"
-license = "Apache-2.0"
-edition.workspace = true
-
+version = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+resolver = "1"
 [lints]
 workspace = true
 

--- a/native-engine/auron-planner/Cargo.toml
+++ b/native-engine/auron-planner/Cargo.toml
@@ -20,7 +20,7 @@ name = "auron-planner"
 version = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
-resolver = "1"
+
 [lints]
 workspace = true
 

--- a/native-engine/auron/Cargo.toml
+++ b/native-engine/auron/Cargo.toml
@@ -17,10 +17,10 @@
 
 [package]
 name = "auron"
-version = "0.1.0"
-license = "Apache-2.0"
-edition.workspace = true
-
+version = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+resolver = "1"
 [lints]
 workspace = true
 
@@ -68,7 +68,7 @@ optional = true
 features = ["disable_initial_exec_tls"]
 
 [dependencies.jemalloc_pprof]
-version = "0.8.0"
+version = "0.8.2"
 features = ["symbolize"]
 optional = true
 

--- a/native-engine/auron/Cargo.toml
+++ b/native-engine/auron/Cargo.toml
@@ -20,7 +20,7 @@ name = "auron"
 version = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
-resolver = "1"
+
 [lints]
 workspace = true
 
@@ -68,7 +68,7 @@ optional = true
 features = ["disable_initial_exec_tls"]
 
 [dependencies.jemalloc_pprof]
-version = "0.8.2"
+version = "0.8.0"
 features = ["symbolize"]
 optional = true
 

--- a/native-engine/datafusion-ext-commons/Cargo.toml
+++ b/native-engine/datafusion-ext-commons/Cargo.toml
@@ -20,7 +20,7 @@ name = "datafusion-ext-commons"
 version = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
-resolver = "1"
+
 [lints]
 workspace = true
 

--- a/native-engine/datafusion-ext-commons/Cargo.toml
+++ b/native-engine/datafusion-ext-commons/Cargo.toml
@@ -17,10 +17,10 @@
 
 [package]
 name = "datafusion-ext-commons"
-version = "0.1.0"
-license = "Apache-2.0"
-edition.workspace = true
-
+version = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+resolver = "1"
 [lints]
 workspace = true
 

--- a/native-engine/datafusion-ext-exprs/Cargo.toml
+++ b/native-engine/datafusion-ext-exprs/Cargo.toml
@@ -17,10 +17,10 @@
 
 [package]
 name = "datafusion-ext-exprs"
-version = "0.1.0"
-license = "Apache-2.0"
-edition.workspace = true
-
+version = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+resolver = "1"
 [lints]
 workspace = true
 

--- a/native-engine/datafusion-ext-exprs/Cargo.toml
+++ b/native-engine/datafusion-ext-exprs/Cargo.toml
@@ -20,7 +20,7 @@ name = "datafusion-ext-exprs"
 version = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
-resolver = "1"
+
 [lints]
 workspace = true
 

--- a/native-engine/datafusion-ext-functions/Cargo.toml
+++ b/native-engine/datafusion-ext-functions/Cargo.toml
@@ -17,10 +17,10 @@
 
 [package]
 name = "datafusion-ext-functions"
-version = "0.1.0"
-license = "Apache-2.0"
-edition.workspace = true
-
+version = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+resolver = "1"
 [lints]
 workspace = true
 
@@ -36,5 +36,5 @@ num = { workspace = true }
 paste = { workspace = true }
 serde_json = { workspace = true }
 sonic-rs = { workspace = true }
-chrono = "0.4.44"
+chrono = "0.4.43"
 chrono-tz = "0.10.4"

--- a/native-engine/datafusion-ext-functions/Cargo.toml
+++ b/native-engine/datafusion-ext-functions/Cargo.toml
@@ -20,7 +20,7 @@ name = "datafusion-ext-functions"
 version = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
-resolver = "1"
+
 [lints]
 workspace = true
 
@@ -36,5 +36,5 @@ num = { workspace = true }
 paste = { workspace = true }
 serde_json = { workspace = true }
 sonic-rs = { workspace = true }
-chrono = "0.4.43"
+chrono = "0.4.44"
 chrono-tz = "0.10.4"

--- a/native-engine/datafusion-ext-plans/Cargo.toml
+++ b/native-engine/datafusion-ext-plans/Cargo.toml
@@ -20,7 +20,7 @@ name = "datafusion-ext-plans"
 version = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
-resolver = "1"
+
 [lints]
 workspace = true
 
@@ -63,6 +63,11 @@ paste = { workspace = true }
 smallvec = { workspace = true }
 tokio = { workspace = true }
 unchecked-index = { workspace = true }
+prost = { workspace = true }
+prost-types = { workspace = true }
+prost-reflect = { workspace = true }
+rdkafka = { workspace = true }
+sonic-rs = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 procfs = { workspace = true }

--- a/native-engine/datafusion-ext-plans/Cargo.toml
+++ b/native-engine/datafusion-ext-plans/Cargo.toml
@@ -17,10 +17,10 @@
 
 [package]
 name = "datafusion-ext-plans"
-version = "0.1.0"
-license = "Apache-2.0"
-edition.workspace = true
-
+version = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+resolver = "1"
 [lints]
 workspace = true
 
@@ -63,11 +63,6 @@ paste = { workspace = true }
 smallvec = { workspace = true }
 tokio = { workspace = true }
 unchecked-index = { workspace = true }
-prost = { workspace = true }
-prost-types = { workspace = true }
-prost-reflect = { workspace = true }
-rdkafka = { workspace = true }
-sonic-rs = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 procfs = { workspace = true }


### PR DESCRIPTION
<!--
  - Start the PR title with the related issue ID, e.g. '[AURON #XXXX] Short summary...'.
-->
# Which issue does this PR close?

Closes #2003

# Rationale for this change

# What changes are included in this PR?
Move `version, license, edition` from sub-crates to root workspace.package.
Keep `resolver` in sub-crates since it does not support workspace inheritance.

# Are there any user-facing changes?

# How was this patch tested?
