### PR TITLE
[AURON #1848] fix pb list name missing

### DIFF
--- a/native-engine/datafusion-ext-plans/src/flink/serde/json_deserializer.rs
+++ b/native-engine/datafusion-ext-plans/src/flink/serde/json_deserializer.rs
@@ -281,6 +281,7 @@ fn create_shared_array_builder_by_data_type(data_type: &DataType) -> Result<Shar
             let values_builder = create_shared_array_builder_by_data_type(field_ref.data_type())?;
             Ok(SharedArrayBuilder::new(SharedListArrayBuilder::new(
                 values_builder,
+                Some(field_ref.clone()),
             )))
         }
         DataType::Map(field_ref, _) => {

--- a/native-engine/datafusion-ext-plans/src/flink/serde/pb_deserializer.rs
+++ b/native-engine/datafusion-ext-plans/src/flink/serde/pb_deserializer.rs
@@ -620,6 +620,7 @@ fn create_output_array_builders(
                         field_desc,
                     )
                     .expect("List create_shared_array_builder_by_data_type failed"),
+                    Some(field_ref.clone()),
                 )));
             }
             other => {
@@ -707,6 +708,7 @@ fn create_shared_array_builder_by_data_type(
             return Ok(SharedArrayBuilder::new(SharedListArrayBuilder::new(
                 create_shared_array_builder_by_data_type(field_ref.data_type().clone(), field_desc)
                     .expect("List create_shared_array_builder_by_data_type failed"),
+                Some(field_ref.clone()),
             )));
         }
         other => return df_execution_err!("Unsupported data type for Arrow conversion: {other:?}"),

--- a/native-engine/datafusion-ext-plans/src/flink/serde/shared_list_array_builder.rs
+++ b/native-engine/datafusion-ext-plans/src/flink/serde/shared_list_array_builder.rs
@@ -63,10 +63,10 @@ impl ArrayBuilder for SharedListArrayBuilder {
 impl SharedListArrayBuilder {
     /// Creates a new [`SharedArrayListBuilder`] from a given values array
     /// builder
-    pub(crate) fn new(values_builder: SharedArrayBuilder) -> Self {
+    pub(crate) fn new(values_builder: SharedArrayBuilder, field: Option<FieldRef>) -> Self {
         let capacity = values_builder.len();
         let appender = adaptive_append_children(&values_builder);
-        Self::with_capacity(values_builder, capacity, appender)
+        Self::with_capacity(values_builder, capacity, appender, field)
     }
 
     /// Creates a new [`SharedArrayListBuilder`] with specified capacity
@@ -74,6 +74,7 @@ impl SharedListArrayBuilder {
         values_builder: SharedArrayBuilder,
         capacity: usize,
         adaptive_append_children: Option<Box<dyn FnMut(usize) + Send + Sync>>,
+        field: Option<FieldRef>,
     ) -> Self {
         let mut offsets_builder = BufferBuilder::<i32>::new(capacity + 1);
         offsets_builder.append(0);
@@ -81,7 +82,7 @@ impl SharedListArrayBuilder {
             offsets_builder,
             null_buffer_builder: NullBufferBuilder::new(capacity),
             values_builder,
-            field: None,
+            field,
             current_offset: 0,
             adaptive_append_children,
         }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1848 

# Rationale for this change
* PB list type add field names

# What changes are included in this PR?
* shared_list_array_builder add `FieldRef`

# Are there any user-facing changes?
* No

# How was this patch tested?
* No