### PR TITLE
[AURON #2118] make native environment initialization retriable after failure

### DIFF
--- a/auron-core/src/main/java/org/apache/auron/jni/AuronCallNativeWrapper.java
+++ b/auron-core/src/main/java/org/apache/auron/jni/AuronCallNativeWrapper.java
@@ -53,27 +53,7 @@ public class AuronCallNativeWrapper {
     private Schema arrowSchema;
     private long nativeRuntimePtr;
     private Consumer<VectorSchemaRoot> batchConsumer;
-
-    // initialize native environment
-    static {
-        LOG.info("Initializing native environment (batchSize="
-                + AuronAdaptor.getInstance().getAuronConfiguration().get(AuronConfiguration.BATCH_SIZE) + ", "
-                + "memoryFraction="
-                + AuronAdaptor.getInstance().getAuronConfiguration().get(AuronConfiguration.MEMORY_FRACTION) + ")");
-
-        // arrow configuration
-        System.setProperty("arrow.struct.conflict.policy", "CONFLICT_APPEND");
-
-        // preload JNI bridge classes
-        try {
-            Class.forName("org.apache.auron.jni.JniBridge");
-        } catch (ClassNotFoundException e) {
-            throw new RuntimeException("Cannot load JniBridge class", e);
-        }
-
-        AuronAdaptor.getInstance().loadAuronLib();
-        Runtime.getRuntime().addShutdownHook(new Thread(JniBridge::onExit));
-    }
+    private static volatile boolean initialized = false;
 
     public AuronCallNativeWrapper(
             BufferAllocator arrowAllocator,
@@ -90,11 +70,43 @@ public class AuronCallNativeWrapper {
         this.stageId = stageId;
         this.taskId = taskId;
 
+        init();
         LOG.warn("Start executing native plan");
         this.nativeRuntimePtr = JniBridge.callNative(
                 nativeMemory,
                 AuronAdaptor.getInstance().getAuronConfiguration().get(AuronConfiguration.NATIVE_LOG_LEVEL),
                 this);
+    }
+
+    private static void init() {
+        if (!initialized) {
+            synchronized (AuronCallNativeWrapper.class) {
+                if (!initialized) {
+                    // initialize native environment
+                    LOG.info("Initializing native environment (batchSize="
+                            + AuronAdaptor.getInstance().getAuronConfiguration().get(AuronConfiguration.BATCH_SIZE)
+                            + ", "
+                            + "memoryFraction="
+                            + AuronAdaptor.getInstance().getAuronConfiguration().get(AuronConfiguration.MEMORY_FRACTION)
+                            + ")");
+
+                    // arrow configuration
+                    System.setProperty("arrow.struct.conflict.policy", "CONFLICT_APPEND");
+
+                    // preload JNI bridge classes
+                    try {
+                        Class.forName("org.apache.auron.jni.JniBridge");
+                    } catch (ClassNotFoundException e) {
+                        throw new RuntimeException("Cannot load JniBridge class", e);
+                    }
+
+                    AuronAdaptor.getInstance().loadAuronLib();
+                    Runtime.getRuntime().addShutdownHook(new Thread(JniBridge::onExit));
+
+                    initialized = true;
+                }
+            }
+        }
     }
 
     /**

--- a/auron-core/src/main/java/org/apache/auron/jni/AuronCallNativeWrapper.java
+++ b/auron-core/src/main/java/org/apache/auron/jni/AuronCallNativeWrapper.java
@@ -82,6 +82,10 @@ public class AuronCallNativeWrapper {
         if (!initialized) {
             synchronized (AuronCallNativeWrapper.class) {
                 if (!initialized) {
+                    // Retry-safe: on failure `initialized` stays false so the next call retries.
+                    // Every step below must be idempotent, or must not run on the failure path.
+                    // In particular, loadAuronLib() must throw before System.load — a retried
+                    // System.load would load the native library twice.
                     // initialize native environment
                     LOG.info("Initializing native environment (batchSize="
                             + AuronAdaptor.getInstance().getAuronConfiguration().get(AuronConfiguration.BATCH_SIZE)


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2118

# Rationale for this change

avoid initialize in static block, make native environment initialization retriable after failure

# What changes are included in this PR?

# Are there any user-facing changes?

# How was this patch tested?
