### PR TITLE
[AURON #2043] Bump hadoop from 3.4.2 to 3.4.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <arrowVersion>16.0.0</arrowVersion>
     <bytebuddyVersion>1.14.11</bytebuddyVersion>
-    <hadoopVersion>3.4.2</hadoopVersion>
+    <hadoopVersion>3.4.3</hadoopVersion>
     <protobufVersion>3.25.5</protobufVersion>
     <nettyVersion>4.2.7.Final</nettyVersion>
     <javaVersion>8</javaVersion>


### PR DESCRIPTION
<!--
  - Start the PR title with the related issue ID, e.g. '[AURON #XXXX] Short summary...'.
-->
# Which issue does this PR close?

Closes #2043 

# Rationale for this change
Hadoop 3.4.3 has been released, and we’re planning to upgrade our Hadoop version to 3.4.3.

# What changes are included in this PR?

# Are there any user-facing changes?

# How was this patch tested?
