### PR TITLE
[AURON #2107] Fix driver spill NPE error

### DIFF
--- a/native-engine/auron-jni-bridge/src/jni_bridge.rs
+++ b/native-engine/auron-jni-bridge/src/jni_bridge.rs
@@ -1535,7 +1535,7 @@ pub struct AuronOnHeapSpillManager<'a> {
     pub method_releaseSpill_ret: ReturnType,
 }
 impl<'a> AuronOnHeapSpillManager<'a> {
-    pub const SIG_TYPE: &'static str = "org/apache/spark/sql/auron/memory/SparkOnHeapSpillManager";
+    pub const SIG_TYPE: &'static str = "org/apache/auron/memory/OnHeapSpillManager";
 
     pub fn new(env: &JNIEnv<'a>) -> JniResult<AuronOnHeapSpillManager<'a>> {
         let class = get_global_jclass(env, Self::SIG_TYPE)?;

--- a/spark-extension/src/main/scala/org/apache/spark/sql/auron/memory/SparkOnHeapSpillManager.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/auron/memory/SparkOnHeapSpillManager.scala
@@ -195,6 +195,10 @@ object SparkOnHeapSpillManager extends Logging {
 
   def current: OnHeapSpillManager = {
     val tc = TaskContext.get
-    all.getOrElseUpdate(tc.taskAttemptId(), new SparkOnHeapSpillManager(tc))
+    if (tc != null) {
+      all.getOrElseUpdate(tc.taskAttemptId(), new SparkOnHeapSpillManager(tc))
+    } else {
+      OnHeapSpillManager.getDisabledOnHeapSpillManager
+    }
   }
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2107

# Rationale for this change
When `SparkOnHeapSpillManager.current` is called on the driver side, `TaskContext.get` returns null, causing a NPE.

# What changes are included in this PR?
Add a null check when TaskContext is unavailable.
Update the JNI bridge SIG_TYPE to resolve methods against the OnHeapSpillManager.

# Are there any user-facing changes?
No.

# How was this patch tested?
UT
