### PR TITLE
[AURON #2158] fix: change const to static in batch_size() to fix OnceCell caching

### DIFF
--- a/native-engine/datafusion-ext-commons/src/lib.rs
+++ b/native-engine/datafusion-ext-commons/src/lib.rs
@@ -72,7 +72,7 @@ macro_rules! downcast_any {
 }
 
 pub fn batch_size() -> usize {
-    const CACHED_BATCH_SIZE: OnceCell<usize> = OnceCell::new();
+    static CACHED_BATCH_SIZE: OnceCell<usize> = OnceCell::new();
     *CACHED_BATCH_SIZE.get_or_init(|| BATCH_SIZE.value().unwrap_or(10000) as usize)
 }
 


### PR DESCRIPTION


Fixes AURON-2158. The const OnceCell was creating a new instance on every call, causing the cache to never hit.

# Which issue does this PR close?

Closes #2158 

# Rationale for this change

# What changes are included in this PR?

# Are there any user-facing changes?

# How was this patch tested?
