### PR TITLE
[AURON #2076] Fix typos and unnecessary memory allocation in native engine

### DIFF
--- a/native-engine/datafusion-ext-plans/src/flink/serde/pb_deserializer.rs
+++ b/native-engine/datafusion-ext-plans/src/flink/serde/pb_deserializer.rs
@@ -176,7 +176,7 @@ impl PbDeserializer {
             nested_msg_mapping.clone(),
             &skip_fields,
         )
-        .expect("Failed to transfer output scheam to pb scheam");
+        .expect("Failed to transfer output schema to pb schema");
 
         let tag_to_output_mapping =
             create_tag_to_output_mapping(message_descriptor.clone(), &pb_schema);
@@ -284,12 +284,13 @@ fn transfer_output_schema_to_pb_schema(
             let index_start = field_name.find(".");
             if let Some(index) = index_start {
                 let msg_field_name = &field_name[..index];
-                let msg_field_desc =
-                    message_descriptor
-                        .get_field_by_name(msg_field_name)
-                        .expect(&format!(
-                            "nested field {msg_field_name} not exits in message_descriptor"
-                        ));
+                let msg_field_desc = message_descriptor
+                    .get_field_by_name(msg_field_name)
+                    .ok_or_else(|| {
+                        DataFusionError::Execution(format!(
+                            "nested field {msg_field_name} does not exist in message_descriptor"
+                        ))
+                    })?;
                 if let Kind::Message(sub_message_desc) = msg_field_desc.kind() {
                     if !msg_set.contains(msg_field_name) {
                         let sub_fields = sub_pb_schema_mapping
@@ -318,18 +319,24 @@ fn transfer_output_schema_to_pb_schema(
                     return df_execution_err!("not message field");
                 }
             } else {
-                let msg_field_desc =
-                    message_descriptor
-                        .get_field_by_name(field_name)
-                        .expect(&format!(
-                            "nested innermost field {field_name} not exits in message_descriptor"
-                        ));
+                let msg_field_desc = message_descriptor
+                    .get_field_by_name(field_name)
+                    .ok_or_else(|| {
+                        DataFusionError::Execution(format!(
+                            "nested innermost field {field_name} does not exist in message_descriptor"
+                        ))
+                    })?;
                 pb_schema_fields.push(create_arrow_field(msg_field_desc.clone(), skip_fields));
             }
         } else {
             let msg_field_desc = message_descriptor
                 .get_field_by_name(field.name())
-                .expect(&format!("{} not exits in message_descriptor", field.name()));
+                .ok_or_else(|| {
+                    DataFusionError::Execution(format!(
+                        "{} does not exist in message_descriptor",
+                        field.name()
+                    ))
+                })?;
             pb_schema_fields.push(create_arrow_field(msg_field_desc.clone(), skip_fields));
         }
     }
@@ -549,9 +556,11 @@ fn create_output_array_builders(
         let field_name = field.name();
         let field_desc = message_descriptor
             .get_field_by_name(field_name)
-            .expect(&format!(
-                "Field {field_name} not exits in message_descriptor",
-            ));
+            .ok_or_else(|| {
+                DataFusionError::Execution(format!(
+                    "Field {field_name} does not exist in message_descriptor"
+                ))
+            })?;
         match field.data_type() {
             DataType::Boolean => {
                 array_builders.push(SharedArrayBuilder::new(BooleanBuilder::new()));

--- a/native-engine/datafusion-ext-plans/src/orc_exec.rs
+++ b/native-engine/datafusion-ext-plans/src/orc_exec.rs
@@ -1434,7 +1434,7 @@ mod tests {
                 col_name,
                 schema
                     .index_of(col_name)
-                    .expect(&format!("Column '{col_name}' not found")),
+                    .expect("Column not found in schema"),
             ));
             let null_lit = Arc::new(Literal::new(null_value));
             let expr = Arc::new(BinaryExpr::new(col, Operator::Eq, null_lit));


### PR DESCRIPTION
<!--
  - Start the PR title with the related issue ID, e.g. '[AURON #XXXX] Short summary...'.
-->
# Which issue does this PR close?
Closes #2076

# Rationale for this change
Fix typos, improve unnecessary memory usage.

# What changes are included in this PR?
Fix typos.
Use `unwrap_or_else(|| panic` instead of `expect(&format`.

# Are there any user-facing changes?
No.

# How was this patch tested?
UT & manual tests