### PR TITLE
[AURON #2119] Add `isTaskRunning` method to check task status in SparkAuronAdaptor

### DIFF
--- a/spark-extension/src/main/java/org/apache/auron/jni/SparkAuronAdaptor.java
+++ b/spark-extension/src/main/java/org/apache/auron/jni/SparkAuronAdaptor.java
@@ -54,6 +54,15 @@ public class SparkAuronAdaptor extends AuronAdaptor {
     }
 
     @Override
+    public boolean isTaskRunning() {
+        TaskContext tc = TaskContext$.MODULE$.get();
+        if (tc == null) { // driver is always running
+            return true;
+        }
+        return !tc.isCompleted() && !tc.isInterrupted();
+    }
+
+    @Override
     public Object getThreadContext() {
         return TaskContext$.MODULE$.get();
     }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2119

# Rationale for this change

When Spark initiates a task kill (e.g. stage cancellation, speculative execution kill, or user-triggered job cancellation), the Rust native engine always receives true from the JNI callback JniBridge.isTaskRunning(), making it unable to detect that the task has already been killed.

# What changes are included in this PR?

# Are there any user-facing changes?

# How was this patch tested?
