### PR TITLE
[AURON #2132] Add native support for instr function

### DIFF
--- a/spark-extension-shims-spark/src/test/scala/org/apache/auron/AuronFunctionSuite.scala
+++ b/spark-extension-shims-spark/src/test/scala/org/apache/auron/AuronFunctionSuite.scala
@@ -137,6 +137,25 @@ class AuronFunctionSuite extends AuronQueryTest with BaseAuronSQLSuite {
     }
   }
 
+  test("instr function") {
+    withTable("t1") {
+      sql(
+        "create table t1(c1 string, c2 string, c3 string, c4 string, c5 string, c6 string, c7 string) using parquet")
+      sql("insert into t1 values('hello', 'll', 'x', '', 'abc', null, 'a')")
+
+      val query =
+        """select
+          |  instr(c1, c2),
+          |  instr(c1, c3),
+          |  instr(c1, c4),
+          |  instr(c6, c7),
+          |  instr(c5, c6)
+          |from t1
+          |""".stripMargin
+      checkSparkAnswerAndOperator(query)
+    }
+  }
+
   test("round function with varying scales for intPi") {
     withTable("t2") {
       sql("CREATE TABLE t2 (c1 INT) USING parquet")

--- a/spark-extension/src/main/scala/org/apache/spark/sql/auron/NativeConverters.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/auron/NativeConverters.scala
@@ -930,6 +930,8 @@ object NativeConverters extends Logging {
 
       case e: Levenshtein =>
         buildScalarFunction(pb.ScalarFunction.Levenshtein, e.children, e.dataType)
+      case e: StringInstr =>
+        buildScalarFunction(pb.ScalarFunction.Strpos, e.children, e.dataType)
 
       case e: Hour if datetimeExtractEnabled =>
         buildTimePartExt("Spark_Hour", e.children.head, isPruningExpr, fallback)


### PR DESCRIPTION

# Which issue does this PR close?
Closes #https://github.com/apache/auron/issues/2132

# Rationale for this change
To improve compatibility with Spark SQL string functions, we should support `instr(str, substr)` with Spark-compatible semantics.

Expected behavior

Function name: `instr(str, substr)`

Return value:
- Returns the 1-based index of the first occurrence of `substr` in `str`
- Returns `0` if `substr` is not found
- Returns `1` if `substr` is an empty string
- Returns `NULL` if either argument is `NULL`

Examples:
- `instr('hello', 'll')` -> `3`
- `instr('hello', 'x')` -> `0`
- `instr('hello', '')` -> `1`

This behavior should match Spark SQL and work consistently for literal and expression inputs.


# What changes are included in this PR?
This PR adds support for the Spark SQL `instr()` function in the native conversion path.
The following changes are included:

- Added `StringInstr` expression support in `NativeConverters`
- Mapped Spark `instr(str, substr)` to the existing native `strpos` scalar function
- Added regression tests to verify correctness for:
  - successful substring match
  - substring not found
  - empty substring handling
  - null input handling

# Are there any user-facing changes?
NO.
# How was this patch tested?
CI.