### PR TITLE
[AURON #2028] Fix extra brace in SparkOnHeapSpillManager log message.

### DIFF
--- a/spark-extension/src/main/scala/org/apache/spark/sql/auron/memory/SparkOnHeapSpillManager.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/auron/memory/SparkOnHeapSpillManager.scala
@@ -158,7 +158,7 @@ class SparkOnHeapSpillManager(taskContext: TaskContext)
       return 0L
     }
 
-    logInfo(s"starts spilling to disk, size=${Utils.bytesToString(size)}}")
+    logInfo(s"starts spilling to disk, size=${Utils.bytesToString(size)}")
     dumpStatus()
     var totalFreed = 0L
 


### PR DESCRIPTION

### Which issue does this PR close?

Closes #2028

### Rationale for this change

There is an extra closing brace in the log message in `SparkOnHeapSpillManager.scala` at line 161, causing improper log formatting.

### What changes are included in this PR?

Remove the extra closing brace `}` from the log message

### Are there any user-facing changes?

No.

### How was this patch tested?

Exists Junit Test.