### PR TITLE
[AURON #2013] Auto-lock Scala version in Spark profiles.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -778,7 +778,31 @@
         <sparkVersion>3.0.3</sparkVersion>
         <shortSparkVersion>3.0</shortSparkVersion>
         <nettyVersion>4.1.47.Final</nettyVersion>
+        <scalaVersion>2.12</scalaVersion>
+        <scalaLongVersion>2.12.18</scalaLongVersion>
       </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>net.alchim31.maven</groupId>
+            <artifactId>scala-maven-plugin</artifactId>
+            <configuration>
+              <compilerPlugins combine.self="override">
+                <compilerPlugin>
+                  <groupId>org.scalameta</groupId>
+                  <artifactId>semanticdb-scalac_${scalaLongVersion}</artifactId>
+                  <version>${semanticdb.version}</version>
+                </compilerPlugin>
+                <compilerPlugin>
+                  <groupId>org.scalamacros</groupId>
+                  <artifactId>paradise_${scalaLongVersion}</artifactId>
+                  <version>${scalamacros.paradise.version}</version>
+                </compilerPlugin>
+              </compilerPlugins>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
 
     <profile>
@@ -789,7 +813,31 @@
         <sparkVersion>3.1.3</sparkVersion>
         <shortSparkVersion>3.1</shortSparkVersion>
         <nettyVersion>4.1.51.Final</nettyVersion>
+        <scalaVersion>2.12</scalaVersion>
+        <scalaLongVersion>2.12.18</scalaLongVersion>
       </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>net.alchim31.maven</groupId>
+            <artifactId>scala-maven-plugin</artifactId>
+            <configuration>
+              <compilerPlugins combine.self="override">
+                <compilerPlugin>
+                  <groupId>org.scalameta</groupId>
+                  <artifactId>semanticdb-scalac_${scalaLongVersion}</artifactId>
+                  <version>${semanticdb.version}</version>
+                </compilerPlugin>
+                <compilerPlugin>
+                  <groupId>org.scalamacros</groupId>
+                  <artifactId>paradise_${scalaLongVersion}</artifactId>
+                  <version>${scalamacros.paradise.version}</version>
+                </compilerPlugin>
+              </compilerPlugins>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
 
     <profile>
@@ -800,7 +848,31 @@
         <sparkVersion>3.2.4</sparkVersion>
         <shortSparkVersion>3.2</shortSparkVersion>
         <nettyVersion>4.1.68.Final</nettyVersion>
+        <scalaVersion>2.12</scalaVersion>
+        <scalaLongVersion>2.12.18</scalaLongVersion>
       </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>net.alchim31.maven</groupId>
+            <artifactId>scala-maven-plugin</artifactId>
+            <configuration>
+              <compilerPlugins combine.self="override">
+                <compilerPlugin>
+                  <groupId>org.scalameta</groupId>
+                  <artifactId>semanticdb-scalac_${scalaLongVersion}</artifactId>
+                  <version>${semanticdb.version}</version>
+                </compilerPlugin>
+                <compilerPlugin>
+                  <groupId>org.scalamacros</groupId>
+                  <artifactId>paradise_${scalaLongVersion}</artifactId>
+                  <version>${scalamacros.paradise.version}</version>
+                </compilerPlugin>
+              </compilerPlugins>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
 
     <profile>
@@ -811,7 +883,31 @@
         <sparkVersion>3.3.4</sparkVersion>
         <shortSparkVersion>3.3</shortSparkVersion>
         <nettyVersion>4.1.74.Final</nettyVersion>
+        <scalaVersion>2.12</scalaVersion>
+        <scalaLongVersion>2.12.18</scalaLongVersion>
       </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>net.alchim31.maven</groupId>
+            <artifactId>scala-maven-plugin</artifactId>
+            <configuration>
+              <compilerPlugins combine.self="override">
+                <compilerPlugin>
+                  <groupId>org.scalameta</groupId>
+                  <artifactId>semanticdb-scalac_${scalaLongVersion}</artifactId>
+                  <version>${semanticdb.version}</version>
+                </compilerPlugin>
+                <compilerPlugin>
+                  <groupId>org.scalamacros</groupId>
+                  <artifactId>paradise_${scalaLongVersion}</artifactId>
+                  <version>${scalamacros.paradise.version}</version>
+                </compilerPlugin>
+              </compilerPlugins>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
 
     <profile>
@@ -822,7 +918,31 @@
         <sparkVersion>3.4.4</sparkVersion>
         <shortSparkVersion>3.4</shortSparkVersion>
         <nettyVersion>4.1.87.Final</nettyVersion>
+        <scalaVersion>2.12</scalaVersion>
+        <scalaLongVersion>2.12.18</scalaLongVersion>
       </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>net.alchim31.maven</groupId>
+            <artifactId>scala-maven-plugin</artifactId>
+            <configuration>
+              <compilerPlugins combine.self="override">
+                <compilerPlugin>
+                  <groupId>org.scalameta</groupId>
+                  <artifactId>semanticdb-scalac_${scalaLongVersion}</artifactId>
+                  <version>${semanticdb.version}</version>
+                </compilerPlugin>
+                <compilerPlugin>
+                  <groupId>org.scalamacros</groupId>
+                  <artifactId>paradise_${scalaLongVersion}</artifactId>
+                  <version>${scalamacros.paradise.version}</version>
+                </compilerPlugin>
+              </compilerPlugins>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
 
     <profile>
@@ -833,7 +953,31 @@
         <sparkVersion>3.5.8</sparkVersion>
         <shortSparkVersion>3.5</shortSparkVersion>
         <nettyVersion>4.1.96.Final</nettyVersion>
+        <scalaVersion>2.12</scalaVersion>
+        <scalaLongVersion>2.12.18</scalaLongVersion>
       </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>net.alchim31.maven</groupId>
+            <artifactId>scala-maven-plugin</artifactId>
+            <configuration>
+              <compilerPlugins combine.self="override">
+                <compilerPlugin>
+                  <groupId>org.scalameta</groupId>
+                  <artifactId>semanticdb-scalac_${scalaLongVersion}</artifactId>
+                  <version>${semanticdb.version}</version>
+                </compilerPlugin>
+                <compilerPlugin>
+                  <groupId>org.scalamacros</groupId>
+                  <artifactId>paradise_${scalaLongVersion}</artifactId>
+                  <version>${scalamacros.paradise.version}</version>
+                </compilerPlugin>
+              </compilerPlugins>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
 
     <profile>
@@ -844,6 +988,8 @@
         <sparkVersion>4.0.2</sparkVersion>
         <shortSparkVersion>4.0</shortSparkVersion>
         <nettyVersion>4.1.111.Final</nettyVersion>
+        <scalaVersion>2.13</scalaVersion>
+        <scalaLongVersion>2.13.17</scalaLongVersion>
       </properties>
       <build>
         <plugins>
@@ -874,6 +1020,33 @@
               </execution>
             </executions>
           </plugin>
+          <plugin>
+            <groupId>net.alchim31.maven</groupId>
+            <artifactId>scala-maven-plugin</artifactId>
+            <configuration>
+              <args combine.self="override">
+                <arg>-Ymacro-annotations</arg>
+                <arg>-Wconf:cat=deprecation:wv,any:e</arg>
+                <arg>-Wconf:cat=other-nullary-override:s</arg>
+                <arg>-Wconf:msg=^(?=.*?method|value|type|object|trait|inheritance)(?=.*?deprecated)(?=.*?since 2.13).+$:s</arg>
+                <arg>-Wconf:msg=Auto-application to \`\(\)\` is deprecated:s</arg>
+                <arg>-Wconf:msg=object JavaConverters in package collection is deprecated:s</arg>
+                <arg>-Wconf:cat=unchecked&amp;msg=outer reference:s</arg>
+                <arg>-Wconf:cat=unchecked&amp;msg=eliminated by erasure:s</arg>
+                <arg>-Wconf:cat=unused-nowarn:s</arg>
+                <arg>-Wconf:msg=early initializers are deprecated:s</arg>
+                <arg>-Wconf:cat=other-match-analysis:s</arg>
+                <arg>-Wconf:cat=feature-existentials:s</arg>
+              </args>
+              <compilerPlugins combine.self="override">
+                <compilerPlugin>
+                  <groupId>org.scalameta</groupId>
+                  <artifactId>semanticdb-scalac_${scalaLongVersion}</artifactId>
+                  <version>${semanticdb.version}</version>
+                </compilerPlugin>
+              </compilerPlugins>
+            </configuration>
+          </plugin>
         </plugins>
       </build>
     </profile>
@@ -886,6 +1059,8 @@
         <sparkVersion>4.1.1</sparkVersion>
         <shortSparkVersion>4.1</shortSparkVersion>
         <nettyVersion>4.1.118.Final</nettyVersion>
+        <scalaVersion>2.13</scalaVersion>
+        <scalaLongVersion>2.13.17</scalaLongVersion>
       </properties>
       <build>
         <plugins>
@@ -915,6 +1090,33 @@
                 </configuration>
               </execution>
             </executions>
+          </plugin>
+          <plugin>
+            <groupId>net.alchim31.maven</groupId>
+            <artifactId>scala-maven-plugin</artifactId>
+            <configuration>
+              <args combine.self="override">
+                <arg>-Ymacro-annotations</arg>
+                <arg>-Wconf:cat=deprecation:wv,any:e</arg>
+                <arg>-Wconf:cat=other-nullary-override:s</arg>
+                <arg>-Wconf:msg=^(?=.*?method|value|type|object|trait|inheritance)(?=.*?deprecated)(?=.*?since 2.13).+$:s</arg>
+                <arg>-Wconf:msg=Auto-application to \`\(\)\` is deprecated:s</arg>
+                <arg>-Wconf:msg=object JavaConverters in package collection is deprecated:s</arg>
+                <arg>-Wconf:cat=unchecked&amp;msg=outer reference:s</arg>
+                <arg>-Wconf:cat=unchecked&amp;msg=eliminated by erasure:s</arg>
+                <arg>-Wconf:cat=unused-nowarn:s</arg>
+                <arg>-Wconf:msg=early initializers are deprecated:s</arg>
+                <arg>-Wconf:cat=other-match-analysis:s</arg>
+                <arg>-Wconf:cat=feature-existentials:s</arg>
+              </args>
+              <compilerPlugins combine.self="override">
+                <compilerPlugin>
+                  <groupId>org.scalameta</groupId>
+                  <artifactId>semanticdb-scalac_${scalaLongVersion}</artifactId>
+                  <version>${semanticdb.version}</version>
+                </compilerPlugin>
+              </compilerPlugins>
+            </configuration>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
### Which issue does this PR close?

Closes #2013

### Rationale for this change

Currently, when developing in IntelliJ IDEA, users need to manually select both a Spark profile (e.g., `spark-3.5`) and a Scala profile (e.g., `scala-2.12`) to ensure correct compilation. This two-step configuration is error-prone and can lead to compatibility issues if mismatched.

This change simplifies the workflow by automatically locking the Scala version and compiler configuration when a Spark profile is selected.

### What changes are included in this PR?

1. **Scala version properties**:
- Spark 3.x profiles: `scalaVersion=2.12`, `scalaLongVersion=2.12.18`
- Spark 4.x profiles: `scalaVersion=2.13`, `scalaLongVersion=2.13.17`

2. **scala-maven-plugin configuration**:
- Spark 3.x: Added `semanticdb-scalac` + `paradise` compiler plugins
- Spark 4.x: Added `-Ymacro-annotations` args + `semanticdb-scalac` plugin (without paradise)
- Used `combine.self="override"` to prevent configuration merging with base settings

### Are there any user-facing changes?

Yes. Users now only need to select a Spark profile (e.g., `spark-3.5`) in IDEA, and the corresponding Scala version will be automatically configured. No need to manually select separate `scala-2.12` or `scala-2.13` profiles.

### How was this patch tested?

Verified in IntelliJ IDEA by:
1. Selecting only `spark-3.5` profile → Scala 2.12.18 correctly configured
2. Selecting only `spark-4.0` profile → Scala 2.13.17 correctly configured
3. No need to select separate `scala-2.12` or `scala-2.13` profiles