### PR TITLE
[AURON #2116] Make libInputStream auto-close when creating in Flink/Spark AuronAdaptor.

### DIFF
--- a/auron-flink-extension/auron-flink-runtime/src/main/java/org/apache/auron/jni/FlinkAuronAdaptor.java
+++ b/auron-flink-extension/auron-flink-runtime/src/main/java/org/apache/auron/jni/FlinkAuronAdaptor.java
@@ -35,8 +35,7 @@ public class FlinkAuronAdaptor extends AuronAdaptor {
     public void loadAuronLib() {
         String libName = System.mapLibraryName("auron");
         ClassLoader classLoader = AuronAdaptor.class.getClassLoader();
-        try {
-            InputStream libInputStream = classLoader.getResourceAsStream(libName);
+        try (InputStream libInputStream = classLoader.getResourceAsStream(libName)) {
             File tempFile = File.createTempFile("libauron-", ".tmp");
             tempFile.deleteOnExit();
             Files.copy(libInputStream, tempFile.toPath(), StandardCopyOption.REPLACE_EXISTING);

--- a/spark-extension/src/main/java/org/apache/auron/jni/SparkAuronAdaptor.java
+++ b/spark-extension/src/main/java/org/apache/auron/jni/SparkAuronAdaptor.java
@@ -42,8 +42,7 @@ public class SparkAuronAdaptor extends AuronAdaptor {
     public void loadAuronLib() {
         String libName = System.mapLibraryName("auron");
         ClassLoader classLoader = AuronAdaptor.class.getClassLoader();
-        try {
-            InputStream libInputStream = classLoader.getResourceAsStream(libName);
+        try (InputStream libInputStream = classLoader.getResourceAsStream(libName)) {
             File tempFile = File.createTempFile("libauron-", ".tmp");
             tempFile.deleteOnExit();
             Files.copy(libInputStream, tempFile.toPath(), StandardCopyOption.REPLACE_EXISTING);


### PR DESCRIPTION


<!--
  - Start the PR title with the related issue ID, e.g. '[AURON #XXXX] Short summary...'.
-->
# Which issue does this PR close?

Closes #2116

# Rationale for this change

fix the input stream leaking.

# What changes are included in this PR?

Make libInputStream auto-close when creating in FlinkAuronAdaptor.java

# Are there any user-facing changes?

N.A

# How was this patch tested?

N.A
