### PR TITLE
[AURON #2047] Fix Scala 2.13 CI NoClassDefFoundError

### DIFF
--- a/.github/workflows/tpcds-reusable.yml
+++ b/.github/workflows/tpcds-reusable.yml
@@ -226,7 +226,7 @@ jobs:
         if: steps.cache-spark-bin.outputs.cache-hit != 'true'
         run: |
           SPARK_PATH="spark/spark-${{ steps.get-dependency-version.outputs.sparkversion }}"
-          if [ ${{ inputs.scalaver }} = "2.13" && "${{ inputs.sparkver }}" != "spark-4.0" && "${{ inputs.sparkver }}" != "spark-4.1" ]; then
+          if [[ ${{ inputs.scalaver }} = "2.13" && "${{ inputs.sparkver }}" != "spark-4.0" && "${{ inputs.sparkver }}" != "spark-4.1" ]]; then
             SPARK_FILE="spark-${{ steps.get-dependency-version.outputs.sparkversion }}-bin-${{ inputs.hadoop-profile }}-scala${{ inputs.scalaver }}.tgz"
           else
             SPARK_FILE="spark-${{ steps.get-dependency-version.outputs.sparkversion }}-bin-${{ inputs.hadoop-profile }}.tgz"


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2047

# Rationale for this change

```bash
  if [ 2.13 = "2.13" && "spark-3.5" != "spark-4.0" && "spark-3.5" != "spark-4.1" ]; then
    SPARK_FILE="spark-3.5.8-bin-hadoop3-scala2.13.tgz"
  else
    SPARK_FILE="spark-3.5.8-bin-hadoop3.tgz"
  fi
```

```
/home/runner/work/_temp/5e39dd44-8905-4fc9-ad30-a316cba0dc50.sh: line 2: [: missing `]'
--2026-02-27 05:16:45--  https://www.apache.org/dyn/closer.lua/spark/spark-3.5.8/spark-3.5.8-bin-hadoop3.tgz?action=download
```

https://github.com/apache/auron/actions/runs/22473356538/job/65096490529?pr=2040


# What changes are included in this PR?

# Are there any user-facing changes?

# How was this patch tested?
GHA

```
--2026-02-27 13:27:10--  https://www.apache.org/dyn/closer.lua/spark/spark-3.5.8/spark-3.5.8-bin-hadoop3-scala2.13.tgz?action=download
```