### PR TITLE
[AURON #2020] [BUILD] Add `--threads` option to control Maven build parallelism.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,6 +128,7 @@ Run `./auron-build.sh --help` to see all available options, including:
 - `--celeborn`, `--uniffle`, `--paimon`, `--iceberg`: Optional integrations
 - `--skiptests`: Skip unit tests (default: true)
 - `--sparktests`: Run Spark integration tests
+- `--threads`: Maven build threads (e.g. 1, 4, 1C). Defaults to single-threaded local builds; Docker defaults to 8 unless overridden.
 
 ### Running Tests
 

--- a/auron-build.sh
+++ b/auron-build.sh
@@ -55,6 +55,7 @@ print_help() {
     echo "  --skiptests <true|false> Skip unit tests (default: true)"
     echo "  --sparktests <true|false> Run spark tests (default: false)"
     echo "  --docker <true|false>    Build in Docker environment (default: false)"
+    echo "  --threads <N|NC>         Maven build threads (e.g. 1, 4, 1C). Default: local unset, docker 8"
     IFS=','; echo "  --image <NAME>           Docker image to use (e.g. ${SUPPORTED_OS_IMAGES[*]}, default: ${SUPPORTED_OS_IMAGES[*]:0:1})"; unset IFS
     IFS=','; echo "  --sparkver <VERSION>     Specify Spark version (e.g. ${SUPPORTED_SPARK_VERSIONS[*]})"; unset IFS
     IFS=','; echo "  --flinkver <VERSION>     Specify Flink version (e.g. ${SUPPORTED_FLINK_VERSIONS[*]})"; unset IFS
@@ -126,6 +127,7 @@ RELEASE_PROFILE=false
 CLEAN=true
 SKIP_TESTS=true
 SPARK_TESTS=false
+THREADS=""
 SPARK_VER=""
 FLINK_VER=""
 SCALA_VER=""
@@ -155,6 +157,21 @@ while [[ $# -gt 0 ]]; do
                 shift 2
             else
                 echo "ERROR: --docker requires true/false" >&2
+                exit 1
+            fi
+            ;;
+        --threads)
+            if [[ -n "$2" && "$2" != -* ]]; then
+                THREADS="$2"
+                # Validate THREADS to prevent command injection when passed through Docker
+                # Maven -T accepts an integer, optionally followed by 'C' (e.g., 4, 8, 2C)
+                if [[ ! "$THREADS" =~ ^[0-9]+C?$ ]]; then
+                    echo "ERROR: Invalid --threads value '$THREADS'. Expected digits with optional 'C' (e.g., 4, 8, 2C)." >&2
+                    exit 1
+                fi
+                shift 2
+            else
+                echo "ERROR: --threads requires a value (e.g. 1, 4, 1C)" >&2
                 exit 1
             fi
             ;;
@@ -316,6 +333,31 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+# Detect conflict between --threads and raw Maven -T arguments.
+if [[ -n "$THREADS" ]]; then
+    HAS_MVN_THREADS=false
+    PREV_MVN_ARG=""
+    for arg in "$@"; do
+        if [[ "$PREV_MVN_ARG" == "-T" ]]; then
+            HAS_MVN_THREADS=true
+            break
+        fi
+        if [[ "$arg" == "-T" ]]; then
+            PREV_MVN_ARG="-T"
+            continue
+        fi
+        if [[ "$arg" =~ ^-T.+ ]]; then
+            HAS_MVN_THREADS=true
+            break
+        fi
+        PREV_MVN_ARG=""
+    done
+    if [[ "$HAS_MVN_THREADS" == true ]]; then
+        echo "ERROR: Do not combine --threads with Maven -T options. Use only one." >&2
+        exit 1
+    fi
+fi
+
 # -----------------------------------------------------------------------------
 # Section: Argument Validation
 # Description:
@@ -396,6 +438,15 @@ if [[ -n "$ICEBERG_VER" ]]; then
     BUILD_ARGS+=("-Piceberg-$ICEBERG_VER")
 fi
 
+# Configure Maven build threads:
+# - local builds default to Maven's single-threaded behavior
+# - docker builds default to -T8 unless overridden
+if [[ -n "$THREADS" ]]; then
+    BUILD_ARGS+=("-T$THREADS")
+elif [[ "$USE_DOCKER" == true ]]; then
+    BUILD_ARGS+=("-T8")
+fi
+
 MVN_ARGS=("${CLEAN_ARGS[@]}" "${BUILD_ARGS[@]}")
 
 # -----------------------------------------------------------------------------
@@ -470,8 +521,6 @@ fi
 # -----------------------------------------------------------------------------
 if [[ "$USE_DOCKER" == true ]]; then
     echo "[INFO] Compiling inside Docker container using image: $IMAGE_NAME"
-    # In Docker mode, use multi-threaded Maven build with -T8 for faster compilation
-    BUILD_ARGS+=("-T8")
     if [[ "$CLEAN" == true ]]; then
         # Clean the host-side directory that is mounted into the Docker container.
         # This avoids "device or resource busy" errors when running `mvn clean` inside the container.


### PR DESCRIPTION
### Which issue does this PR close?

Closes #2020

### Rationale for this change

Currently, local builds are always single-threaded, which can be slow on multi-core machines. Docker builds hardcode `-T8`, which cannot be overridden by users. This change adds a `--threads` option to `auron-build.sh` to give users control over Maven build parallelism.


### What changes are included in this PR?

1. **auron-build.sh**
   - Added `--threads` parameter parsing and validation
   - Unified thread configuration logic: user-specified value takes precedence, Docker defaults to 8 threads, local defaults to single-threaded
   - Removed hardcoded `-T8` from Docker build section
   - Updated help text to document the new option

2. **CONTRIBUTING.md**
   - Documented `--threads` option under Build Options section
   - Described default behavior for local vs Docker builds

### Are there any user-facing changes?

Yes. Users can now specify `--threads` to control Maven build parallelism

Default behavior remains unchanged (backward compatible):
- Local builds: single-threaded
- Docker builds: 8 threads

### How was this patch tested?

- Verified `./auron-build.sh --help` displays correct usage information