### PR TITLE
[AURON #2193] Implement native support for inner residual join conditions on SMJ/SHJ

### DIFF
--- a/dev/auron-it/src/main/resources/tpcds-plan-stability/spark-3.5/q1.txt
+++ b/dev/auron-it/src/main/resources/tpcds-plan-stability/spark-3.5/q1.txt
@@ -1,160 +1,159 @@
 == Physical Plan ==
-AdaptiveSparkPlan (151)
+AdaptiveSparkPlan (150)
 +- == Final Plan ==
-   NativeTakeOrdered (96)
-   +- NativeProject (95)
-      +- NativeSortMergeJoin Inner (94)
-         :- NativeSort (85)
-         :  +- InputAdapter (84)
-         :     +- AQEShuffleRead (83)
-         :        +- ShuffleQueryStage (82), Statistics(X)
-         :           +- NativeShuffleExchange (81)
-         :              +- NativeProject (80)
-         :                 +- NativeSortMergeJoin Inner (79)
-         :                    :- ConvertToNative (69)
-         :                    :  +- * Project (68)
-         :                    :     +- * SortMergeJoin Inner (67)
-         :                    :        :- NativeSort (33)
-         :                    :        :  +- InputAdapter (32)
-         :                    :        :     +- AQEShuffleRead (31)
-         :                    :        :        +- ShuffleQueryStage (30), Statistics(X)
-         :                    :        :           +- NativeShuffleExchange (29)
-         :                    :        :              +- NativeFilter (28)
-         :                    :        :                 +- NativeProject (27)
-         :                    :        :                    +- NativeHashAggregate (26)
-         :                    :        :                       +- InputAdapter (25)
-         :                    :        :                          +- AQEShuffleRead (24)
-         :                    :        :                             +- ShuffleQueryStage (23), Statistics(X)
-         :                    :        :                                +- NativeShuffleExchange (22)
-         :                    :        :                                   +- NativeHashAggregate (21)
-         :                    :        :                                      +- NativeProject (20)
-         :                    :        :                                         +- NativeProject (19)
-         :                    :        :                                            +- NativeSortMergeJoin Inner (18)
-         :                    :        :                                               :- NativeSort (8)
-         :                    :        :                                               :  +- InputAdapter (7)
-         :                    :        :                                               :     +- AQEShuffleRead (6)
-         :                    :        :                                               :        +- ShuffleQueryStage (5), Statistics(X)
-         :                    :        :                                               :           +- NativeShuffleExchange (4)
-         :                    :        :                                               :              +- NativeFilter (3)
-         :                    :        :                                               :                 +- InputAdapter (2)
-         :                    :        :                                               :                    +- NativeParquetScan  (1)
-         :                    :        :                                               +- NativeSort (17)
-         :                    :        :                                                  +- InputAdapter (16)
-         :                    :        :                                                     +- AQEShuffleRead (15)
-         :                    :        :                                                        +- ShuffleQueryStage (14), Statistics(X)
-         :                    :        :                                                           +- NativeShuffleExchange (13)
-         :                    :        :                                                              +- NativeProject (12)
-         :                    :        :                                                                 +- NativeFilter (11)
-         :                    :        :                                                                    +- InputAdapter (10)
-         :                    :        :                                                                       +- NativeParquetScan  (9)
-         :                    :        +- NativeSort (66)
-         :                    :           +- NativeFilter (65)
-         :                    :              +- NativeProject (64)
-         :                    :                 +- NativeHashAggregate (63)
-         :                    :                    +- InputAdapter (62)
-         :                    :                       +- AQEShuffleRead (61)
-         :                    :                          +- ShuffleQueryStage (60), Statistics(X)
-         :                    :                             +- NativeShuffleExchange (59)
-         :                    :                                +- NativeHashAggregate (58)
-         :                    :                                   +- NativeProject (57)
-         :                    :                                      +- NativeHashAggregate (56)
-         :                    :                                         +- InputAdapter (55)
-         :                    :                                            +- AQEShuffleRead (54)
-         :                    :                                               +- ShuffleQueryStage (53), Statistics(X)
-         :                    :                                                  +- NativeShuffleExchange (52)
-         :                    :                                                     +- NativeHashAggregate (51)
-         :                    :                                                        +- NativeProject (50)
-         :                    :                                                           +- NativeProject (49)
-         :                    :                                                              +- NativeSortMergeJoin Inner (48)
-         :                    :                                                                 :- NativeSort (41)
-         :                    :                                                                 :  +- InputAdapter (40)
-         :                    :                                                                 :     +- AQEShuffleRead (39)
-         :                    :                                                                 :        +- ShuffleQueryStage (38), Statistics(X)
-         :                    :                                                                 :           +- NativeShuffleExchange (37)
-         :                    :                                                                 :              +- NativeFilter (36)
-         :                    :                                                                 :                 +- InputAdapter (35)
-         :                    :                                                                 :                    +- NativeParquetScan  (34)
-         :                    :                                                                 +- NativeSort (47)
-         :                    :                                                                    +- InputAdapter (46)
-         :                    :                                                                       +- InputAdapter (45)
-         :                    :                                                                          +- AQEShuffleRead (44)
-         :                    :                                                                             +- ShuffleQueryStage (43), Statistics(X)
-         :                    :                                                                                +- ReusedExchange (42)
-         :                    +- NativeSort (78)
-         :                       +- InputAdapter (77)
-         :                          +- AQEShuffleRead (76)
-         :                             +- ShuffleQueryStage (75), Statistics(X)
-         :                                +- NativeShuffleExchange (74)
-         :                                   +- NativeProject (73)
-         :                                      +- NativeFilter (72)
-         :                                         +- InputAdapter (71)
-         :                                            +- NativeParquetScan  (70)
-         +- NativeSort (93)
-            +- InputAdapter (92)
-               +- AQEShuffleRead (91)
-                  +- ShuffleQueryStage (90), Statistics(X)
-                     +- NativeShuffleExchange (89)
-                        +- NativeFilter (88)
-                           +- InputAdapter (87)
-                              +- NativeParquetScan  (86)
+   NativeTakeOrdered (95)
+   +- NativeProject (94)
+      +- NativeSortMergeJoin Inner (93)
+         :- NativeSort (84)
+         :  +- InputAdapter (83)
+         :     +- AQEShuffleRead (82)
+         :        +- ShuffleQueryStage (81), Statistics(X)
+         :           +- NativeShuffleExchange (80)
+         :              +- NativeProject (79)
+         :                 +- NativeSortMergeJoin Inner (78)
+         :                    :- NativeProject (68)
+         :                    :  +- NativeSortMergeJoin Inner (67)
+         :                    :     :- NativeSort (33)
+         :                    :     :  +- InputAdapter (32)
+         :                    :     :     +- AQEShuffleRead (31)
+         :                    :     :        +- ShuffleQueryStage (30), Statistics(X)
+         :                    :     :           +- NativeShuffleExchange (29)
+         :                    :     :              +- NativeFilter (28)
+         :                    :     :                 +- NativeProject (27)
+         :                    :     :                    +- NativeHashAggregate (26)
+         :                    :     :                       +- InputAdapter (25)
+         :                    :     :                          +- AQEShuffleRead (24)
+         :                    :     :                             +- ShuffleQueryStage (23), Statistics(X)
+         :                    :     :                                +- NativeShuffleExchange (22)
+         :                    :     :                                   +- NativeHashAggregate (21)
+         :                    :     :                                      +- NativeProject (20)
+         :                    :     :                                         +- NativeProject (19)
+         :                    :     :                                            +- NativeSortMergeJoin Inner (18)
+         :                    :     :                                               :- NativeSort (8)
+         :                    :     :                                               :  +- InputAdapter (7)
+         :                    :     :                                               :     +- AQEShuffleRead (6)
+         :                    :     :                                               :        +- ShuffleQueryStage (5), Statistics(X)
+         :                    :     :                                               :           +- NativeShuffleExchange (4)
+         :                    :     :                                               :              +- NativeFilter (3)
+         :                    :     :                                               :                 +- InputAdapter (2)
+         :                    :     :                                               :                    +- NativeParquetScan  (1)
+         :                    :     :                                               +- NativeSort (17)
+         :                    :     :                                                  +- InputAdapter (16)
+         :                    :     :                                                     +- AQEShuffleRead (15)
+         :                    :     :                                                        +- ShuffleQueryStage (14), Statistics(X)
+         :                    :     :                                                           +- NativeShuffleExchange (13)
+         :                    :     :                                                              +- NativeProject (12)
+         :                    :     :                                                                 +- NativeFilter (11)
+         :                    :     :                                                                    +- InputAdapter (10)
+         :                    :     :                                                                       +- NativeParquetScan  (9)
+         :                    :     +- NativeSort (66)
+         :                    :        +- NativeFilter (65)
+         :                    :           +- NativeProject (64)
+         :                    :              +- NativeHashAggregate (63)
+         :                    :                 +- InputAdapter (62)
+         :                    :                    +- AQEShuffleRead (61)
+         :                    :                       +- ShuffleQueryStage (60), Statistics(X)
+         :                    :                          +- NativeShuffleExchange (59)
+         :                    :                             +- NativeHashAggregate (58)
+         :                    :                                +- NativeProject (57)
+         :                    :                                   +- NativeHashAggregate (56)
+         :                    :                                      +- InputAdapter (55)
+         :                    :                                         +- AQEShuffleRead (54)
+         :                    :                                            +- ShuffleQueryStage (53), Statistics(X)
+         :                    :                                               +- NativeShuffleExchange (52)
+         :                    :                                                  +- NativeHashAggregate (51)
+         :                    :                                                     +- NativeProject (50)
+         :                    :                                                        +- NativeProject (49)
+         :                    :                                                           +- NativeSortMergeJoin Inner (48)
+         :                    :                                                              :- NativeSort (41)
+         :                    :                                                              :  +- InputAdapter (40)
+         :                    :                                                              :     +- AQEShuffleRead (39)
+         :                    :                                                              :        +- ShuffleQueryStage (38), Statistics(X)
+         :                    :                                                              :           +- NativeShuffleExchange (37)
+         :                    :                                                              :              +- NativeFilter (36)
+         :                    :                                                              :                 +- InputAdapter (35)
+         :                    :                                                              :                    +- NativeParquetScan  (34)
+         :                    :                                                              +- NativeSort (47)
+         :                    :                                                                 +- InputAdapter (46)
+         :                    :                                                                    +- InputAdapter (45)
+         :                    :                                                                       +- AQEShuffleRead (44)
+         :                    :                                                                          +- ShuffleQueryStage (43), Statistics(X)
+         :                    :                                                                             +- ReusedExchange (42)
+         :                    +- NativeSort (77)
+         :                       +- InputAdapter (76)
+         :                          +- AQEShuffleRead (75)
+         :                             +- ShuffleQueryStage (74), Statistics(X)
+         :                                +- NativeShuffleExchange (73)
+         :                                   +- NativeProject (72)
+         :                                      +- NativeFilter (71)
+         :                                         +- InputAdapter (70)
+         :                                            +- NativeParquetScan  (69)
+         +- NativeSort (92)
+            +- InputAdapter (91)
+               +- AQEShuffleRead (90)
+                  +- ShuffleQueryStage (89), Statistics(X)
+                     +- NativeShuffleExchange (88)
+                        +- NativeFilter (87)
+                           +- InputAdapter (86)
+                              +- NativeParquetScan  (85)
 +- == Initial Plan ==
-   TakeOrderedAndProject (150)
-   +- Project (149)
-      +- SortMergeJoin Inner (148)
-         :- Sort (143)
-         :  +- Exchange (142)
-         :     +- Project (141)
-         :        +- SortMergeJoin Inner (140)
-         :           :- Project (134)
-         :           :  +- SortMergeJoin Inner (133)
-         :           :     :- Sort (113)
-         :           :     :  +- Exchange (112)
-         :           :     :     +- Filter (111)
-         :           :     :        +- HashAggregate (110)
-         :           :     :           +- Exchange (109)
-         :           :     :              +- HashAggregate (108)
-         :           :     :                 +- Project (107)
-         :           :     :                    +- SortMergeJoin Inner (106)
-         :           :     :                       :- Sort (100)
-         :           :     :                       :  +- Exchange (99)
-         :           :     :                       :     +- Filter (98)
-         :           :     :                       :        +- Scan parquet (97)
-         :           :     :                       +- Sort (105)
-         :           :     :                          +- Exchange (104)
-         :           :     :                             +- Project (103)
-         :           :     :                                +- Filter (102)
-         :           :     :                                   +- Scan parquet (101)
-         :           :     +- Sort (132)
-         :           :        +- Filter (131)
-         :           :           +- HashAggregate (130)
-         :           :              +- Exchange (129)
-         :           :                 +- HashAggregate (128)
-         :           :                    +- HashAggregate (127)
-         :           :                       +- Exchange (126)
-         :           :                          +- HashAggregate (125)
-         :           :                             +- Project (124)
-         :           :                                +- SortMergeJoin Inner (123)
-         :           :                                   :- Sort (117)
-         :           :                                   :  +- Exchange (116)
-         :           :                                   :     +- Filter (115)
-         :           :                                   :        +- Scan parquet (114)
-         :           :                                   +- Sort (122)
-         :           :                                      +- Exchange (121)
-         :           :                                         +- Project (120)
-         :           :                                            +- Filter (119)
-         :           :                                               +- Scan parquet (118)
-         :           +- Sort (139)
-         :              +- Exchange (138)
-         :                 +- Project (137)
-         :                    +- Filter (136)
-         :                       +- Scan parquet (135)
-         +- Sort (147)
-            +- Exchange (146)
-               +- Filter (145)
-                  +- Scan parquet (144)
+   TakeOrderedAndProject (149)
+   +- Project (148)
+      +- SortMergeJoin Inner (147)
+         :- Sort (142)
+         :  +- Exchange (141)
+         :     +- Project (140)
+         :        +- SortMergeJoin Inner (139)
+         :           :- Project (133)
+         :           :  +- SortMergeJoin Inner (132)
+         :           :     :- Sort (112)
+         :           :     :  +- Exchange (111)
+         :           :     :     +- Filter (110)
+         :           :     :        +- HashAggregate (109)
+         :           :     :           +- Exchange (108)
+         :           :     :              +- HashAggregate (107)
+         :           :     :                 +- Project (106)
+         :           :     :                    +- SortMergeJoin Inner (105)
+         :           :     :                       :- Sort (99)
+         :           :     :                       :  +- Exchange (98)
+         :           :     :                       :     +- Filter (97)
+         :           :     :                       :        +- Scan parquet (96)
+         :           :     :                       +- Sort (104)
+         :           :     :                          +- Exchange (103)
+         :           :     :                             +- Project (102)
+         :           :     :                                +- Filter (101)
+         :           :     :                                   +- Scan parquet (100)
+         :           :     +- Sort (131)
+         :           :        +- Filter (130)
+         :           :           +- HashAggregate (129)
+         :           :              +- Exchange (128)
+         :           :                 +- HashAggregate (127)
+         :           :                    +- HashAggregate (126)
+         :           :                       +- Exchange (125)
+         :           :                          +- HashAggregate (124)
+         :           :                             +- Project (123)
+         :           :                                +- SortMergeJoin Inner (122)
+         :           :                                   :- Sort (116)
+         :           :                                   :  +- Exchange (115)
+         :           :                                   :     +- Filter (114)
+         :           :                                   :        +- Scan parquet (113)
+         :           :                                   +- Sort (121)
+         :           :                                      +- Exchange (120)
+         :           :                                         +- Project (119)
+         :           :                                            +- Filter (118)
+         :           :                                               +- Scan parquet (117)
+         :           +- Sort (138)
+         :              +- Exchange (137)
+         :                 +- Project (136)
+         :                    +- Filter (135)
+         :                       +- Scan parquet (134)
+         +- Sort (146)
+            +- Exchange (145)
+               +- Filter (144)
+                  +- Scan parquet (143)
 
 
-(97) Scan parquet
+(96) Scan parquet
 Output [4]: [sr_returned_date_sk#1, sr_customer_sk#2, sr_store_sk#3, sr_return_amt#4]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
@@ -188,7 +187,7 @@ Input [4]: [#1#1, #2#2, #3#3, #4#4]
 Input [4]: [#1#1, #2#2, #3#3, #4#4]
 Arguments: [sr_returned_date_sk#1 ASC NULLS FIRST], false
 
-(101) Scan parquet
+(100) Scan parquet
 Output [2]: [d_date_sk#5, d_year#6]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
@@ -296,7 +295,7 @@ Input [3]: [ctr_customer_sk#11, ctr_store_sk#12, ctr_total_return#13]
 Input [3]: [ctr_customer_sk#11, ctr_store_sk#12, ctr_total_return#13]
 Arguments: [ctr_store_sk#12 ASC NULLS FIRST], false
 
-(114) Scan parquet
+(113) Scan parquet
 Output [4]: [sr_returned_date_sk#14, sr_customer_sk#15, sr_store_sk#16, sr_return_amt#17]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
@@ -440,397 +439,394 @@ Condition : isnotnull((avg(ctr_total_return) * 1.2)#27)
 Input [2]: [(avg(ctr_total_return) * 1.2)#27, ctr_store_sk#21]
 Arguments: [ctr_store_sk#21 ASC NULLS FIRST], false
 
-(67) SortMergeJoin [codegen id : X]
+(67) NativeSortMergeJoin
 Left keys [1]: [ctr_store_sk#12]
 Right keys [1]: [ctr_store_sk#21]
 Join type: Inner
 Join condition: (cast(ctr_total_return#13 as decimal(24,7)) > (avg(ctr_total_return) * 1.2)#27)
 
-(68) Project [codegen id : X]
+(68) NativeProject
 Output [2]: [ctr_customer_sk#11, ctr_store_sk#12]
 Input [5]: [ctr_customer_sk#11, ctr_store_sk#12, ctr_total_return#13, (avg(ctr_total_return) * 1.2)#27, ctr_store_sk#21]
 
-(69) ConvertToNative
-Input [2]: [ctr_customer_sk#11, ctr_store_sk#12]
-
-(135) Scan parquet
+(134) Scan parquet
 Output [2]: [s_store_sk#28, s_state#29]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(s_state), EqualTo(s_state,TN), IsNotNull(s_store_sk)]
 ReadSchema: struct<s_store_sk:int,s_state:string>
 
-(71) InputAdapter
+(70) InputAdapter
 Input [2]: [s_store_sk#28, s_state#29]
 Arguments: [#28, #29]
 
-(72) NativeFilter
+(71) NativeFilter
 Input [2]: [#28#28, #29#29]
 Condition : ((isnotnull(s_state#29) AND (s_state#29 = TN)) AND isnotnull(s_store_sk#28))
 
-(73) NativeProject
+(72) NativeProject
 Output [1]: [s_store_sk#28]
 Input [2]: [#28#28, #29#29]
 
-(74) NativeShuffleExchange
+(73) NativeShuffleExchange
 Input [1]: [s_store_sk#28]
 Arguments: hashpartitioning(s_store_sk#28, 100), ENSURE_REQUIREMENTS, [plan_id=8]
 
-(75) ShuffleQueryStage
+(74) ShuffleQueryStage
 Output [1]: [s_store_sk#28]
 Arguments: X
 
-(76) AQEShuffleRead
+(75) AQEShuffleRead
 Input [1]: [s_store_sk#28]
 Arguments: coalesced
 
-(77) InputAdapter
+(76) InputAdapter
 Input [1]: [s_store_sk#28]
 
-(78) NativeSort
+(77) NativeSort
 Input [1]: [s_store_sk#28]
 Arguments: [s_store_sk#28 ASC NULLS FIRST], false
 
-(79) NativeSortMergeJoin
+(78) NativeSortMergeJoin
 Left keys [1]: [ctr_store_sk#12]
 Right keys [1]: [s_store_sk#28]
 Join type: Inner
 Join condition: None
 
-(80) NativeProject
+(79) NativeProject
 Output [1]: [ctr_customer_sk#11]
 Input [3]: [ctr_customer_sk#11, ctr_store_sk#12, s_store_sk#28]
 
-(81) NativeShuffleExchange
+(80) NativeShuffleExchange
 Input [1]: [ctr_customer_sk#11]
 Arguments: hashpartitioning(ctr_customer_sk#11, 100), ENSURE_REQUIREMENTS, [plan_id=9]
 
-(82) ShuffleQueryStage
+(81) ShuffleQueryStage
 Output [1]: [ctr_customer_sk#11]
 Arguments: X
 
-(83) AQEShuffleRead
+(82) AQEShuffleRead
 Input [1]: [ctr_customer_sk#11]
 Arguments: coalesced
 
-(84) InputAdapter
+(83) InputAdapter
 Input [1]: [ctr_customer_sk#11]
 
-(85) NativeSort
+(84) NativeSort
 Input [1]: [ctr_customer_sk#11]
 Arguments: [ctr_customer_sk#11 ASC NULLS FIRST], false
 
-(144) Scan parquet
+(143) Scan parquet
 Output [2]: [c_customer_sk#30, c_customer_id#31]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(c_customer_sk)]
 ReadSchema: struct<c_customer_sk:int,c_customer_id:string>
 
-(87) InputAdapter
+(86) InputAdapter
 Input [2]: [c_customer_sk#30, c_customer_id#31]
 Arguments: [#30, #31]
 
-(88) NativeFilter
+(87) NativeFilter
 Input [2]: [#30#30, #31#31]
 Condition : isnotnull(c_customer_sk#30)
 
-(89) NativeShuffleExchange
+(88) NativeShuffleExchange
 Input [2]: [#30#30, #31#31]
 Arguments: hashpartitioning(c_customer_sk#30, 100), ENSURE_REQUIREMENTS, [plan_id=10]
 
-(90) ShuffleQueryStage
+(89) ShuffleQueryStage
 Output [2]: [#30#30, #31#31]
 Arguments: X
 
-(91) AQEShuffleRead
+(90) AQEShuffleRead
 Input [2]: [#30#30, #31#31]
 Arguments: coalesced
 
-(92) InputAdapter
+(91) InputAdapter
 Input [2]: [#30#30, #31#31]
 
-(93) NativeSort
+(92) NativeSort
 Input [2]: [#30#30, #31#31]
 Arguments: [c_customer_sk#30 ASC NULLS FIRST], false
 
-(94) NativeSortMergeJoin
+(93) NativeSortMergeJoin
 Left keys [1]: [ctr_customer_sk#11]
 Right keys [1]: [c_customer_sk#30]
 Join type: Inner
 Join condition: None
 
-(95) NativeProject
+(94) NativeProject
 Output [1]: [c_customer_id#31]
 Input [3]: [ctr_customer_sk#11, #30#30, #31#31]
 
-(96) NativeTakeOrdered
+(95) NativeTakeOrdered
 Input [1]: [c_customer_id#31]
 Arguments: X, X, [c_customer_id#31 ASC NULLS FIRST]
 
-(97) Scan parquet
+(96) Scan parquet
 Output [4]: [sr_returned_date_sk#1, sr_customer_sk#2, sr_store_sk#3, sr_return_amt#4]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(sr_returned_date_sk), IsNotNull(sr_store_sk), IsNotNull(sr_customer_sk)]
 ReadSchema: struct<sr_returned_date_sk:int,sr_customer_sk:int,sr_store_sk:int,sr_return_amt:decimal(7,2)>
 
-(98) Filter
+(97) Filter
 Input [4]: [sr_returned_date_sk#1, sr_customer_sk#2, sr_store_sk#3, sr_return_amt#4]
 Condition : ((isnotnull(sr_returned_date_sk#1) AND isnotnull(sr_store_sk#3)) AND isnotnull(sr_customer_sk#2))
 
-(99) Exchange
+(98) Exchange
 Input [4]: [sr_returned_date_sk#1, sr_customer_sk#2, sr_store_sk#3, sr_return_amt#4]
 Arguments: hashpartitioning(sr_returned_date_sk#1, 100), ENSURE_REQUIREMENTS, [plan_id=11]
 
-(100) Sort
+(99) Sort
 Input [4]: [sr_returned_date_sk#1, sr_customer_sk#2, sr_store_sk#3, sr_return_amt#4]
 Arguments: [sr_returned_date_sk#1 ASC NULLS FIRST], false, 0
 
-(101) Scan parquet
+(100) Scan parquet
 Output [2]: [d_date_sk#5, d_year#6]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2000), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
-(102) Filter
+(101) Filter
 Input [2]: [d_date_sk#5, d_year#6]
 Condition : ((isnotnull(d_year#6) AND (d_year#6 = 2000)) AND isnotnull(d_date_sk#5))
 
-(103) Project
+(102) Project
 Output [1]: [d_date_sk#5]
 Input [2]: [d_date_sk#5, d_year#6]
 
-(104) Exchange
+(103) Exchange
 Input [1]: [d_date_sk#5]
 Arguments: hashpartitioning(d_date_sk#5, 100), ENSURE_REQUIREMENTS, [plan_id=12]
 
-(105) Sort
+(104) Sort
 Input [1]: [d_date_sk#5]
 Arguments: [d_date_sk#5 ASC NULLS FIRST], false, 0
 
-(106) SortMergeJoin
+(105) SortMergeJoin
 Left keys [1]: [sr_returned_date_sk#1]
 Right keys [1]: [d_date_sk#5]
 Join type: Inner
 Join condition: None
 
-(107) Project
+(106) Project
 Output [3]: [sr_customer_sk#2, sr_store_sk#3, sr_return_amt#4]
 Input [5]: [sr_returned_date_sk#1, sr_customer_sk#2, sr_store_sk#3, sr_return_amt#4, d_date_sk#5]
 
-(108) HashAggregate
+(107) HashAggregate
 Input [3]: [sr_customer_sk#2, sr_store_sk#3, sr_return_amt#4]
 Keys [2]: [sr_customer_sk#2, sr_store_sk#3]
 Functions [1]: [partial_sum(UnscaledValue(sr_return_amt#4))]
 Aggregate Attributes [1]: [sum#8]
 Results [3]: [sr_customer_sk#2, sr_store_sk#3, sum#32]
 
-(109) Exchange
+(108) Exchange
 Input [3]: [sr_customer_sk#2, sr_store_sk#3, sum#32]
 Arguments: hashpartitioning(sr_customer_sk#2, sr_store_sk#3, 100), ENSURE_REQUIREMENTS, [plan_id=13]
 
-(110) HashAggregate
+(109) HashAggregate
 Input [3]: [sr_customer_sk#2, sr_store_sk#3, sum#32]
 Keys [2]: [sr_customer_sk#2, sr_store_sk#3]
 Functions [1]: [sum(UnscaledValue(sr_return_amt#4))]
 Aggregate Attributes [1]: [sum(UnscaledValue(sr_return_amt#4))#10]
 Results [3]: [sr_customer_sk#2 AS ctr_customer_sk#11, sr_store_sk#3 AS ctr_store_sk#12, MakeDecimal(sum(UnscaledValue(sr_return_amt#4))#10,17,2) AS ctr_total_return#13]
 
-(111) Filter
+(110) Filter
 Input [3]: [ctr_customer_sk#11, ctr_store_sk#12, ctr_total_return#13]
 Condition : isnotnull(ctr_total_return#13)
 
-(112) Exchange
+(111) Exchange
 Input [3]: [ctr_customer_sk#11, ctr_store_sk#12, ctr_total_return#13]
 Arguments: hashpartitioning(ctr_store_sk#12, 100), ENSURE_REQUIREMENTS, [plan_id=14]
 
-(113) Sort
+(112) Sort
 Input [3]: [ctr_customer_sk#11, ctr_store_sk#12, ctr_total_return#13]
 Arguments: [ctr_store_sk#12 ASC NULLS FIRST], false, 0
 
-(114) Scan parquet
+(113) Scan parquet
 Output [4]: [sr_returned_date_sk#14, sr_customer_sk#15, sr_store_sk#16, sr_return_amt#17]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(sr_returned_date_sk), IsNotNull(sr_store_sk)]
 ReadSchema: struct<sr_returned_date_sk:int,sr_customer_sk:int,sr_store_sk:int,sr_return_amt:decimal(7,2)>
 
-(115) Filter
+(114) Filter
 Input [4]: [sr_returned_date_sk#14, sr_customer_sk#15, sr_store_sk#16, sr_return_amt#17]
 Condition : (isnotnull(sr_returned_date_sk#14) AND isnotnull(sr_store_sk#16))
 
-(116) Exchange
+(115) Exchange
 Input [4]: [sr_returned_date_sk#14, sr_customer_sk#15, sr_store_sk#16, sr_return_amt#17]
 Arguments: hashpartitioning(sr_returned_date_sk#14, 100), ENSURE_REQUIREMENTS, [plan_id=15]
 
-(117) Sort
+(116) Sort
 Input [4]: [sr_returned_date_sk#14, sr_customer_sk#15, sr_store_sk#16, sr_return_amt#17]
 Arguments: [sr_returned_date_sk#14 ASC NULLS FIRST], false, 0
 
-(118) Scan parquet
+(117) Scan parquet
 Output [2]: [d_date_sk#18, d_year#33]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2000), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
-(119) Filter
+(118) Filter
 Input [2]: [d_date_sk#18, d_year#33]
 Condition : ((isnotnull(d_year#33) AND (d_year#33 = 2000)) AND isnotnull(d_date_sk#18))
 
-(120) Project
+(119) Project
 Output [1]: [d_date_sk#18]
 Input [2]: [d_date_sk#18, d_year#33]
 
-(121) Exchange
+(120) Exchange
 Input [1]: [d_date_sk#18]
 Arguments: hashpartitioning(d_date_sk#18, 100), ENSURE_REQUIREMENTS, [plan_id=16]
 
-(122) Sort
+(121) Sort
 Input [1]: [d_date_sk#18]
 Arguments: [d_date_sk#18 ASC NULLS FIRST], false, 0
 
-(123) SortMergeJoin
+(122) SortMergeJoin
 Left keys [1]: [sr_returned_date_sk#14]
 Right keys [1]: [d_date_sk#18]
 Join type: Inner
 Join condition: None
 
-(124) Project
+(123) Project
 Output [3]: [sr_customer_sk#15, sr_store_sk#16, sr_return_amt#17]
 Input [5]: [sr_returned_date_sk#14, sr_customer_sk#15, sr_store_sk#16, sr_return_amt#17, d_date_sk#18]
 
-(125) HashAggregate
+(124) HashAggregate
 Input [3]: [sr_customer_sk#15, sr_store_sk#16, sr_return_amt#17]
 Keys [2]: [sr_customer_sk#15, sr_store_sk#16]
 Functions [1]: [partial_sum(UnscaledValue(sr_return_amt#17))]
 Aggregate Attributes [1]: [sum#20]
 Results [3]: [sr_customer_sk#15, sr_store_sk#16, sum#34]
 
-(126) Exchange
+(125) Exchange
 Input [3]: [sr_customer_sk#15, sr_store_sk#16, sum#34]
 Arguments: hashpartitioning(sr_customer_sk#15, sr_store_sk#16, 100), ENSURE_REQUIREMENTS, [plan_id=17]
 
-(127) HashAggregate
+(126) HashAggregate
 Input [3]: [sr_customer_sk#15, sr_store_sk#16, sum#34]
 Keys [2]: [sr_customer_sk#15, sr_store_sk#16]
 Functions [1]: [sum(UnscaledValue(sr_return_amt#17))]
 Aggregate Attributes [1]: [sum(UnscaledValue(sr_return_amt#17))#10]
 Results [2]: [sr_store_sk#16 AS ctr_store_sk#21, MakeDecimal(sum(UnscaledValue(sr_return_amt#17))#10,17,2) AS ctr_total_return#22]
 
-(128) HashAggregate
+(127) HashAggregate
 Input [2]: [ctr_store_sk#21, ctr_total_return#22]
 Keys [1]: [ctr_store_sk#21]
 Functions [1]: [partial_avg(ctr_total_return#22)]
 Aggregate Attributes [2]: [sum#23, count#24]
 Results [3]: [ctr_store_sk#21, sum#35, count#36]
 
-(129) Exchange
+(128) Exchange
 Input [3]: [ctr_store_sk#21, sum#35, count#36]
 Arguments: hashpartitioning(ctr_store_sk#21, 100), ENSURE_REQUIREMENTS, [plan_id=18]
 
-(130) HashAggregate
+(129) HashAggregate
 Input [3]: [ctr_store_sk#21, sum#35, count#36]
 Keys [1]: [ctr_store_sk#21]
 Functions [1]: [avg(ctr_total_return#22)]
 Aggregate Attributes [1]: [avg(ctr_total_return#22)#26]
 Results [2]: [(avg(ctr_total_return#22)#26 * 1.2) AS (avg(ctr_total_return) * 1.2)#27, ctr_store_sk#21]
 
-(131) Filter
+(130) Filter
 Input [2]: [(avg(ctr_total_return) * 1.2)#27, ctr_store_sk#21]
 Condition : isnotnull((avg(ctr_total_return) * 1.2)#27)
 
-(132) Sort
+(131) Sort
 Input [2]: [(avg(ctr_total_return) * 1.2)#27, ctr_store_sk#21]
 Arguments: [ctr_store_sk#21 ASC NULLS FIRST], false, 0
 
-(133) SortMergeJoin
+(132) SortMergeJoin
 Left keys [1]: [ctr_store_sk#12]
 Right keys [1]: [ctr_store_sk#21]
 Join type: Inner
 Join condition: (cast(ctr_total_return#13 as decimal(24,7)) > (avg(ctr_total_return) * 1.2)#27)
 
-(134) Project
+(133) Project
 Output [2]: [ctr_customer_sk#11, ctr_store_sk#12]
 Input [5]: [ctr_customer_sk#11, ctr_store_sk#12, ctr_total_return#13, (avg(ctr_total_return) * 1.2)#27, ctr_store_sk#21]
 
-(135) Scan parquet
+(134) Scan parquet
 Output [2]: [s_store_sk#28, s_state#29]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(s_state), EqualTo(s_state,TN), IsNotNull(s_store_sk)]
 ReadSchema: struct<s_store_sk:int,s_state:string>
 
-(136) Filter
+(135) Filter
 Input [2]: [s_store_sk#28, s_state#29]
 Condition : ((isnotnull(s_state#29) AND (s_state#29 = TN)) AND isnotnull(s_store_sk#28))
 
-(137) Project
+(136) Project
 Output [1]: [s_store_sk#28]
 Input [2]: [s_store_sk#28, s_state#29]
 
-(138) Exchange
+(137) Exchange
 Input [1]: [s_store_sk#28]
 Arguments: hashpartitioning(s_store_sk#28, 100), ENSURE_REQUIREMENTS, [plan_id=19]
 
-(139) Sort
+(138) Sort
 Input [1]: [s_store_sk#28]
 Arguments: [s_store_sk#28 ASC NULLS FIRST], false, 0
 
-(140) SortMergeJoin
+(139) SortMergeJoin
 Left keys [1]: [ctr_store_sk#12]
 Right keys [1]: [s_store_sk#28]
 Join type: Inner
 Join condition: None
 
-(141) Project
+(140) Project
 Output [1]: [ctr_customer_sk#11]
 Input [3]: [ctr_customer_sk#11, ctr_store_sk#12, s_store_sk#28]
 
-(142) Exchange
+(141) Exchange
 Input [1]: [ctr_customer_sk#11]
 Arguments: hashpartitioning(ctr_customer_sk#11, 100), ENSURE_REQUIREMENTS, [plan_id=20]
 
-(143) Sort
+(142) Sort
 Input [1]: [ctr_customer_sk#11]
 Arguments: [ctr_customer_sk#11 ASC NULLS FIRST], false, 0
 
-(144) Scan parquet
+(143) Scan parquet
 Output [2]: [c_customer_sk#30, c_customer_id#31]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(c_customer_sk)]
 ReadSchema: struct<c_customer_sk:int,c_customer_id:string>
 
-(145) Filter
+(144) Filter
 Input [2]: [c_customer_sk#30, c_customer_id#31]
 Condition : isnotnull(c_customer_sk#30)
 
-(146) Exchange
+(145) Exchange
 Input [2]: [c_customer_sk#30, c_customer_id#31]
 Arguments: hashpartitioning(c_customer_sk#30, 100), ENSURE_REQUIREMENTS, [plan_id=21]
 
-(147) Sort
+(146) Sort
 Input [2]: [c_customer_sk#30, c_customer_id#31]
 Arguments: [c_customer_sk#30 ASC NULLS FIRST], false, 0
 
-(148) SortMergeJoin
+(147) SortMergeJoin
 Left keys [1]: [ctr_customer_sk#11]
 Right keys [1]: [c_customer_sk#30]
 Join type: Inner
 Join condition: None
 
-(149) Project
+(148) Project
 Output [1]: [c_customer_id#31]
 Input [3]: [ctr_customer_sk#11, c_customer_sk#30, c_customer_id#31]
 
-(150) TakeOrderedAndProject
+(149) TakeOrderedAndProject
 Input [1]: [c_customer_id#31]
 Arguments: X, [c_customer_id#31 ASC NULLS FIRST], [c_customer_id#31]
 
-(151) AdaptiveSparkPlan
+(150) AdaptiveSparkPlan
 Output [1]: [c_customer_id#31]
 Arguments: isFinalPlan=true
 

--- a/dev/auron-it/src/main/resources/tpcds-plan-stability/spark-3.5/q11.txt
+++ b/dev/auron-it/src/main/resources/tpcds-plan-stability/spark-3.5/q11.txt
@@ -1,9 +1,9 @@
 == Physical Plan ==
 AdaptiveSparkPlan (255)
 +- == Final Plan ==
-   TakeOrderedAndProject (153)
-   +- * Project (152)
-      +- * SortMergeJoin Inner (151)
+   NativeTakeOrdered (153)
+   +- NativeProject (152)
+      +- NativeSortMergeJoin Inner (151)
          :- NativeProject (123)
          :  +- NativeSortMergeJoin Inner (122)
          :     :- NativeProject (78)
@@ -888,19 +888,19 @@ Input [2]: [customer_id#71, year_total#72]
 Input [2]: [customer_id#71, year_total#72]
 Arguments: [customer_id#71 ASC NULLS FIRST], false
 
-(151) SortMergeJoin [codegen id : X]
+(151) NativeSortMergeJoin
 Left keys [1]: [customer_id#19]
 Right keys [1]: [customer_id#71]
 Join type: Inner
 Join condition: (CASE WHEN (year_total#56 > 0.00) THEN (year_total#72 / year_total#56) END > CASE WHEN (year_total#20 > 0.00) THEN (year_total#37 / year_total#20) END)
 
-(152) Project [codegen id : X]
+(152) NativeProject
 Output [1]: [customer_preferred_cust_flag#36]
 Input [7]: [customer_id#19, year_total#20, customer_preferred_cust_flag#36, year_total#37, year_total#56, customer_id#71, year_total#72]
 
-(153) TakeOrderedAndProject
+(153) NativeTakeOrdered
 Input [1]: [customer_preferred_cust_flag#36]
-Arguments: X, [customer_preferred_cust_flag#36 ASC NULLS FIRST], [customer_preferred_cust_flag#36]
+Arguments: X, X, [customer_preferred_cust_flag#36 ASC NULLS FIRST]
 
 (154) Scan parquet
 Output [8]: [c_customer_sk#1, c_customer_id#2, c_first_name#3, c_last_name#4, c_preferred_cust_flag#5, c_birth_country#6, c_login#7, c_email_address#8]

--- a/dev/auron-it/src/main/resources/tpcds-plan-stability/spark-3.5/q13.txt
+++ b/dev/auron-it/src/main/resources/tpcds-plan-stability/spark-3.5/q13.txt
@@ -1,92 +1,92 @@
 == Physical Plan ==
 AdaptiveSparkPlan (134)
 +- == Final Plan ==
-   * HashAggregate (86)
-   +- ShuffleQueryStage (85), Statistics(X)
-      +- Exchange (84)
-         +- * HashAggregate (83)
-            +- * Project (82)
-               +- * SortMergeJoin Inner (81)
-                  :- NativeSort (72)
-                  :  +- InputAdapter (71)
-                  :     +- AQEShuffleRead (70)
-                  :        +- ShuffleQueryStage (69), Statistics(X)
-                  :           +- NativeShuffleExchange (68)
-                  :              +- ConvertToNative (67)
-                  :                 +- * Project (66)
-                  :                    +- * SortMergeJoin Inner (65)
-                  :                       :- NativeSort (56)
-                  :                       :  +- InputAdapter (55)
-                  :                       :     +- AQEShuffleRead (54)
-                  :                       :        +- ShuffleQueryStage (53), Statistics(X)
-                  :                       :           +- NativeShuffleExchange (52)
-                  :                       :              +- NativeProject (51)
-                  :                       :                 +- NativeSortMergeJoin Inner (50)
-                  :                       :                    :- NativeSort (40)
-                  :                       :                    :  +- InputAdapter (39)
-                  :                       :                    :     +- AQEShuffleRead (38)
-                  :                       :                    :        +- ShuffleQueryStage (37), Statistics(X)
-                  :                       :                    :           +- NativeShuffleExchange (36)
-                  :                       :                    :              +- ConvertToNative (35)
-                  :                       :                    :                 +- * Project (34)
-                  :                       :                    :                    +- * SortMergeJoin Inner (33)
-                  :                       :                    :                       :- NativeSort (23)
-                  :                       :                    :                       :  +- InputAdapter (22)
-                  :                       :                    :                       :     +- AQEShuffleRead (21)
-                  :                       :                    :                       :        +- ShuffleQueryStage (20), Statistics(X)
-                  :                       :                    :                       :           +- NativeShuffleExchange (19)
-                  :                       :                    :                       :              +- NativeProject (18)
-                  :                       :                    :                       :                 +- NativeSortMergeJoin Inner (17)
-                  :                       :                    :                       :                    :- NativeSort (8)
-                  :                       :                    :                       :                    :  +- InputAdapter (7)
-                  :                       :                    :                       :                    :     +- AQEShuffleRead (6)
-                  :                       :                    :                       :                    :        +- ShuffleQueryStage (5), Statistics(X)
-                  :                       :                    :                       :                    :           +- NativeShuffleExchange (4)
-                  :                       :                    :                       :                    :              +- NativeFilter (3)
-                  :                       :                    :                       :                    :                 +- InputAdapter (2)
-                  :                       :                    :                       :                    :                    +- NativeParquetScan  (1)
-                  :                       :                    :                       :                    +- NativeSort (16)
-                  :                       :                    :                       :                       +- InputAdapter (15)
-                  :                       :                    :                       :                          +- AQEShuffleRead (14)
-                  :                       :                    :                       :                             +- ShuffleQueryStage (13), Statistics(X)
-                  :                       :                    :                       :                                +- NativeShuffleExchange (12)
-                  :                       :                    :                       :                                   +- NativeFilter (11)
-                  :                       :                    :                       :                                      +- InputAdapter (10)
-                  :                       :                    :                       :                                         +- NativeParquetScan  (9)
-                  :                       :                    :                       +- NativeSort (32)
-                  :                       :                    :                          +- InputAdapter (31)
-                  :                       :                    :                             +- AQEShuffleRead (30)
-                  :                       :                    :                                +- ShuffleQueryStage (29), Statistics(X)
-                  :                       :                    :                                   +- NativeShuffleExchange (28)
-                  :                       :                    :                                      +- NativeProject (27)
-                  :                       :                    :                                         +- NativeFilter (26)
-                  :                       :                    :                                            +- InputAdapter (25)
-                  :                       :                    :                                               +- NativeParquetScan  (24)
-                  :                       :                    +- NativeSort (49)
-                  :                       :                       +- InputAdapter (48)
-                  :                       :                          +- AQEShuffleRead (47)
-                  :                       :                             +- ShuffleQueryStage (46), Statistics(X)
-                  :                       :                                +- NativeShuffleExchange (45)
-                  :                       :                                   +- NativeProject (44)
-                  :                       :                                      +- NativeFilter (43)
-                  :                       :                                         +- InputAdapter (42)
-                  :                       :                                            +- NativeParquetScan  (41)
-                  :                       +- NativeSort (64)
-                  :                          +- InputAdapter (63)
-                  :                             +- AQEShuffleRead (62)
-                  :                                +- ShuffleQueryStage (61), Statistics(X)
-                  :                                   +- NativeShuffleExchange (60)
-                  :                                      +- NativeFilter (59)
-                  :                                         +- InputAdapter (58)
-                  :                                            +- NativeParquetScan  (57)
-                  +- NativeSort (80)
-                     +- InputAdapter (79)
-                        +- AQEShuffleRead (78)
-                           +- ShuffleQueryStage (77), Statistics(X)
-                              +- NativeShuffleExchange (76)
-                                 +- NativeFilter (75)
-                                    +- InputAdapter (74)
-                                       +- NativeParquetScan  (73)
+   NativeProject (86)
+   +- NativeHashAggregate (85)
+      +- ShuffleQueryStage (84), Statistics(X)
+         +- NativeShuffleExchange (83)
+            +- NativeHashAggregate (82)
+               +- NativeProject (81)
+                  +- NativeProject (80)
+                     +- NativeSortMergeJoin Inner (79)
+                        :- NativeSort (70)
+                        :  +- InputAdapter (69)
+                        :     +- AQEShuffleRead (68)
+                        :        +- ShuffleQueryStage (67), Statistics(X)
+                        :           +- NativeShuffleExchange (66)
+                        :              +- NativeProject (65)
+                        :                 +- NativeSortMergeJoin Inner (64)
+                        :                    :- NativeSort (55)
+                        :                    :  +- InputAdapter (54)
+                        :                    :     +- AQEShuffleRead (53)
+                        :                    :        +- ShuffleQueryStage (52), Statistics(X)
+                        :                    :           +- NativeShuffleExchange (51)
+                        :                    :              +- NativeProject (50)
+                        :                    :                 +- NativeSortMergeJoin Inner (49)
+                        :                    :                    :- NativeSort (39)
+                        :                    :                    :  +- InputAdapter (38)
+                        :                    :                    :     +- AQEShuffleRead (37)
+                        :                    :                    :        +- ShuffleQueryStage (36), Statistics(X)
+                        :                    :                    :           +- NativeShuffleExchange (35)
+                        :                    :                    :              +- NativeProject (34)
+                        :                    :                    :                 +- NativeSortMergeJoin Inner (33)
+                        :                    :                    :                    :- NativeSort (23)
+                        :                    :                    :                    :  +- InputAdapter (22)
+                        :                    :                    :                    :     +- AQEShuffleRead (21)
+                        :                    :                    :                    :        +- ShuffleQueryStage (20), Statistics(X)
+                        :                    :                    :                    :           +- NativeShuffleExchange (19)
+                        :                    :                    :                    :              +- NativeProject (18)
+                        :                    :                    :                    :                 +- NativeSortMergeJoin Inner (17)
+                        :                    :                    :                    :                    :- NativeSort (8)
+                        :                    :                    :                    :                    :  +- InputAdapter (7)
+                        :                    :                    :                    :                    :     +- AQEShuffleRead (6)
+                        :                    :                    :                    :                    :        +- ShuffleQueryStage (5), Statistics(X)
+                        :                    :                    :                    :                    :           +- NativeShuffleExchange (4)
+                        :                    :                    :                    :                    :              +- NativeFilter (3)
+                        :                    :                    :                    :                    :                 +- InputAdapter (2)
+                        :                    :                    :                    :                    :                    +- NativeParquetScan  (1)
+                        :                    :                    :                    :                    +- NativeSort (16)
+                        :                    :                    :                    :                       +- InputAdapter (15)
+                        :                    :                    :                    :                          +- AQEShuffleRead (14)
+                        :                    :                    :                    :                             +- ShuffleQueryStage (13), Statistics(X)
+                        :                    :                    :                    :                                +- NativeShuffleExchange (12)
+                        :                    :                    :                    :                                   +- NativeFilter (11)
+                        :                    :                    :                    :                                      +- InputAdapter (10)
+                        :                    :                    :                    :                                         +- NativeParquetScan  (9)
+                        :                    :                    :                    +- NativeSort (32)
+                        :                    :                    :                       +- InputAdapter (31)
+                        :                    :                    :                          +- AQEShuffleRead (30)
+                        :                    :                    :                             +- ShuffleQueryStage (29), Statistics(X)
+                        :                    :                    :                                +- NativeShuffleExchange (28)
+                        :                    :                    :                                   +- NativeProject (27)
+                        :                    :                    :                                      +- NativeFilter (26)
+                        :                    :                    :                                         +- InputAdapter (25)
+                        :                    :                    :                                            +- NativeParquetScan  (24)
+                        :                    :                    +- NativeSort (48)
+                        :                    :                       +- InputAdapter (47)
+                        :                    :                          +- AQEShuffleRead (46)
+                        :                    :                             +- ShuffleQueryStage (45), Statistics(X)
+                        :                    :                                +- NativeShuffleExchange (44)
+                        :                    :                                   +- NativeProject (43)
+                        :                    :                                      +- NativeFilter (42)
+                        :                    :                                         +- InputAdapter (41)
+                        :                    :                                            +- NativeParquetScan  (40)
+                        :                    +- NativeSort (63)
+                        :                       +- InputAdapter (62)
+                        :                          +- AQEShuffleRead (61)
+                        :                             +- ShuffleQueryStage (60), Statistics(X)
+                        :                                +- NativeShuffleExchange (59)
+                        :                                   +- NativeFilter (58)
+                        :                                      +- InputAdapter (57)
+                        :                                         +- NativeParquetScan  (56)
+                        +- NativeSort (78)
+                           +- InputAdapter (77)
+                              +- AQEShuffleRead (76)
+                                 +- ShuffleQueryStage (75), Statistics(X)
+                                    +- NativeShuffleExchange (74)
+                                       +- NativeFilter (73)
+                                          +- InputAdapter (72)
+                                             +- NativeParquetScan  (71)
 +- == Initial Plan ==
    HashAggregate (133)
    +- Exchange (132)
@@ -272,35 +272,32 @@ Input [2]: [ca_address_sk#12, ca_state#13]
 Input [2]: [ca_address_sk#12, ca_state#13]
 Arguments: [ca_address_sk#12 ASC NULLS FIRST], false
 
-(33) SortMergeJoin [codegen id : X]
+(33) NativeSortMergeJoin
 Left keys [1]: [ss_addr_sk#4]
 Right keys [1]: [ca_address_sk#12]
 Join type: Inner
 Join condition: ((((ca_state#13 IN (TX,OH) AND (ss_net_profit#10 >= 100.00)) AND (ss_net_profit#10 <= 200.00)) OR ((ca_state#13 IN (OR,NM,KY) AND (ss_net_profit#10 >= 150.00)) AND (ss_net_profit#10 <= 300.00))) OR ((ca_state#13 IN (VA,TX,MS) AND (ss_net_profit#10 >= 50.00)) AND (ss_net_profit#10 <= 250.00)))
 
-(34) Project [codegen id : X]
+(34) NativeProject
 Output [7]: [ss_sold_date_sk#1, ss_cdemo_sk#2, ss_hdemo_sk#3, ss_quantity#6, ss_sales_price#7, ss_ext_sales_price#8, ss_ext_wholesale_cost#9]
 Input [11]: [ss_sold_date_sk#1, ss_cdemo_sk#2, ss_hdemo_sk#3, ss_addr_sk#4, ss_quantity#6, ss_sales_price#7, ss_ext_sales_price#8, ss_ext_wholesale_cost#9, ss_net_profit#10, ca_address_sk#12, ca_state#13]
 
-(35) ConvertToNative
-Input [7]: [ss_sold_date_sk#1, ss_cdemo_sk#2, ss_hdemo_sk#3, ss_quantity#6, ss_sales_price#7, ss_ext_sales_price#8, ss_ext_wholesale_cost#9]
-
-(36) NativeShuffleExchange
+(35) NativeShuffleExchange
 Input [7]: [ss_sold_date_sk#1, ss_cdemo_sk#2, ss_hdemo_sk#3, ss_quantity#6, ss_sales_price#7, ss_ext_sales_price#8, ss_ext_wholesale_cost#9]
 Arguments: hashpartitioning(ss_sold_date_sk#1, 100), ENSURE_REQUIREMENTS, [plan_id=5]
 
-(37) ShuffleQueryStage
+(36) ShuffleQueryStage
 Output [7]: [ss_sold_date_sk#1, ss_cdemo_sk#2, ss_hdemo_sk#3, ss_quantity#6, ss_sales_price#7, ss_ext_sales_price#8, ss_ext_wholesale_cost#9]
 Arguments: X
 
-(38) AQEShuffleRead
+(37) AQEShuffleRead
 Input [7]: [ss_sold_date_sk#1, ss_cdemo_sk#2, ss_hdemo_sk#3, ss_quantity#6, ss_sales_price#7, ss_ext_sales_price#8, ss_ext_wholesale_cost#9]
 Arguments: coalesced
 
-(39) InputAdapter
+(38) InputAdapter
 Input [7]: [ss_sold_date_sk#1, ss_cdemo_sk#2, ss_hdemo_sk#3, ss_quantity#6, ss_sales_price#7, ss_ext_sales_price#8, ss_ext_wholesale_cost#9]
 
-(40) NativeSort
+(39) NativeSort
 Input [7]: [ss_sold_date_sk#1, ss_cdemo_sk#2, ss_hdemo_sk#3, ss_quantity#6, ss_sales_price#7, ss_ext_sales_price#8, ss_ext_wholesale_cost#9]
 Arguments: [ss_sold_date_sk#1 ASC NULLS FIRST], false
 
@@ -311,63 +308,63 @@ Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2001), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
-(42) InputAdapter
+(41) InputAdapter
 Input [2]: [d_date_sk#15, d_year#16]
 Arguments: [#15, #16]
 
-(43) NativeFilter
+(42) NativeFilter
 Input [2]: [#15#15, #16#16]
 Condition : ((isnotnull(d_year#16) AND (d_year#16 = 2001)) AND isnotnull(d_date_sk#15))
 
-(44) NativeProject
+(43) NativeProject
 Output [1]: [d_date_sk#15]
 Input [2]: [#15#15, #16#16]
 
-(45) NativeShuffleExchange
+(44) NativeShuffleExchange
 Input [1]: [d_date_sk#15]
 Arguments: hashpartitioning(d_date_sk#15, 100), ENSURE_REQUIREMENTS, [plan_id=6]
 
-(46) ShuffleQueryStage
+(45) ShuffleQueryStage
 Output [1]: [d_date_sk#15]
 Arguments: X
 
-(47) AQEShuffleRead
+(46) AQEShuffleRead
 Input [1]: [d_date_sk#15]
 Arguments: coalesced
 
-(48) InputAdapter
+(47) InputAdapter
 Input [1]: [d_date_sk#15]
 
-(49) NativeSort
+(48) NativeSort
 Input [1]: [d_date_sk#15]
 Arguments: [d_date_sk#15 ASC NULLS FIRST], false
 
-(50) NativeSortMergeJoin
+(49) NativeSortMergeJoin
 Left keys [1]: [ss_sold_date_sk#1]
 Right keys [1]: [d_date_sk#15]
 Join type: Inner
 Join condition: None
 
-(51) NativeProject
+(50) NativeProject
 Output [6]: [ss_cdemo_sk#2, ss_hdemo_sk#3, ss_quantity#6, ss_sales_price#7, ss_ext_sales_price#8, ss_ext_wholesale_cost#9]
 Input [8]: [ss_sold_date_sk#1, ss_cdemo_sk#2, ss_hdemo_sk#3, ss_quantity#6, ss_sales_price#7, ss_ext_sales_price#8, ss_ext_wholesale_cost#9, d_date_sk#15]
 
-(52) NativeShuffleExchange
+(51) NativeShuffleExchange
 Input [6]: [ss_cdemo_sk#2, ss_hdemo_sk#3, ss_quantity#6, ss_sales_price#7, ss_ext_sales_price#8, ss_ext_wholesale_cost#9]
 Arguments: hashpartitioning(ss_cdemo_sk#2, 100), ENSURE_REQUIREMENTS, [plan_id=7]
 
-(53) ShuffleQueryStage
+(52) ShuffleQueryStage
 Output [6]: [ss_cdemo_sk#2, ss_hdemo_sk#3, ss_quantity#6, ss_sales_price#7, ss_ext_sales_price#8, ss_ext_wholesale_cost#9]
 Arguments: X
 
-(54) AQEShuffleRead
+(53) AQEShuffleRead
 Input [6]: [ss_cdemo_sk#2, ss_hdemo_sk#3, ss_quantity#6, ss_sales_price#7, ss_ext_sales_price#8, ss_ext_wholesale_cost#9]
 Arguments: coalesced
 
-(55) InputAdapter
+(54) InputAdapter
 Input [6]: [ss_cdemo_sk#2, ss_hdemo_sk#3, ss_quantity#6, ss_sales_price#7, ss_ext_sales_price#8, ss_ext_wholesale_cost#9]
 
-(56) NativeSort
+(55) NativeSort
 Input [6]: [ss_cdemo_sk#2, ss_hdemo_sk#3, ss_quantity#6, ss_sales_price#7, ss_ext_sales_price#8, ss_ext_wholesale_cost#9]
 Arguments: [ss_cdemo_sk#2 ASC NULLS FIRST], false
 
@@ -378,62 +375,59 @@ Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(cd_demo_sk), Or(Or(And(EqualTo(cd_marital_status,M),EqualTo(cd_education_status,Advanced Degree)),And(EqualTo(cd_marital_status,S),EqualTo(cd_education_status,College))),And(EqualTo(cd_marital_status,W),EqualTo(cd_education_status,2 yr Degree)))]
 ReadSchema: struct<cd_demo_sk:int,cd_marital_status:string,cd_education_status:string>
 
-(58) InputAdapter
+(57) InputAdapter
 Input [3]: [cd_demo_sk#17, cd_marital_status#18, cd_education_status#19]
 Arguments: [#17, #18, #19]
 
-(59) NativeFilter
+(58) NativeFilter
 Input [3]: [#17#17, #18#18, #19#19]
 Condition : (isnotnull(cd_demo_sk#17) AND ((((cd_marital_status#18 = M) AND (cd_education_status#19 = Advanced Degree)) OR ((cd_marital_status#18 = S) AND (cd_education_status#19 = College))) OR ((cd_marital_status#18 = W) AND (cd_education_status#19 = 2 yr Degree))))
 
-(60) NativeShuffleExchange
+(59) NativeShuffleExchange
 Input [3]: [#17#17, #18#18, #19#19]
 Arguments: hashpartitioning(cd_demo_sk#17, 100), ENSURE_REQUIREMENTS, [plan_id=8]
 
-(61) ShuffleQueryStage
+(60) ShuffleQueryStage
 Output [3]: [#17#17, #18#18, #19#19]
 Arguments: X
 
-(62) AQEShuffleRead
+(61) AQEShuffleRead
 Input [3]: [#17#17, #18#18, #19#19]
 Arguments: coalesced
 
-(63) InputAdapter
+(62) InputAdapter
 Input [3]: [#17#17, #18#18, #19#19]
 
-(64) NativeSort
+(63) NativeSort
 Input [3]: [#17#17, #18#18, #19#19]
 Arguments: [cd_demo_sk#17 ASC NULLS FIRST], false
 
-(65) SortMergeJoin [codegen id : X]
+(64) NativeSortMergeJoin
 Left keys [1]: [ss_cdemo_sk#2]
 Right keys [1]: [cd_demo_sk#17]
 Join type: Inner
 Join condition: ((((((cd_marital_status#18 = M) AND (cd_education_status#19 = Advanced Degree)) AND (ss_sales_price#7 >= 100.00)) AND (ss_sales_price#7 <= 150.00)) OR ((((cd_marital_status#18 = S) AND (cd_education_status#19 = College)) AND (ss_sales_price#7 >= 50.00)) AND (ss_sales_price#7 <= 100.00))) OR ((((cd_marital_status#18 = W) AND (cd_education_status#19 = 2 yr Degree)) AND (ss_sales_price#7 >= 150.00)) AND (ss_sales_price#7 <= 200.00)))
 
-(66) Project [codegen id : X]
+(65) NativeProject
 Output [7]: [ss_hdemo_sk#3, ss_quantity#6, ss_sales_price#7, ss_ext_sales_price#8, ss_ext_wholesale_cost#9, cd_marital_status#18, cd_education_status#19]
 Input [9]: [ss_cdemo_sk#2, ss_hdemo_sk#3, ss_quantity#6, ss_sales_price#7, ss_ext_sales_price#8, ss_ext_wholesale_cost#9, #17#17, #18#18, #19#19]
 
-(67) ConvertToNative
-Input [7]: [ss_hdemo_sk#3, ss_quantity#6, ss_sales_price#7, ss_ext_sales_price#8, ss_ext_wholesale_cost#9, cd_marital_status#18, cd_education_status#19]
-
-(68) NativeShuffleExchange
+(66) NativeShuffleExchange
 Input [7]: [ss_hdemo_sk#3, ss_quantity#6, ss_sales_price#7, ss_ext_sales_price#8, ss_ext_wholesale_cost#9, cd_marital_status#18, cd_education_status#19]
 Arguments: hashpartitioning(ss_hdemo_sk#3, 100), ENSURE_REQUIREMENTS, [plan_id=9]
 
-(69) ShuffleQueryStage
+(67) ShuffleQueryStage
 Output [7]: [ss_hdemo_sk#3, ss_quantity#6, ss_sales_price#7, ss_ext_sales_price#8, ss_ext_wholesale_cost#9, cd_marital_status#18, cd_education_status#19]
 Arguments: X
 
-(70) AQEShuffleRead
+(68) AQEShuffleRead
 Input [7]: [ss_hdemo_sk#3, ss_quantity#6, ss_sales_price#7, ss_ext_sales_price#8, ss_ext_wholesale_cost#9, cd_marital_status#18, cd_education_status#19]
 Arguments: coalesced
 
-(71) InputAdapter
+(69) InputAdapter
 Input [7]: [ss_hdemo_sk#3, ss_quantity#6, ss_sales_price#7, ss_ext_sales_price#8, ss_ext_wholesale_cost#9, cd_marital_status#18, cd_education_status#19]
 
-(72) NativeSort
+(70) NativeSort
 Input [7]: [ss_hdemo_sk#3, ss_quantity#6, ss_sales_price#7, ss_ext_sales_price#8, ss_ext_wholesale_cost#9, cd_marital_status#18, cd_education_status#19]
 Arguments: [ss_hdemo_sk#3 ASC NULLS FIRST], false
 
@@ -444,64 +438,72 @@ Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(hd_demo_sk), Or(EqualTo(hd_dep_count,3),EqualTo(hd_dep_count,1))]
 ReadSchema: struct<hd_demo_sk:int,hd_dep_count:int>
 
-(74) InputAdapter
+(72) InputAdapter
 Input [2]: [hd_demo_sk#20, hd_dep_count#21]
 Arguments: [#20, #21]
 
-(75) NativeFilter
+(73) NativeFilter
 Input [2]: [#20#20, #21#21]
 Condition : (isnotnull(hd_demo_sk#20) AND ((hd_dep_count#21 = 3) OR (hd_dep_count#21 = 1)))
 
-(76) NativeShuffleExchange
+(74) NativeShuffleExchange
 Input [2]: [#20#20, #21#21]
 Arguments: hashpartitioning(hd_demo_sk#20, 100), ENSURE_REQUIREMENTS, [plan_id=10]
 
-(77) ShuffleQueryStage
+(75) ShuffleQueryStage
 Output [2]: [#20#20, #21#21]
 Arguments: X
 
-(78) AQEShuffleRead
+(76) AQEShuffleRead
 Input [2]: [#20#20, #21#21]
 Arguments: coalesced
 
-(79) InputAdapter
+(77) InputAdapter
 Input [2]: [#20#20, #21#21]
 
-(80) NativeSort
+(78) NativeSort
 Input [2]: [#20#20, #21#21]
 Arguments: [hd_demo_sk#20 ASC NULLS FIRST], false
 
-(81) SortMergeJoin [codegen id : X]
+(79) NativeSortMergeJoin
 Left keys [1]: [ss_hdemo_sk#3]
 Right keys [1]: [hd_demo_sk#20]
 Join type: Inner
 Join condition: (((((((cd_marital_status#18 = M) AND (cd_education_status#19 = Advanced Degree)) AND (ss_sales_price#7 >= 100.00)) AND (ss_sales_price#7 <= 150.00)) AND (hd_dep_count#21 = 3)) OR (((((cd_marital_status#18 = S) AND (cd_education_status#19 = College)) AND (ss_sales_price#7 >= 50.00)) AND (ss_sales_price#7 <= 100.00)) AND (hd_dep_count#21 = 1))) OR (((((cd_marital_status#18 = W) AND (cd_education_status#19 = 2 yr Degree)) AND (ss_sales_price#7 >= 150.00)) AND (ss_sales_price#7 <= 200.00)) AND (hd_dep_count#21 = 1)))
 
-(82) Project [codegen id : X]
+(80) NativeProject
 Output [3]: [ss_quantity#6, ss_ext_sales_price#8, ss_ext_wholesale_cost#9]
 Input [9]: [ss_hdemo_sk#3, ss_quantity#6, ss_sales_price#7, ss_ext_sales_price#8, ss_ext_wholesale_cost#9, cd_marital_status#18, cd_education_status#19, #20#20, #21#21]
 
-(83) HashAggregate [codegen id : X]
+(81) NativeProject
+Output [3]: [ss_quantity#6 AS _c0#22, UnscaledValue(ss_ext_sales_price#8) AS _c1#23, UnscaledValue(ss_ext_wholesale_cost#9) AS _c2#24]
 Input [3]: [ss_quantity#6, ss_ext_sales_price#8, ss_ext_wholesale_cost#9]
-Keys: []
-Functions [4]: [partial_avg(ss_quantity#6), partial_avg(UnscaledValue(ss_ext_sales_price#8)), partial_avg(UnscaledValue(ss_ext_wholesale_cost#9)), partial_sum(UnscaledValue(ss_ext_wholesale_cost#9))]
-Aggregate Attributes [7]: [sum#22, count#23, sum#24, count#25, sum#26, count#27, sum#28]
-Results [7]: [sum#29, count#30, sum#31, count#32, sum#33, count#34, sum#35]
 
-(84) Exchange
-Input [7]: [sum#29, count#30, sum#31, count#32, sum#33, count#34, sum#35]
+(82) NativeHashAggregate
+Input [3]: [_c0#22, _c1#23, _c2#24]
+Keys: []
+Functions [4]: [partial_avg(_c0#22), partial_avg(_c1#23), partial_avg(_c2#24), partial_sum(_c2#24)]
+Aggregate Attributes [7]: [sum#25, count#26, sum#27, count#28, sum#29, count#30, sum#31]
+Results [7]: [#32, #33, #32, #33, #32, #33, #33]
+
+(83) NativeShuffleExchange
+Input [7]: [#32, #33, #32, #33, #32, #33, #33]
 Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=11]
 
-(85) ShuffleQueryStage
-Output [7]: [sum#29, count#30, sum#31, count#32, sum#33, count#34, sum#35]
+(84) ShuffleQueryStage
+Output [7]: [#32, #33, #32, #33, #32, #33, #33]
 Arguments: X
 
-(86) HashAggregate [codegen id : X]
-Input [7]: [sum#29, count#30, sum#31, count#32, sum#33, count#34, sum#35]
+(85) NativeHashAggregate
+Input [7]: [#32, #33, #32, #33, #32, #33, #33]
 Keys: []
 Functions [4]: [avg(ss_quantity#6), avg(UnscaledValue(ss_ext_sales_price#8)), avg(UnscaledValue(ss_ext_wholesale_cost#9)), sum(UnscaledValue(ss_ext_wholesale_cost#9))]
-Aggregate Attributes [4]: [avg(ss_quantity#6)#36, avg(UnscaledValue(ss_ext_sales_price#8))#37, avg(UnscaledValue(ss_ext_wholesale_cost#9))#38, sum(UnscaledValue(ss_ext_wholesale_cost#9))#39]
-Results [4]: [avg(ss_quantity#6)#36 AS avg(ss_quantity)#40, cast((avg(UnscaledValue(ss_ext_sales_price#8))#37 / 100.0) as decimal(11,6)) AS avg(ss_ext_sales_price)#41, cast((avg(UnscaledValue(ss_ext_wholesale_cost#9))#38 / 100.0) as decimal(11,6)) AS avg(ss_ext_wholesale_cost)#42, MakeDecimal(sum(UnscaledValue(ss_ext_wholesale_cost#9))#39,17,2) AS sum(ss_ext_wholesale_cost)#43]
+Aggregate Attributes [4]: [avg(ss_quantity#6)#34, avg(UnscaledValue(ss_ext_sales_price#8))#35, avg(UnscaledValue(ss_ext_wholesale_cost#9))#36, sum(UnscaledValue(ss_ext_wholesale_cost#9))#37]
+Results [4]: [avg(ss_quantity#6)#34, avg(UnscaledValue(ss_ext_sales_price#8))#35, avg(UnscaledValue(ss_ext_wholesale_cost#9))#36, sum(UnscaledValue(ss_ext_wholesale_cost#9))#37]
+
+(86) NativeProject
+Output [4]: [avg(ss_quantity#6)#34 AS avg(ss_quantity)#38, cast((avg(UnscaledValue(ss_ext_sales_price#8))#35 / 100.0) as decimal(11,6)) AS avg(ss_ext_sales_price)#39, cast((avg(UnscaledValue(ss_ext_wholesale_cost#9))#36 / 100.0) as decimal(11,6)) AS avg(ss_ext_wholesale_cost)#40, MakeDecimal(sum(UnscaledValue(ss_ext_wholesale_cost#9))#37,17,2) AS sum(ss_ext_wholesale_cost)#41]
+Input [4]: [avg(ss_quantity#6)#34, avg(UnscaledValue(ss_ext_sales_price#8))#35, avg(UnscaledValue(ss_ext_wholesale_cost#9))#36, sum(UnscaledValue(ss_ext_wholesale_cost#9))#37]
 
 (87) Scan parquet
 Output [10]: [ss_sold_date_sk#1, ss_cdemo_sk#2, ss_hdemo_sk#3, ss_addr_sk#4, ss_store_sk#5, ss_quantity#6, ss_sales_price#7, ss_ext_sales_price#8, ss_ext_wholesale_cost#9, ss_net_profit#10]
@@ -711,21 +713,21 @@ Input [9]: [ss_hdemo_sk#3, ss_quantity#6, ss_sales_price#7, ss_ext_sales_price#8
 Input [3]: [ss_quantity#6, ss_ext_sales_price#8, ss_ext_wholesale_cost#9]
 Keys: []
 Functions [4]: [partial_avg(ss_quantity#6), partial_avg(UnscaledValue(ss_ext_sales_price#8)), partial_avg(UnscaledValue(ss_ext_wholesale_cost#9)), partial_sum(UnscaledValue(ss_ext_wholesale_cost#9))]
-Aggregate Attributes [7]: [sum#22, count#23, sum#24, count#25, sum#26, count#27, sum#28]
-Results [7]: [sum#29, count#30, sum#31, count#32, sum#33, count#34, sum#35]
+Aggregate Attributes [7]: [sum#25, count#26, sum#27, count#28, sum#29, count#30, sum#31]
+Results [7]: [sum#42, count#43, sum#44, count#45, sum#46, count#47, sum#48]
 
 (132) Exchange
-Input [7]: [sum#29, count#30, sum#31, count#32, sum#33, count#34, sum#35]
+Input [7]: [sum#42, count#43, sum#44, count#45, sum#46, count#47, sum#48]
 Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=22]
 
 (133) HashAggregate
-Input [7]: [sum#29, count#30, sum#31, count#32, sum#33, count#34, sum#35]
+Input [7]: [sum#42, count#43, sum#44, count#45, sum#46, count#47, sum#48]
 Keys: []
 Functions [4]: [avg(ss_quantity#6), avg(UnscaledValue(ss_ext_sales_price#8)), avg(UnscaledValue(ss_ext_wholesale_cost#9)), sum(UnscaledValue(ss_ext_wholesale_cost#9))]
-Aggregate Attributes [4]: [avg(ss_quantity#6)#36, avg(UnscaledValue(ss_ext_sales_price#8))#37, avg(UnscaledValue(ss_ext_wholesale_cost#9))#38, sum(UnscaledValue(ss_ext_wholesale_cost#9))#39]
-Results [4]: [avg(ss_quantity#6)#36 AS avg(ss_quantity)#40, cast((avg(UnscaledValue(ss_ext_sales_price#8))#37 / 100.0) as decimal(11,6)) AS avg(ss_ext_sales_price)#41, cast((avg(UnscaledValue(ss_ext_wholesale_cost#9))#38 / 100.0) as decimal(11,6)) AS avg(ss_ext_wholesale_cost)#42, MakeDecimal(sum(UnscaledValue(ss_ext_wholesale_cost#9))#39,17,2) AS sum(ss_ext_wholesale_cost)#43]
+Aggregate Attributes [4]: [avg(ss_quantity#6)#34, avg(UnscaledValue(ss_ext_sales_price#8))#35, avg(UnscaledValue(ss_ext_wholesale_cost#9))#36, sum(UnscaledValue(ss_ext_wholesale_cost#9))#37]
+Results [4]: [avg(ss_quantity#6)#34 AS avg(ss_quantity)#38, cast((avg(UnscaledValue(ss_ext_sales_price#8))#35 / 100.0) as decimal(11,6)) AS avg(ss_ext_sales_price)#39, cast((avg(UnscaledValue(ss_ext_wholesale_cost#9))#36 / 100.0) as decimal(11,6)) AS avg(ss_ext_wholesale_cost)#40, MakeDecimal(sum(UnscaledValue(ss_ext_wholesale_cost#9))#37,17,2) AS sum(ss_ext_wholesale_cost)#41]
 
 (134) AdaptiveSparkPlan
-Output [4]: [avg(ss_quantity)#40, avg(ss_ext_sales_price)#41, avg(ss_ext_wholesale_cost)#42, sum(ss_ext_wholesale_cost)#43]
+Output [4]: [avg(ss_quantity)#38, avg(ss_ext_sales_price)#39, avg(ss_ext_wholesale_cost)#40, sum(ss_ext_wholesale_cost)#41]
 Arguments: isFinalPlan=true
 

--- a/dev/auron-it/src/main/resources/tpcds-plan-stability/spark-3.5/q15.txt
+++ b/dev/auron-it/src/main/resources/tpcds-plan-stability/spark-3.5/q15.txt
@@ -1,100 +1,99 @@
 == Physical Plan ==
-AdaptiveSparkPlan (91)
+AdaptiveSparkPlan (90)
 +- == Final Plan ==
-   NativeTakeOrdered (59)
-   +- NativeProject (58)
-      +- NativeHashAggregate (57)
-         +- InputAdapter (56)
-            +- AQEShuffleRead (55)
-               +- ShuffleQueryStage (54), Statistics(X)
-                  +- NativeShuffleExchange (53)
-                     +- NativeHashAggregate (52)
-                        +- NativeProject (51)
-                           +- NativeProject (50)
-                              +- NativeSortMergeJoin Inner (49)
-                                 :- NativeSort (39)
-                                 :  +- InputAdapter (38)
-                                 :     +- AQEShuffleRead (37)
-                                 :        +- ShuffleQueryStage (36), Statistics(X)
-                                 :           +- NativeShuffleExchange (35)
-                                 :              +- ConvertToNative (34)
-                                 :                 +- * Project (33)
-                                 :                    +- * SortMergeJoin Inner (32)
-                                 :                       :- NativeSort (23)
-                                 :                       :  +- InputAdapter (22)
-                                 :                       :     +- AQEShuffleRead (21)
-                                 :                       :        +- ShuffleQueryStage (20), Statistics(X)
-                                 :                       :           +- NativeShuffleExchange (19)
-                                 :                       :              +- NativeProject (18)
-                                 :                       :                 +- NativeSortMergeJoin Inner (17)
-                                 :                       :                    :- NativeSort (8)
-                                 :                       :                    :  +- InputAdapter (7)
-                                 :                       :                    :     +- AQEShuffleRead (6)
-                                 :                       :                    :        +- ShuffleQueryStage (5), Statistics(X)
-                                 :                       :                    :           +- NativeShuffleExchange (4)
-                                 :                       :                    :              +- NativeFilter (3)
-                                 :                       :                    :                 +- InputAdapter (2)
-                                 :                       :                    :                    +- NativeParquetScan  (1)
-                                 :                       :                    +- NativeSort (16)
-                                 :                       :                       +- InputAdapter (15)
-                                 :                       :                          +- AQEShuffleRead (14)
-                                 :                       :                             +- ShuffleQueryStage (13), Statistics(X)
-                                 :                       :                                +- NativeShuffleExchange (12)
-                                 :                       :                                   +- NativeFilter (11)
-                                 :                       :                                      +- InputAdapter (10)
-                                 :                       :                                         +- NativeParquetScan  (9)
-                                 :                       +- NativeSort (31)
-                                 :                          +- InputAdapter (30)
-                                 :                             +- AQEShuffleRead (29)
-                                 :                                +- ShuffleQueryStage (28), Statistics(X)
-                                 :                                   +- NativeShuffleExchange (27)
-                                 :                                      +- NativeFilter (26)
-                                 :                                         +- InputAdapter (25)
-                                 :                                            +- NativeParquetScan  (24)
-                                 +- NativeSort (48)
-                                    +- InputAdapter (47)
-                                       +- AQEShuffleRead (46)
-                                          +- ShuffleQueryStage (45), Statistics(X)
-                                             +- NativeShuffleExchange (44)
-                                                +- NativeProject (43)
-                                                   +- NativeFilter (42)
-                                                      +- InputAdapter (41)
-                                                         +- NativeParquetScan  (40)
+   NativeTakeOrdered (58)
+   +- NativeProject (57)
+      +- NativeHashAggregate (56)
+         +- InputAdapter (55)
+            +- AQEShuffleRead (54)
+               +- ShuffleQueryStage (53), Statistics(X)
+                  +- NativeShuffleExchange (52)
+                     +- NativeHashAggregate (51)
+                        +- NativeProject (50)
+                           +- NativeProject (49)
+                              +- NativeSortMergeJoin Inner (48)
+                                 :- NativeSort (38)
+                                 :  +- InputAdapter (37)
+                                 :     +- AQEShuffleRead (36)
+                                 :        +- ShuffleQueryStage (35), Statistics(X)
+                                 :           +- NativeShuffleExchange (34)
+                                 :              +- NativeProject (33)
+                                 :                 +- NativeSortMergeJoin Inner (32)
+                                 :                    :- NativeSort (23)
+                                 :                    :  +- InputAdapter (22)
+                                 :                    :     +- AQEShuffleRead (21)
+                                 :                    :        +- ShuffleQueryStage (20), Statistics(X)
+                                 :                    :           +- NativeShuffleExchange (19)
+                                 :                    :              +- NativeProject (18)
+                                 :                    :                 +- NativeSortMergeJoin Inner (17)
+                                 :                    :                    :- NativeSort (8)
+                                 :                    :                    :  +- InputAdapter (7)
+                                 :                    :                    :     +- AQEShuffleRead (6)
+                                 :                    :                    :        +- ShuffleQueryStage (5), Statistics(X)
+                                 :                    :                    :           +- NativeShuffleExchange (4)
+                                 :                    :                    :              +- NativeFilter (3)
+                                 :                    :                    :                 +- InputAdapter (2)
+                                 :                    :                    :                    +- NativeParquetScan  (1)
+                                 :                    :                    +- NativeSort (16)
+                                 :                    :                       +- InputAdapter (15)
+                                 :                    :                          +- AQEShuffleRead (14)
+                                 :                    :                             +- ShuffleQueryStage (13), Statistics(X)
+                                 :                    :                                +- NativeShuffleExchange (12)
+                                 :                    :                                   +- NativeFilter (11)
+                                 :                    :                                      +- InputAdapter (10)
+                                 :                    :                                         +- NativeParquetScan  (9)
+                                 :                    +- NativeSort (31)
+                                 :                       +- InputAdapter (30)
+                                 :                          +- AQEShuffleRead (29)
+                                 :                             +- ShuffleQueryStage (28), Statistics(X)
+                                 :                                +- NativeShuffleExchange (27)
+                                 :                                   +- NativeFilter (26)
+                                 :                                      +- InputAdapter (25)
+                                 :                                         +- NativeParquetScan  (24)
+                                 +- NativeSort (47)
+                                    +- InputAdapter (46)
+                                       +- AQEShuffleRead (45)
+                                          +- ShuffleQueryStage (44), Statistics(X)
+                                             +- NativeShuffleExchange (43)
+                                                +- NativeProject (42)
+                                                   +- NativeFilter (41)
+                                                      +- InputAdapter (40)
+                                                         +- NativeParquetScan  (39)
 +- == Initial Plan ==
-   TakeOrderedAndProject (90)
-   +- HashAggregate (89)
-      +- Exchange (88)
-         +- HashAggregate (87)
-            +- Project (86)
-               +- SortMergeJoin Inner (85)
-                  :- Sort (79)
-                  :  +- Exchange (78)
-                  :     +- Project (77)
-                  :        +- SortMergeJoin Inner (76)
-                  :           :- Sort (71)
-                  :           :  +- Exchange (70)
-                  :           :     +- Project (69)
-                  :           :        +- SortMergeJoin Inner (68)
-                  :           :           :- Sort (63)
-                  :           :           :  +- Exchange (62)
-                  :           :           :     +- Filter (61)
-                  :           :           :        +- Scan parquet (60)
-                  :           :           +- Sort (67)
-                  :           :              +- Exchange (66)
-                  :           :                 +- Filter (65)
-                  :           :                    +- Scan parquet (64)
-                  :           +- Sort (75)
-                  :              +- Exchange (74)
-                  :                 +- Filter (73)
-                  :                    +- Scan parquet (72)
-                  +- Sort (84)
-                     +- Exchange (83)
-                        +- Project (82)
-                           +- Filter (81)
-                              +- Scan parquet (80)
+   TakeOrderedAndProject (89)
+   +- HashAggregate (88)
+      +- Exchange (87)
+         +- HashAggregate (86)
+            +- Project (85)
+               +- SortMergeJoin Inner (84)
+                  :- Sort (78)
+                  :  +- Exchange (77)
+                  :     +- Project (76)
+                  :        +- SortMergeJoin Inner (75)
+                  :           :- Sort (70)
+                  :           :  +- Exchange (69)
+                  :           :     +- Project (68)
+                  :           :        +- SortMergeJoin Inner (67)
+                  :           :           :- Sort (62)
+                  :           :           :  +- Exchange (61)
+                  :           :           :     +- Filter (60)
+                  :           :           :        +- Scan parquet (59)
+                  :           :           +- Sort (66)
+                  :           :              +- Exchange (65)
+                  :           :                 +- Filter (64)
+                  :           :                    +- Scan parquet (63)
+                  :           +- Sort (74)
+                  :              +- Exchange (73)
+                  :                 +- Filter (72)
+                  :                    +- Scan parquet (71)
+                  +- Sort (83)
+                     +- Exchange (82)
+                        +- Project (81)
+                           +- Filter (80)
+                              +- Scan parquet (79)
 
 
-(60) Scan parquet
+(59) Scan parquet
 Output [3]: [cs_sold_date_sk#1, cs_bill_customer_sk#2, cs_sales_price#3]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
@@ -128,7 +127,7 @@ Input [3]: [#1#1, #2#2, #3#3]
 Input [3]: [#1#1, #2#2, #3#3]
 Arguments: [cs_bill_customer_sk#2 ASC NULLS FIRST], false
 
-(64) Scan parquet
+(63) Scan parquet
 Output [2]: [c_customer_sk#4, c_current_addr_sk#5]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
@@ -191,7 +190,7 @@ Input [3]: [cs_sold_date_sk#1, cs_sales_price#3, c_current_addr_sk#5]
 Input [3]: [cs_sold_date_sk#1, cs_sales_price#3, c_current_addr_sk#5]
 Arguments: [c_current_addr_sk#5 ASC NULLS FIRST], false
 
-(72) Scan parquet
+(71) Scan parquet
 Output [3]: [ca_address_sk#6, ca_state#7, ca_zip#8]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
@@ -225,276 +224,273 @@ Input [3]: [#6#6, #7#7, #8#8]
 Input [3]: [#6#6, #7#7, #8#8]
 Arguments: [ca_address_sk#6 ASC NULLS FIRST], false
 
-(32) SortMergeJoin [codegen id : X]
+(32) NativeSortMergeJoin
 Left keys [1]: [c_current_addr_sk#5]
 Right keys [1]: [ca_address_sk#6]
 Join type: Inner
 Join condition: ((substr(ca_zip#8, 1, 5) IN (85669,86197,88274,83405,86475,85392,85460,80348,81792) OR ca_state#7 IN (CA,WA,GA)) OR (cs_sales_price#3 > 500.00))
 
-(33) Project [codegen id : X]
+(33) NativeProject
 Output [3]: [cs_sold_date_sk#1, cs_sales_price#3, ca_zip#8]
 Input [6]: [cs_sold_date_sk#1, cs_sales_price#3, c_current_addr_sk#5, #6#6, #7#7, #8#8]
 
-(34) ConvertToNative
-Input [3]: [cs_sold_date_sk#1, cs_sales_price#3, ca_zip#8]
-
-(35) NativeShuffleExchange
+(34) NativeShuffleExchange
 Input [3]: [cs_sold_date_sk#1, cs_sales_price#3, ca_zip#8]
 Arguments: hashpartitioning(cs_sold_date_sk#1, 100), ENSURE_REQUIREMENTS, [plan_id=5]
 
-(36) ShuffleQueryStage
+(35) ShuffleQueryStage
 Output [3]: [cs_sold_date_sk#1, cs_sales_price#3, ca_zip#8]
 Arguments: X
 
-(37) AQEShuffleRead
+(36) AQEShuffleRead
 Input [3]: [cs_sold_date_sk#1, cs_sales_price#3, ca_zip#8]
 Arguments: coalesced
 
-(38) InputAdapter
+(37) InputAdapter
 Input [3]: [cs_sold_date_sk#1, cs_sales_price#3, ca_zip#8]
 
-(39) NativeSort
+(38) NativeSort
 Input [3]: [cs_sold_date_sk#1, cs_sales_price#3, ca_zip#8]
 Arguments: [cs_sold_date_sk#1 ASC NULLS FIRST], false
 
-(80) Scan parquet
+(79) Scan parquet
 Output [3]: [d_date_sk#9, d_year#10, d_qoy#11]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(d_qoy), IsNotNull(d_year), EqualTo(d_qoy,2), EqualTo(d_year,2001), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_qoy:int>
 
-(41) InputAdapter
+(40) InputAdapter
 Input [3]: [d_date_sk#9, d_year#10, d_qoy#11]
 Arguments: [#9, #10, #11]
 
-(42) NativeFilter
+(41) NativeFilter
 Input [3]: [#9#9, #10#10, #11#11]
 Condition : ((((isnotnull(d_qoy#11) AND isnotnull(d_year#10)) AND (d_qoy#11 = 2)) AND (d_year#10 = 2001)) AND isnotnull(d_date_sk#9))
 
-(43) NativeProject
+(42) NativeProject
 Output [1]: [d_date_sk#9]
 Input [3]: [#9#9, #10#10, #11#11]
 
-(44) NativeShuffleExchange
+(43) NativeShuffleExchange
 Input [1]: [d_date_sk#9]
 Arguments: hashpartitioning(d_date_sk#9, 100), ENSURE_REQUIREMENTS, [plan_id=6]
 
-(45) ShuffleQueryStage
+(44) ShuffleQueryStage
 Output [1]: [d_date_sk#9]
 Arguments: X
 
-(46) AQEShuffleRead
+(45) AQEShuffleRead
 Input [1]: [d_date_sk#9]
 Arguments: coalesced
 
-(47) InputAdapter
+(46) InputAdapter
 Input [1]: [d_date_sk#9]
 
-(48) NativeSort
+(47) NativeSort
 Input [1]: [d_date_sk#9]
 Arguments: [d_date_sk#9 ASC NULLS FIRST], false
 
-(49) NativeSortMergeJoin
+(48) NativeSortMergeJoin
 Left keys [1]: [cs_sold_date_sk#1]
 Right keys [1]: [d_date_sk#9]
 Join type: Inner
 Join condition: None
 
-(50) NativeProject
+(49) NativeProject
 Output [2]: [cs_sales_price#3, ca_zip#8]
 Input [4]: [cs_sold_date_sk#1, cs_sales_price#3, ca_zip#8, d_date_sk#9]
 
-(51) NativeProject
+(50) NativeProject
 Output [2]: [ca_zip#8 AS ca_zip#8, UnscaledValue(cs_sales_price#3) AS _c1#12]
 Input [2]: [cs_sales_price#3, ca_zip#8]
 
-(52) NativeHashAggregate
+(51) NativeHashAggregate
 Input [2]: [ca_zip#8, _c1#12]
 Keys [1]: [ca_zip#8]
 Functions [1]: [partial_sum(_c1#12)]
 Aggregate Attributes [1]: [sum#13]
 Results [2]: [ca_zip#8, #14]
 
-(53) NativeShuffleExchange
+(52) NativeShuffleExchange
 Input [2]: [ca_zip#8, #14]
 Arguments: hashpartitioning(ca_zip#8, 100), ENSURE_REQUIREMENTS, [plan_id=7]
 
-(54) ShuffleQueryStage
+(53) ShuffleQueryStage
 Output [2]: [ca_zip#8, #14]
 Arguments: X
 
-(55) AQEShuffleRead
+(54) AQEShuffleRead
 Input [2]: [ca_zip#8, #14]
 Arguments: coalesced
 
-(56) InputAdapter
+(55) InputAdapter
 Input [2]: [ca_zip#8, #14]
 
-(57) NativeHashAggregate
+(56) NativeHashAggregate
 Input [2]: [ca_zip#8, #14]
 Keys [1]: [ca_zip#8]
 Functions [1]: [sum(UnscaledValue(cs_sales_price#3))]
 Aggregate Attributes [1]: [sum(UnscaledValue(cs_sales_price#3))#15]
 Results [2]: [ca_zip#8, sum(UnscaledValue(cs_sales_price#3))#15]
 
-(58) NativeProject
+(57) NativeProject
 Output [2]: [ca_zip#8, MakeDecimal(sum(UnscaledValue(cs_sales_price#3))#15,17,2) AS sum(cs_sales_price)#16]
 Input [2]: [ca_zip#8, sum(UnscaledValue(cs_sales_price#3))#15]
 
-(59) NativeTakeOrdered
+(58) NativeTakeOrdered
 Input [2]: [ca_zip#8, sum(cs_sales_price)#16]
 Arguments: X, X, [ca_zip#8 ASC NULLS FIRST]
 
-(60) Scan parquet
+(59) Scan parquet
 Output [3]: [cs_sold_date_sk#1, cs_bill_customer_sk#2, cs_sales_price#3]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(cs_bill_customer_sk), IsNotNull(cs_sold_date_sk)]
 ReadSchema: struct<cs_sold_date_sk:int,cs_bill_customer_sk:int,cs_sales_price:decimal(7,2)>
 
-(61) Filter
+(60) Filter
 Input [3]: [cs_sold_date_sk#1, cs_bill_customer_sk#2, cs_sales_price#3]
 Condition : (isnotnull(cs_bill_customer_sk#2) AND isnotnull(cs_sold_date_sk#1))
 
-(62) Exchange
+(61) Exchange
 Input [3]: [cs_sold_date_sk#1, cs_bill_customer_sk#2, cs_sales_price#3]
 Arguments: hashpartitioning(cs_bill_customer_sk#2, 100), ENSURE_REQUIREMENTS, [plan_id=8]
 
-(63) Sort
+(62) Sort
 Input [3]: [cs_sold_date_sk#1, cs_bill_customer_sk#2, cs_sales_price#3]
 Arguments: [cs_bill_customer_sk#2 ASC NULLS FIRST], false, 0
 
-(64) Scan parquet
+(63) Scan parquet
 Output [2]: [c_customer_sk#4, c_current_addr_sk#5]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_current_addr_sk)]
 ReadSchema: struct<c_customer_sk:int,c_current_addr_sk:int>
 
-(65) Filter
+(64) Filter
 Input [2]: [c_customer_sk#4, c_current_addr_sk#5]
 Condition : (isnotnull(c_customer_sk#4) AND isnotnull(c_current_addr_sk#5))
 
-(66) Exchange
+(65) Exchange
 Input [2]: [c_customer_sk#4, c_current_addr_sk#5]
 Arguments: hashpartitioning(c_customer_sk#4, 100), ENSURE_REQUIREMENTS, [plan_id=9]
 
-(67) Sort
+(66) Sort
 Input [2]: [c_customer_sk#4, c_current_addr_sk#5]
 Arguments: [c_customer_sk#4 ASC NULLS FIRST], false, 0
 
-(68) SortMergeJoin
+(67) SortMergeJoin
 Left keys [1]: [cs_bill_customer_sk#2]
 Right keys [1]: [c_customer_sk#4]
 Join type: Inner
 Join condition: None
 
-(69) Project
+(68) Project
 Output [3]: [cs_sold_date_sk#1, cs_sales_price#3, c_current_addr_sk#5]
 Input [5]: [cs_sold_date_sk#1, cs_bill_customer_sk#2, cs_sales_price#3, c_customer_sk#4, c_current_addr_sk#5]
 
-(70) Exchange
+(69) Exchange
 Input [3]: [cs_sold_date_sk#1, cs_sales_price#3, c_current_addr_sk#5]
 Arguments: hashpartitioning(c_current_addr_sk#5, 100), ENSURE_REQUIREMENTS, [plan_id=10]
 
-(71) Sort
+(70) Sort
 Input [3]: [cs_sold_date_sk#1, cs_sales_price#3, c_current_addr_sk#5]
 Arguments: [c_current_addr_sk#5 ASC NULLS FIRST], false, 0
 
-(72) Scan parquet
+(71) Scan parquet
 Output [3]: [ca_address_sk#6, ca_state#7, ca_zip#8]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(ca_address_sk)]
 ReadSchema: struct<ca_address_sk:int,ca_state:string,ca_zip:string>
 
-(73) Filter
+(72) Filter
 Input [3]: [ca_address_sk#6, ca_state#7, ca_zip#8]
 Condition : isnotnull(ca_address_sk#6)
 
-(74) Exchange
+(73) Exchange
 Input [3]: [ca_address_sk#6, ca_state#7, ca_zip#8]
 Arguments: hashpartitioning(ca_address_sk#6, 100), ENSURE_REQUIREMENTS, [plan_id=11]
 
-(75) Sort
+(74) Sort
 Input [3]: [ca_address_sk#6, ca_state#7, ca_zip#8]
 Arguments: [ca_address_sk#6 ASC NULLS FIRST], false, 0
 
-(76) SortMergeJoin
+(75) SortMergeJoin
 Left keys [1]: [c_current_addr_sk#5]
 Right keys [1]: [ca_address_sk#6]
 Join type: Inner
 Join condition: ((substr(ca_zip#8, 1, 5) IN (85669,86197,88274,83405,86475,85392,85460,80348,81792) OR ca_state#7 IN (CA,WA,GA)) OR (cs_sales_price#3 > 500.00))
 
-(77) Project
+(76) Project
 Output [3]: [cs_sold_date_sk#1, cs_sales_price#3, ca_zip#8]
 Input [6]: [cs_sold_date_sk#1, cs_sales_price#3, c_current_addr_sk#5, ca_address_sk#6, ca_state#7, ca_zip#8]
 
-(78) Exchange
+(77) Exchange
 Input [3]: [cs_sold_date_sk#1, cs_sales_price#3, ca_zip#8]
 Arguments: hashpartitioning(cs_sold_date_sk#1, 100), ENSURE_REQUIREMENTS, [plan_id=12]
 
-(79) Sort
+(78) Sort
 Input [3]: [cs_sold_date_sk#1, cs_sales_price#3, ca_zip#8]
 Arguments: [cs_sold_date_sk#1 ASC NULLS FIRST], false, 0
 
-(80) Scan parquet
+(79) Scan parquet
 Output [3]: [d_date_sk#9, d_year#10, d_qoy#11]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(d_qoy), IsNotNull(d_year), EqualTo(d_qoy,2), EqualTo(d_year,2001), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_qoy:int>
 
-(81) Filter
+(80) Filter
 Input [3]: [d_date_sk#9, d_year#10, d_qoy#11]
 Condition : ((((isnotnull(d_qoy#11) AND isnotnull(d_year#10)) AND (d_qoy#11 = 2)) AND (d_year#10 = 2001)) AND isnotnull(d_date_sk#9))
 
-(82) Project
+(81) Project
 Output [1]: [d_date_sk#9]
 Input [3]: [d_date_sk#9, d_year#10, d_qoy#11]
 
-(83) Exchange
+(82) Exchange
 Input [1]: [d_date_sk#9]
 Arguments: hashpartitioning(d_date_sk#9, 100), ENSURE_REQUIREMENTS, [plan_id=13]
 
-(84) Sort
+(83) Sort
 Input [1]: [d_date_sk#9]
 Arguments: [d_date_sk#9 ASC NULLS FIRST], false, 0
 
-(85) SortMergeJoin
+(84) SortMergeJoin
 Left keys [1]: [cs_sold_date_sk#1]
 Right keys [1]: [d_date_sk#9]
 Join type: Inner
 Join condition: None
 
-(86) Project
+(85) Project
 Output [2]: [cs_sales_price#3, ca_zip#8]
 Input [4]: [cs_sold_date_sk#1, cs_sales_price#3, ca_zip#8, d_date_sk#9]
 
-(87) HashAggregate
+(86) HashAggregate
 Input [2]: [cs_sales_price#3, ca_zip#8]
 Keys [1]: [ca_zip#8]
 Functions [1]: [partial_sum(UnscaledValue(cs_sales_price#3))]
 Aggregate Attributes [1]: [sum#13]
 Results [2]: [ca_zip#8, sum#17]
 
-(88) Exchange
+(87) Exchange
 Input [2]: [ca_zip#8, sum#17]
 Arguments: hashpartitioning(ca_zip#8, 100), ENSURE_REQUIREMENTS, [plan_id=14]
 
-(89) HashAggregate
+(88) HashAggregate
 Input [2]: [ca_zip#8, sum#17]
 Keys [1]: [ca_zip#8]
 Functions [1]: [sum(UnscaledValue(cs_sales_price#3))]
 Aggregate Attributes [1]: [sum(UnscaledValue(cs_sales_price#3))#15]
 Results [2]: [ca_zip#8, MakeDecimal(sum(UnscaledValue(cs_sales_price#3))#15,17,2) AS sum(cs_sales_price)#16]
 
-(90) TakeOrderedAndProject
+(89) TakeOrderedAndProject
 Input [2]: [ca_zip#8, sum(cs_sales_price)#16]
 Arguments: X, [ca_zip#8 ASC NULLS FIRST], [ca_zip#8, sum(cs_sales_price)#16]
 
-(91) AdaptiveSparkPlan
+(90) AdaptiveSparkPlan
 Output [2]: [ca_zip#8, sum(cs_sales_price)#16]
 Arguments: isFinalPlan=true
 

--- a/dev/auron-it/src/main/resources/tpcds-plan-stability/spark-3.5/q19.txt
+++ b/dev/auron-it/src/main/resources/tpcds-plan-stability/spark-3.5/q19.txt
@@ -1,144 +1,147 @@
 == Physical Plan ==
-AdaptiveSparkPlan (135)
+AdaptiveSparkPlan (138)
 +- == Final Plan ==
-   TakeOrderedAndProject (86)
-   +- * HashAggregate (85)
-      +- AQEShuffleRead (84)
-         +- ShuffleQueryStage (83), Statistics(X)
-            +- Exchange (82)
-               +- * HashAggregate (81)
-                  +- * Project (80)
-                     +- * SortMergeJoin Inner (79)
-                        :- NativeSort (70)
-                        :  +- InputAdapter (69)
-                        :     +- AQEShuffleRead (68)
-                        :        +- ShuffleQueryStage (67), Statistics(X)
-                        :           +- NativeShuffleExchange (66)
-                        :              +- NativeProject (65)
-                        :                 +- NativeSortMergeJoin Inner (64)
-                        :                    :- NativeSort (55)
-                        :                    :  +- InputAdapter (54)
-                        :                    :     +- AQEShuffleRead (53)
-                        :                    :        +- ShuffleQueryStage (52), Statistics(X)
-                        :                    :           +- NativeShuffleExchange (51)
-                        :                    :              +- NativeProject (50)
-                        :                    :                 +- NativeSortMergeJoin Inner (49)
-                        :                    :                    :- NativeSort (40)
-                        :                    :                    :  +- InputAdapter (39)
-                        :                    :                    :     +- AQEShuffleRead (38)
-                        :                    :                    :        +- ShuffleQueryStage (37), Statistics(X)
-                        :                    :                    :           +- NativeShuffleExchange (36)
-                        :                    :                    :              +- NativeProject (35)
-                        :                    :                    :                 +- NativeSortMergeJoin Inner (34)
-                        :                    :                    :                    :- NativeSort (24)
-                        :                    :                    :                    :  +- InputAdapter (23)
-                        :                    :                    :                    :     +- AQEShuffleRead (22)
-                        :                    :                    :                    :        +- ShuffleQueryStage (21), Statistics(X)
-                        :                    :                    :                    :           +- NativeShuffleExchange (20)
-                        :                    :                    :                    :              +- NativeProject (19)
-                        :                    :                    :                    :                 +- NativeSortMergeJoin Inner (18)
-                        :                    :                    :                    :                    :- NativeSort (9)
-                        :                    :                    :                    :                    :  +- InputAdapter (8)
-                        :                    :                    :                    :                    :     +- AQEShuffleRead (7)
-                        :                    :                    :                    :                    :        +- ShuffleQueryStage (6), Statistics(X)
-                        :                    :                    :                    :                    :           +- NativeShuffleExchange (5)
-                        :                    :                    :                    :                    :              +- NativeProject (4)
-                        :                    :                    :                    :                    :                 +- NativeFilter (3)
-                        :                    :                    :                    :                    :                    +- InputAdapter (2)
-                        :                    :                    :                    :                    :                       +- NativeParquetScan  (1)
-                        :                    :                    :                    :                    +- NativeSort (17)
-                        :                    :                    :                    :                       +- InputAdapter (16)
-                        :                    :                    :                    :                          +- AQEShuffleRead (15)
-                        :                    :                    :                    :                             +- ShuffleQueryStage (14), Statistics(X)
-                        :                    :                    :                    :                                +- NativeShuffleExchange (13)
-                        :                    :                    :                    :                                   +- NativeFilter (12)
-                        :                    :                    :                    :                                      +- InputAdapter (11)
-                        :                    :                    :                    :                                         +- NativeParquetScan  (10)
-                        :                    :                    :                    +- NativeSort (33)
-                        :                    :                    :                       +- InputAdapter (32)
-                        :                    :                    :                          +- AQEShuffleRead (31)
-                        :                    :                    :                             +- ShuffleQueryStage (30), Statistics(X)
-                        :                    :                    :                                +- NativeShuffleExchange (29)
-                        :                    :                    :                                   +- NativeProject (28)
-                        :                    :                    :                                      +- NativeFilter (27)
-                        :                    :                    :                                         +- InputAdapter (26)
-                        :                    :                    :                                            +- NativeParquetScan  (25)
-                        :                    :                    +- NativeSort (48)
-                        :                    :                       +- InputAdapter (47)
-                        :                    :                          +- AQEShuffleRead (46)
-                        :                    :                             +- ShuffleQueryStage (45), Statistics(X)
-                        :                    :                                +- NativeShuffleExchange (44)
-                        :                    :                                   +- NativeFilter (43)
-                        :                    :                                      +- InputAdapter (42)
-                        :                    :                                         +- NativeParquetScan  (41)
-                        :                    +- NativeSort (63)
-                        :                       +- InputAdapter (62)
-                        :                          +- AQEShuffleRead (61)
-                        :                             +- ShuffleQueryStage (60), Statistics(X)
-                        :                                +- NativeShuffleExchange (59)
-                        :                                   +- NativeFilter (58)
-                        :                                      +- InputAdapter (57)
-                        :                                         +- NativeParquetScan  (56)
-                        +- NativeSort (78)
-                           +- InputAdapter (77)
-                              +- AQEShuffleRead (76)
-                                 +- ShuffleQueryStage (75), Statistics(X)
-                                    +- NativeShuffleExchange (74)
-                                       +- NativeFilter (73)
-                                          +- InputAdapter (72)
-                                             +- NativeParquetScan  (71)
+   NativeTakeOrdered (89)
+   +- NativeProject (88)
+      +- NativeHashAggregate (87)
+         +- InputAdapter (86)
+            +- AQEShuffleRead (85)
+               +- ShuffleQueryStage (84), Statistics(X)
+                  +- NativeShuffleExchange (83)
+                     +- NativeHashAggregate (82)
+                        +- NativeProject (81)
+                           +- NativeProject (80)
+                              +- NativeSortMergeJoin Inner (79)
+                                 :- NativeSort (70)
+                                 :  +- InputAdapter (69)
+                                 :     +- AQEShuffleRead (68)
+                                 :        +- ShuffleQueryStage (67), Statistics(X)
+                                 :           +- NativeShuffleExchange (66)
+                                 :              +- NativeProject (65)
+                                 :                 +- NativeSortMergeJoin Inner (64)
+                                 :                    :- NativeSort (55)
+                                 :                    :  +- InputAdapter (54)
+                                 :                    :     +- AQEShuffleRead (53)
+                                 :                    :        +- ShuffleQueryStage (52), Statistics(X)
+                                 :                    :           +- NativeShuffleExchange (51)
+                                 :                    :              +- NativeProject (50)
+                                 :                    :                 +- NativeSortMergeJoin Inner (49)
+                                 :                    :                    :- NativeSort (40)
+                                 :                    :                    :  +- InputAdapter (39)
+                                 :                    :                    :     +- AQEShuffleRead (38)
+                                 :                    :                    :        +- ShuffleQueryStage (37), Statistics(X)
+                                 :                    :                    :           +- NativeShuffleExchange (36)
+                                 :                    :                    :              +- NativeProject (35)
+                                 :                    :                    :                 +- NativeSortMergeJoin Inner (34)
+                                 :                    :                    :                    :- NativeSort (24)
+                                 :                    :                    :                    :  +- InputAdapter (23)
+                                 :                    :                    :                    :     +- AQEShuffleRead (22)
+                                 :                    :                    :                    :        +- ShuffleQueryStage (21), Statistics(X)
+                                 :                    :                    :                    :           +- NativeShuffleExchange (20)
+                                 :                    :                    :                    :              +- NativeProject (19)
+                                 :                    :                    :                    :                 +- NativeSortMergeJoin Inner (18)
+                                 :                    :                    :                    :                    :- NativeSort (9)
+                                 :                    :                    :                    :                    :  +- InputAdapter (8)
+                                 :                    :                    :                    :                    :     +- AQEShuffleRead (7)
+                                 :                    :                    :                    :                    :        +- ShuffleQueryStage (6), Statistics(X)
+                                 :                    :                    :                    :                    :           +- NativeShuffleExchange (5)
+                                 :                    :                    :                    :                    :              +- NativeProject (4)
+                                 :                    :                    :                    :                    :                 +- NativeFilter (3)
+                                 :                    :                    :                    :                    :                    +- InputAdapter (2)
+                                 :                    :                    :                    :                    :                       +- NativeParquetScan  (1)
+                                 :                    :                    :                    :                    +- NativeSort (17)
+                                 :                    :                    :                    :                       +- InputAdapter (16)
+                                 :                    :                    :                    :                          +- AQEShuffleRead (15)
+                                 :                    :                    :                    :                             +- ShuffleQueryStage (14), Statistics(X)
+                                 :                    :                    :                    :                                +- NativeShuffleExchange (13)
+                                 :                    :                    :                    :                                   +- NativeFilter (12)
+                                 :                    :                    :                    :                                      +- InputAdapter (11)
+                                 :                    :                    :                    :                                         +- NativeParquetScan  (10)
+                                 :                    :                    :                    +- NativeSort (33)
+                                 :                    :                    :                       +- InputAdapter (32)
+                                 :                    :                    :                          +- AQEShuffleRead (31)
+                                 :                    :                    :                             +- ShuffleQueryStage (30), Statistics(X)
+                                 :                    :                    :                                +- NativeShuffleExchange (29)
+                                 :                    :                    :                                   +- NativeProject (28)
+                                 :                    :                    :                                      +- NativeFilter (27)
+                                 :                    :                    :                                         +- InputAdapter (26)
+                                 :                    :                    :                                            +- NativeParquetScan  (25)
+                                 :                    :                    +- NativeSort (48)
+                                 :                    :                       +- InputAdapter (47)
+                                 :                    :                          +- AQEShuffleRead (46)
+                                 :                    :                             +- ShuffleQueryStage (45), Statistics(X)
+                                 :                    :                                +- NativeShuffleExchange (44)
+                                 :                    :                                   +- NativeFilter (43)
+                                 :                    :                                      +- InputAdapter (42)
+                                 :                    :                                         +- NativeParquetScan  (41)
+                                 :                    +- NativeSort (63)
+                                 :                       +- InputAdapter (62)
+                                 :                          +- AQEShuffleRead (61)
+                                 :                             +- ShuffleQueryStage (60), Statistics(X)
+                                 :                                +- NativeShuffleExchange (59)
+                                 :                                   +- NativeFilter (58)
+                                 :                                      +- InputAdapter (57)
+                                 :                                         +- NativeParquetScan  (56)
+                                 +- NativeSort (78)
+                                    +- InputAdapter (77)
+                                       +- AQEShuffleRead (76)
+                                          +- ShuffleQueryStage (75), Statistics(X)
+                                             +- NativeShuffleExchange (74)
+                                                +- NativeFilter (73)
+                                                   +- InputAdapter (72)
+                                                      +- NativeParquetScan  (71)
 +- == Initial Plan ==
-   TakeOrderedAndProject (134)
-   +- HashAggregate (133)
-      +- Exchange (132)
-         +- HashAggregate (131)
-            +- Project (130)
-               +- SortMergeJoin Inner (129)
-                  :- Sort (124)
-                  :  +- Exchange (123)
-                  :     +- Project (122)
-                  :        +- SortMergeJoin Inner (121)
-                  :           :- Sort (116)
-                  :           :  +- Exchange (115)
-                  :           :     +- Project (114)
-                  :           :        +- SortMergeJoin Inner (113)
-                  :           :           :- Sort (108)
-                  :           :           :  +- Exchange (107)
-                  :           :           :     +- Project (106)
-                  :           :           :        +- SortMergeJoin Inner (105)
-                  :           :           :           :- Sort (99)
-                  :           :           :           :  +- Exchange (98)
-                  :           :           :           :     +- Project (97)
-                  :           :           :           :        +- SortMergeJoin Inner (96)
-                  :           :           :           :           :- Sort (91)
-                  :           :           :           :           :  +- Exchange (90)
-                  :           :           :           :           :     +- Project (89)
-                  :           :           :           :           :        +- Filter (88)
-                  :           :           :           :           :           +- Scan parquet (87)
-                  :           :           :           :           +- Sort (95)
-                  :           :           :           :              +- Exchange (94)
-                  :           :           :           :                 +- Filter (93)
-                  :           :           :           :                    +- Scan parquet (92)
-                  :           :           :           +- Sort (104)
-                  :           :           :              +- Exchange (103)
-                  :           :           :                 +- Project (102)
-                  :           :           :                    +- Filter (101)
-                  :           :           :                       +- Scan parquet (100)
-                  :           :           +- Sort (112)
-                  :           :              +- Exchange (111)
-                  :           :                 +- Filter (110)
-                  :           :                    +- Scan parquet (109)
-                  :           +- Sort (120)
-                  :              +- Exchange (119)
-                  :                 +- Filter (118)
-                  :                    +- Scan parquet (117)
-                  +- Sort (128)
-                     +- Exchange (127)
-                        +- Filter (126)
-                           +- Scan parquet (125)
+   TakeOrderedAndProject (137)
+   +- HashAggregate (136)
+      +- Exchange (135)
+         +- HashAggregate (134)
+            +- Project (133)
+               +- SortMergeJoin Inner (132)
+                  :- Sort (127)
+                  :  +- Exchange (126)
+                  :     +- Project (125)
+                  :        +- SortMergeJoin Inner (124)
+                  :           :- Sort (119)
+                  :           :  +- Exchange (118)
+                  :           :     +- Project (117)
+                  :           :        +- SortMergeJoin Inner (116)
+                  :           :           :- Sort (111)
+                  :           :           :  +- Exchange (110)
+                  :           :           :     +- Project (109)
+                  :           :           :        +- SortMergeJoin Inner (108)
+                  :           :           :           :- Sort (102)
+                  :           :           :           :  +- Exchange (101)
+                  :           :           :           :     +- Project (100)
+                  :           :           :           :        +- SortMergeJoin Inner (99)
+                  :           :           :           :           :- Sort (94)
+                  :           :           :           :           :  +- Exchange (93)
+                  :           :           :           :           :     +- Project (92)
+                  :           :           :           :           :        +- Filter (91)
+                  :           :           :           :           :           +- Scan parquet (90)
+                  :           :           :           :           +- Sort (98)
+                  :           :           :           :              +- Exchange (97)
+                  :           :           :           :                 +- Filter (96)
+                  :           :           :           :                    +- Scan parquet (95)
+                  :           :           :           +- Sort (107)
+                  :           :           :              +- Exchange (106)
+                  :           :           :                 +- Project (105)
+                  :           :           :                    +- Filter (104)
+                  :           :           :                       +- Scan parquet (103)
+                  :           :           +- Sort (115)
+                  :           :              +- Exchange (114)
+                  :           :                 +- Filter (113)
+                  :           :                    +- Scan parquet (112)
+                  :           +- Sort (123)
+                  :              +- Exchange (122)
+                  :                 +- Filter (121)
+                  :                    +- Scan parquet (120)
+                  +- Sort (131)
+                     +- Exchange (130)
+                        +- Filter (129)
+                           +- Scan parquet (128)
 
 
-(87) Scan parquet
+(90) Scan parquet
 Output [3]: [d_date_sk#1, d_year#2, d_moy#3]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
@@ -176,7 +179,7 @@ Input [1]: [d_date_sk#1]
 Input [1]: [d_date_sk#1]
 Arguments: [d_date_sk#1 ASC NULLS FIRST], false
 
-(92) Scan parquet
+(95) Scan parquet
 Output [5]: [ss_sold_date_sk#4, ss_item_sk#5, ss_customer_sk#6, ss_store_sk#7, ss_ext_sales_price#8]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
@@ -239,7 +242,7 @@ Input [4]: [ss_item_sk#5, ss_customer_sk#6, ss_store_sk#7, ss_ext_sales_price#8]
 Input [4]: [ss_item_sk#5, ss_customer_sk#6, ss_store_sk#7, ss_ext_sales_price#8]
 Arguments: [ss_item_sk#5 ASC NULLS FIRST], false
 
-(100) Scan parquet
+(103) Scan parquet
 Output [6]: [i_item_sk#9, i_brand_id#10, i_brand#11, i_manufact_id#12, i_manufact#13, i_manager_id#14]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
@@ -306,7 +309,7 @@ Input [7]: [ss_customer_sk#6, ss_store_sk#7, ss_ext_sales_price#8, i_brand_id#10
 Input [7]: [ss_customer_sk#6, ss_store_sk#7, ss_ext_sales_price#8, i_brand_id#10, i_brand#11, i_manufact_id#12, i_manufact#13]
 Arguments: [ss_customer_sk#6 ASC NULLS FIRST], false
 
-(109) Scan parquet
+(112) Scan parquet
 Output [2]: [c_customer_sk#15, c_current_addr_sk#16]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
@@ -369,7 +372,7 @@ Input [7]: [ss_store_sk#7, ss_ext_sales_price#8, i_brand_id#10, i_brand#11, i_ma
 Input [7]: [ss_store_sk#7, ss_ext_sales_price#8, i_brand_id#10, i_brand#11, i_manufact_id#12, i_manufact#13, c_current_addr_sk#16]
 Arguments: [c_current_addr_sk#16 ASC NULLS FIRST], false
 
-(117) Scan parquet
+(120) Scan parquet
 Output [2]: [ca_address_sk#17, ca_zip#18]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
@@ -432,7 +435,7 @@ Input [7]: [ss_store_sk#7, ss_ext_sales_price#8, i_brand_id#10, i_brand#11, i_ma
 Input [7]: [ss_store_sk#7, ss_ext_sales_price#8, i_brand_id#10, i_brand#11, i_manufact_id#12, i_manufact#13, ca_zip#18]
 Arguments: [ss_store_sk#7 ASC NULLS FIRST], false
 
-(125) Scan parquet
+(128) Scan parquet
 Output [2]: [s_store_sk#19, s_zip#20]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
@@ -466,273 +469,284 @@ Input [2]: [#19#19, #20#20]
 Input [2]: [#19#19, #20#20]
 Arguments: [s_store_sk#19 ASC NULLS FIRST], false
 
-(79) SortMergeJoin [codegen id : X]
+(79) NativeSortMergeJoin
 Left keys [1]: [ss_store_sk#7]
 Right keys [1]: [s_store_sk#19]
 Join type: Inner
 Join condition: NOT (substr(ca_zip#18, 1, 5) = substr(s_zip#20, 1, 5))
 
-(80) Project [codegen id : X]
+(80) NativeProject
 Output [5]: [ss_ext_sales_price#8, i_brand_id#10, i_brand#11, i_manufact_id#12, i_manufact#13]
 Input [9]: [ss_store_sk#7, ss_ext_sales_price#8, i_brand_id#10, i_brand#11, i_manufact_id#12, i_manufact#13, ca_zip#18, #19#19, #20#20]
 
-(81) HashAggregate [codegen id : X]
+(81) NativeProject
+Output [5]: [i_brand#11 AS i_brand#11, i_brand_id#10 AS i_brand_id#10, i_manufact_id#12 AS i_manufact_id#12, i_manufact#13 AS i_manufact#13, UnscaledValue(ss_ext_sales_price#8) AS _c4#21]
 Input [5]: [ss_ext_sales_price#8, i_brand_id#10, i_brand#11, i_manufact_id#12, i_manufact#13]
-Keys [4]: [i_brand#11, i_brand_id#10, i_manufact_id#12, i_manufact#13]
-Functions [1]: [partial_sum(UnscaledValue(ss_ext_sales_price#8))]
-Aggregate Attributes [1]: [sum#21]
-Results [5]: [i_brand#11, i_brand_id#10, i_manufact_id#12, i_manufact#13, sum#22]
 
-(82) Exchange
-Input [5]: [i_brand#11, i_brand_id#10, i_manufact_id#12, i_manufact#13, sum#22]
+(82) NativeHashAggregate
+Input [5]: [i_brand#11, i_brand_id#10, i_manufact_id#12, i_manufact#13, _c4#21]
+Keys [4]: [i_brand#11, i_brand_id#10, i_manufact_id#12, i_manufact#13]
+Functions [1]: [partial_sum(_c4#21)]
+Aggregate Attributes [1]: [sum#22]
+Results [5]: [i_brand#11, i_brand_id#10, i_manufact_id#12, i_manufact#13, #23]
+
+(83) NativeShuffleExchange
+Input [5]: [i_brand#11, i_brand_id#10, i_manufact_id#12, i_manufact#13, #23]
 Arguments: hashpartitioning(i_brand#11, i_brand_id#10, i_manufact_id#12, i_manufact#13, 100), ENSURE_REQUIREMENTS, [plan_id=11]
 
-(83) ShuffleQueryStage
-Output [5]: [i_brand#11, i_brand_id#10, i_manufact_id#12, i_manufact#13, sum#22]
+(84) ShuffleQueryStage
+Output [5]: [i_brand#11, i_brand_id#10, i_manufact_id#12, i_manufact#13, #23]
 Arguments: X
 
-(84) AQEShuffleRead
-Input [5]: [i_brand#11, i_brand_id#10, i_manufact_id#12, i_manufact#13, sum#22]
+(85) AQEShuffleRead
+Input [5]: [i_brand#11, i_brand_id#10, i_manufact_id#12, i_manufact#13, #23]
 Arguments: coalesced
 
-(85) HashAggregate [codegen id : X]
-Input [5]: [i_brand#11, i_brand_id#10, i_manufact_id#12, i_manufact#13, sum#22]
+(86) InputAdapter
+Input [5]: [i_brand#11, i_brand_id#10, i_manufact_id#12, i_manufact#13, #23]
+
+(87) NativeHashAggregate
+Input [5]: [i_brand#11, i_brand_id#10, i_manufact_id#12, i_manufact#13, #23]
 Keys [4]: [i_brand#11, i_brand_id#10, i_manufact_id#12, i_manufact#13]
 Functions [1]: [sum(UnscaledValue(ss_ext_sales_price#8))]
-Aggregate Attributes [1]: [sum(UnscaledValue(ss_ext_sales_price#8))#23]
-Results [5]: [i_brand_id#10 AS brand_id#24, i_brand#11 AS brand#25, i_manufact_id#12, i_manufact#13, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#8))#23,17,2) AS ext_price#26]
+Aggregate Attributes [1]: [sum(UnscaledValue(ss_ext_sales_price#8))#24]
+Results [5]: [i_brand#11, i_brand_id#10, i_manufact_id#12, i_manufact#13, sum(UnscaledValue(ss_ext_sales_price#8))#24]
 
-(86) TakeOrderedAndProject
-Input [5]: [brand_id#24, brand#25, i_manufact_id#12, i_manufact#13, ext_price#26]
-Arguments: X, [ext_price#26 DESC NULLS LAST, brand#25 ASC NULLS FIRST, brand_id#24 ASC NULLS FIRST, i_manufact_id#12 ASC NULLS FIRST, i_manufact#13 ASC NULLS FIRST], [brand_id#24, brand#25, i_manufact_id#12, i_manufact#13, ext_price#26]
+(88) NativeProject
+Output [5]: [i_brand_id#10 AS brand_id#25, i_brand#11 AS brand#26, i_manufact_id#12, i_manufact#13, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#8))#24,17,2) AS ext_price#27]
+Input [5]: [i_brand#11, i_brand_id#10, i_manufact_id#12, i_manufact#13, sum(UnscaledValue(ss_ext_sales_price#8))#24]
 
-(87) Scan parquet
+(89) NativeTakeOrdered
+Input [5]: [brand_id#25, brand#26, i_manufact_id#12, i_manufact#13, ext_price#27]
+Arguments: X, X, [ext_price#27 DESC NULLS LAST, brand#26 ASC NULLS FIRST, brand_id#25 ASC NULLS FIRST, i_manufact_id#12 ASC NULLS FIRST, i_manufact#13 ASC NULLS FIRST]
+
+(90) Scan parquet
 Output [3]: [d_date_sk#1, d_year#2, d_moy#3]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(d_moy), IsNotNull(d_year), EqualTo(d_moy,11), EqualTo(d_year,1998), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_moy:int>
 
-(88) Filter
+(91) Filter
 Input [3]: [d_date_sk#1, d_year#2, d_moy#3]
 Condition : ((((isnotnull(d_moy#3) AND isnotnull(d_year#2)) AND (d_moy#3 = 11)) AND (d_year#2 = 1998)) AND isnotnull(d_date_sk#1))
 
-(89) Project
+(92) Project
 Output [1]: [d_date_sk#1]
 Input [3]: [d_date_sk#1, d_year#2, d_moy#3]
 
-(90) Exchange
+(93) Exchange
 Input [1]: [d_date_sk#1]
 Arguments: hashpartitioning(d_date_sk#1, 100), ENSURE_REQUIREMENTS, [plan_id=12]
 
-(91) Sort
+(94) Sort
 Input [1]: [d_date_sk#1]
 Arguments: [d_date_sk#1 ASC NULLS FIRST], false, 0
 
-(92) Scan parquet
+(95) Scan parquet
 Output [5]: [ss_sold_date_sk#4, ss_item_sk#5, ss_customer_sk#6, ss_store_sk#7, ss_ext_sales_price#8]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(ss_sold_date_sk), IsNotNull(ss_item_sk), IsNotNull(ss_customer_sk), IsNotNull(ss_store_sk)]
 ReadSchema: struct<ss_sold_date_sk:int,ss_item_sk:int,ss_customer_sk:int,ss_store_sk:int,ss_ext_sales_price:decimal(7,2)>
 
-(93) Filter
+(96) Filter
 Input [5]: [ss_sold_date_sk#4, ss_item_sk#5, ss_customer_sk#6, ss_store_sk#7, ss_ext_sales_price#8]
 Condition : (((isnotnull(ss_sold_date_sk#4) AND isnotnull(ss_item_sk#5)) AND isnotnull(ss_customer_sk#6)) AND isnotnull(ss_store_sk#7))
 
-(94) Exchange
+(97) Exchange
 Input [5]: [ss_sold_date_sk#4, ss_item_sk#5, ss_customer_sk#6, ss_store_sk#7, ss_ext_sales_price#8]
 Arguments: hashpartitioning(ss_sold_date_sk#4, 100), ENSURE_REQUIREMENTS, [plan_id=13]
 
-(95) Sort
+(98) Sort
 Input [5]: [ss_sold_date_sk#4, ss_item_sk#5, ss_customer_sk#6, ss_store_sk#7, ss_ext_sales_price#8]
 Arguments: [ss_sold_date_sk#4 ASC NULLS FIRST], false, 0
 
-(96) SortMergeJoin
+(99) SortMergeJoin
 Left keys [1]: [d_date_sk#1]
 Right keys [1]: [ss_sold_date_sk#4]
 Join type: Inner
 Join condition: None
 
-(97) Project
+(100) Project
 Output [4]: [ss_item_sk#5, ss_customer_sk#6, ss_store_sk#7, ss_ext_sales_price#8]
 Input [6]: [d_date_sk#1, ss_sold_date_sk#4, ss_item_sk#5, ss_customer_sk#6, ss_store_sk#7, ss_ext_sales_price#8]
 
-(98) Exchange
+(101) Exchange
 Input [4]: [ss_item_sk#5, ss_customer_sk#6, ss_store_sk#7, ss_ext_sales_price#8]
 Arguments: hashpartitioning(ss_item_sk#5, 100), ENSURE_REQUIREMENTS, [plan_id=14]
 
-(99) Sort
+(102) Sort
 Input [4]: [ss_item_sk#5, ss_customer_sk#6, ss_store_sk#7, ss_ext_sales_price#8]
 Arguments: [ss_item_sk#5 ASC NULLS FIRST], false, 0
 
-(100) Scan parquet
+(103) Scan parquet
 Output [6]: [i_item_sk#9, i_brand_id#10, i_brand#11, i_manufact_id#12, i_manufact#13, i_manager_id#14]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(i_manager_id), EqualTo(i_manager_id,8), IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_brand_id:int,i_brand:string,i_manufact_id:int,i_manufact:string,i_manager_id:int>
 
-(101) Filter
+(104) Filter
 Input [6]: [i_item_sk#9, i_brand_id#10, i_brand#11, i_manufact_id#12, i_manufact#13, i_manager_id#14]
 Condition : ((isnotnull(i_manager_id#14) AND (i_manager_id#14 = 8)) AND isnotnull(i_item_sk#9))
 
-(102) Project
+(105) Project
 Output [5]: [i_item_sk#9, i_brand_id#10, i_brand#11, i_manufact_id#12, i_manufact#13]
 Input [6]: [i_item_sk#9, i_brand_id#10, i_brand#11, i_manufact_id#12, i_manufact#13, i_manager_id#14]
 
-(103) Exchange
+(106) Exchange
 Input [5]: [i_item_sk#9, i_brand_id#10, i_brand#11, i_manufact_id#12, i_manufact#13]
 Arguments: hashpartitioning(i_item_sk#9, 100), ENSURE_REQUIREMENTS, [plan_id=15]
 
-(104) Sort
+(107) Sort
 Input [5]: [i_item_sk#9, i_brand_id#10, i_brand#11, i_manufact_id#12, i_manufact#13]
 Arguments: [i_item_sk#9 ASC NULLS FIRST], false, 0
 
-(105) SortMergeJoin
+(108) SortMergeJoin
 Left keys [1]: [ss_item_sk#5]
 Right keys [1]: [i_item_sk#9]
 Join type: Inner
 Join condition: None
 
-(106) Project
+(109) Project
 Output [7]: [ss_customer_sk#6, ss_store_sk#7, ss_ext_sales_price#8, i_brand_id#10, i_brand#11, i_manufact_id#12, i_manufact#13]
 Input [9]: [ss_item_sk#5, ss_customer_sk#6, ss_store_sk#7, ss_ext_sales_price#8, i_item_sk#9, i_brand_id#10, i_brand#11, i_manufact_id#12, i_manufact#13]
 
-(107) Exchange
+(110) Exchange
 Input [7]: [ss_customer_sk#6, ss_store_sk#7, ss_ext_sales_price#8, i_brand_id#10, i_brand#11, i_manufact_id#12, i_manufact#13]
 Arguments: hashpartitioning(ss_customer_sk#6, 100), ENSURE_REQUIREMENTS, [plan_id=16]
 
-(108) Sort
+(111) Sort
 Input [7]: [ss_customer_sk#6, ss_store_sk#7, ss_ext_sales_price#8, i_brand_id#10, i_brand#11, i_manufact_id#12, i_manufact#13]
 Arguments: [ss_customer_sk#6 ASC NULLS FIRST], false, 0
 
-(109) Scan parquet
+(112) Scan parquet
 Output [2]: [c_customer_sk#15, c_current_addr_sk#16]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_current_addr_sk)]
 ReadSchema: struct<c_customer_sk:int,c_current_addr_sk:int>
 
-(110) Filter
+(113) Filter
 Input [2]: [c_customer_sk#15, c_current_addr_sk#16]
 Condition : (isnotnull(c_customer_sk#15) AND isnotnull(c_current_addr_sk#16))
 
-(111) Exchange
+(114) Exchange
 Input [2]: [c_customer_sk#15, c_current_addr_sk#16]
 Arguments: hashpartitioning(c_customer_sk#15, 100), ENSURE_REQUIREMENTS, [plan_id=17]
 
-(112) Sort
+(115) Sort
 Input [2]: [c_customer_sk#15, c_current_addr_sk#16]
 Arguments: [c_customer_sk#15 ASC NULLS FIRST], false, 0
 
-(113) SortMergeJoin
+(116) SortMergeJoin
 Left keys [1]: [ss_customer_sk#6]
 Right keys [1]: [c_customer_sk#15]
 Join type: Inner
 Join condition: None
 
-(114) Project
+(117) Project
 Output [7]: [ss_store_sk#7, ss_ext_sales_price#8, i_brand_id#10, i_brand#11, i_manufact_id#12, i_manufact#13, c_current_addr_sk#16]
 Input [9]: [ss_customer_sk#6, ss_store_sk#7, ss_ext_sales_price#8, i_brand_id#10, i_brand#11, i_manufact_id#12, i_manufact#13, c_customer_sk#15, c_current_addr_sk#16]
 
-(115) Exchange
+(118) Exchange
 Input [7]: [ss_store_sk#7, ss_ext_sales_price#8, i_brand_id#10, i_brand#11, i_manufact_id#12, i_manufact#13, c_current_addr_sk#16]
 Arguments: hashpartitioning(c_current_addr_sk#16, 100), ENSURE_REQUIREMENTS, [plan_id=18]
 
-(116) Sort
+(119) Sort
 Input [7]: [ss_store_sk#7, ss_ext_sales_price#8, i_brand_id#10, i_brand#11, i_manufact_id#12, i_manufact#13, c_current_addr_sk#16]
 Arguments: [c_current_addr_sk#16 ASC NULLS FIRST], false, 0
 
-(117) Scan parquet
+(120) Scan parquet
 Output [2]: [ca_address_sk#17, ca_zip#18]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(ca_address_sk), IsNotNull(ca_zip)]
 ReadSchema: struct<ca_address_sk:int,ca_zip:string>
 
-(118) Filter
+(121) Filter
 Input [2]: [ca_address_sk#17, ca_zip#18]
 Condition : (isnotnull(ca_address_sk#17) AND isnotnull(ca_zip#18))
 
-(119) Exchange
+(122) Exchange
 Input [2]: [ca_address_sk#17, ca_zip#18]
 Arguments: hashpartitioning(ca_address_sk#17, 100), ENSURE_REQUIREMENTS, [plan_id=19]
 
-(120) Sort
+(123) Sort
 Input [2]: [ca_address_sk#17, ca_zip#18]
 Arguments: [ca_address_sk#17 ASC NULLS FIRST], false, 0
 
-(121) SortMergeJoin
+(124) SortMergeJoin
 Left keys [1]: [c_current_addr_sk#16]
 Right keys [1]: [ca_address_sk#17]
 Join type: Inner
 Join condition: None
 
-(122) Project
+(125) Project
 Output [7]: [ss_store_sk#7, ss_ext_sales_price#8, i_brand_id#10, i_brand#11, i_manufact_id#12, i_manufact#13, ca_zip#18]
 Input [9]: [ss_store_sk#7, ss_ext_sales_price#8, i_brand_id#10, i_brand#11, i_manufact_id#12, i_manufact#13, c_current_addr_sk#16, ca_address_sk#17, ca_zip#18]
 
-(123) Exchange
+(126) Exchange
 Input [7]: [ss_store_sk#7, ss_ext_sales_price#8, i_brand_id#10, i_brand#11, i_manufact_id#12, i_manufact#13, ca_zip#18]
 Arguments: hashpartitioning(ss_store_sk#7, 100), ENSURE_REQUIREMENTS, [plan_id=20]
 
-(124) Sort
+(127) Sort
 Input [7]: [ss_store_sk#7, ss_ext_sales_price#8, i_brand_id#10, i_brand#11, i_manufact_id#12, i_manufact#13, ca_zip#18]
 Arguments: [ss_store_sk#7 ASC NULLS FIRST], false, 0
 
-(125) Scan parquet
+(128) Scan parquet
 Output [2]: [s_store_sk#19, s_zip#20]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(s_zip), IsNotNull(s_store_sk)]
 ReadSchema: struct<s_store_sk:int,s_zip:string>
 
-(126) Filter
+(129) Filter
 Input [2]: [s_store_sk#19, s_zip#20]
 Condition : (isnotnull(s_zip#20) AND isnotnull(s_store_sk#19))
 
-(127) Exchange
+(130) Exchange
 Input [2]: [s_store_sk#19, s_zip#20]
 Arguments: hashpartitioning(s_store_sk#19, 100), ENSURE_REQUIREMENTS, [plan_id=21]
 
-(128) Sort
+(131) Sort
 Input [2]: [s_store_sk#19, s_zip#20]
 Arguments: [s_store_sk#19 ASC NULLS FIRST], false, 0
 
-(129) SortMergeJoin
+(132) SortMergeJoin
 Left keys [1]: [ss_store_sk#7]
 Right keys [1]: [s_store_sk#19]
 Join type: Inner
 Join condition: NOT (substr(ca_zip#18, 1, 5) = substr(s_zip#20, 1, 5))
 
-(130) Project
+(133) Project
 Output [5]: [ss_ext_sales_price#8, i_brand_id#10, i_brand#11, i_manufact_id#12, i_manufact#13]
 Input [9]: [ss_store_sk#7, ss_ext_sales_price#8, i_brand_id#10, i_brand#11, i_manufact_id#12, i_manufact#13, ca_zip#18, s_store_sk#19, s_zip#20]
 
-(131) HashAggregate
+(134) HashAggregate
 Input [5]: [ss_ext_sales_price#8, i_brand_id#10, i_brand#11, i_manufact_id#12, i_manufact#13]
 Keys [4]: [i_brand#11, i_brand_id#10, i_manufact_id#12, i_manufact#13]
 Functions [1]: [partial_sum(UnscaledValue(ss_ext_sales_price#8))]
-Aggregate Attributes [1]: [sum#21]
-Results [5]: [i_brand#11, i_brand_id#10, i_manufact_id#12, i_manufact#13, sum#22]
+Aggregate Attributes [1]: [sum#22]
+Results [5]: [i_brand#11, i_brand_id#10, i_manufact_id#12, i_manufact#13, sum#28]
 
-(132) Exchange
-Input [5]: [i_brand#11, i_brand_id#10, i_manufact_id#12, i_manufact#13, sum#22]
+(135) Exchange
+Input [5]: [i_brand#11, i_brand_id#10, i_manufact_id#12, i_manufact#13, sum#28]
 Arguments: hashpartitioning(i_brand#11, i_brand_id#10, i_manufact_id#12, i_manufact#13, 100), ENSURE_REQUIREMENTS, [plan_id=22]
 
-(133) HashAggregate
-Input [5]: [i_brand#11, i_brand_id#10, i_manufact_id#12, i_manufact#13, sum#22]
+(136) HashAggregate
+Input [5]: [i_brand#11, i_brand_id#10, i_manufact_id#12, i_manufact#13, sum#28]
 Keys [4]: [i_brand#11, i_brand_id#10, i_manufact_id#12, i_manufact#13]
 Functions [1]: [sum(UnscaledValue(ss_ext_sales_price#8))]
-Aggregate Attributes [1]: [sum(UnscaledValue(ss_ext_sales_price#8))#23]
-Results [5]: [i_brand_id#10 AS brand_id#24, i_brand#11 AS brand#25, i_manufact_id#12, i_manufact#13, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#8))#23,17,2) AS ext_price#26]
+Aggregate Attributes [1]: [sum(UnscaledValue(ss_ext_sales_price#8))#24]
+Results [5]: [i_brand_id#10 AS brand_id#25, i_brand#11 AS brand#26, i_manufact_id#12, i_manufact#13, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#8))#24,17,2) AS ext_price#27]
 
-(134) TakeOrderedAndProject
-Input [5]: [brand_id#24, brand#25, i_manufact_id#12, i_manufact#13, ext_price#26]
-Arguments: X, [ext_price#26 DESC NULLS LAST, brand#25 ASC NULLS FIRST, brand_id#24 ASC NULLS FIRST, i_manufact_id#12 ASC NULLS FIRST, i_manufact#13 ASC NULLS FIRST], [brand_id#24, brand#25, i_manufact_id#12, i_manufact#13, ext_price#26]
+(137) TakeOrderedAndProject
+Input [5]: [brand_id#25, brand#26, i_manufact_id#12, i_manufact#13, ext_price#27]
+Arguments: X, [ext_price#27 DESC NULLS LAST, brand#26 ASC NULLS FIRST, brand_id#25 ASC NULLS FIRST, i_manufact_id#12 ASC NULLS FIRST, i_manufact#13 ASC NULLS FIRST], [brand_id#25, brand#26, i_manufact_id#12, i_manufact#13, ext_price#27]
 
-(135) AdaptiveSparkPlan
-Output [5]: [brand_id#24, brand#25, i_manufact_id#12, i_manufact#13, ext_price#26]
+(138) AdaptiveSparkPlan
+Output [5]: [brand_id#25, brand#26, i_manufact_id#12, i_manufact#13, ext_price#27]
 Arguments: isFinalPlan=true
 

--- a/dev/auron-it/src/main/resources/tpcds-plan-stability/spark-3.5/q30.txt
+++ b/dev/auron-it/src/main/resources/tpcds-plan-stability/spark-3.5/q30.txt
@@ -1,211 +1,210 @@
 == Physical Plan ==
-AdaptiveSparkPlan (202)
+AdaptiveSparkPlan (201)
 +- == Final Plan ==
-   NativeTakeOrdered (129)
-   +- NativeProject (128)
-      +- NativeSortMergeJoin Inner (127)
-         :- NativeSort (117)
-         :  +- InputAdapter (116)
-         :     +- AQEShuffleRead (115)
-         :        +- ShuffleQueryStage (114), Statistics(X)
-         :           +- NativeShuffleExchange (113)
-         :              +- NativeProject (112)
-         :                 +- NativeSortMergeJoin Inner (111)
-         :                    :- NativeSort (102)
-         :                    :  +- InputAdapter (101)
-         :                    :     +- AQEShuffleRead (100)
-         :                    :        +- ShuffleQueryStage (99), Statistics(X)
-         :                    :           +- NativeShuffleExchange (98)
-         :                    :              +- ConvertToNative (97)
-         :                    :                 +- * Project (96)
-         :                    :                    +- * SortMergeJoin Inner (95)
-         :                    :                       :- NativeSort (48)
-         :                    :                       :  +- InputAdapter (47)
-         :                    :                       :     +- AQEShuffleRead (46)
-         :                    :                       :        +- ShuffleQueryStage (45), Statistics(X)
-         :                    :                       :           +- NativeShuffleExchange (44)
-         :                    :                       :              +- NativeFilter (43)
-         :                    :                       :                 +- NativeProject (42)
-         :                    :                       :                    +- NativeHashAggregate (41)
-         :                    :                       :                       +- InputAdapter (40)
-         :                    :                       :                          +- AQEShuffleRead (39)
-         :                    :                       :                             +- ShuffleQueryStage (38), Statistics(X)
-         :                    :                       :                                +- NativeShuffleExchange (37)
-         :                    :                       :                                   +- NativeHashAggregate (36)
-         :                    :                       :                                      +- NativeProject (35)
-         :                    :                       :                                         +- NativeProject (34)
-         :                    :                       :                                            +- NativeSortMergeJoin Inner (33)
-         :                    :                       :                                               :- NativeSort (24)
-         :                    :                       :                                               :  +- InputAdapter (23)
-         :                    :                       :                                               :     +- AQEShuffleRead (22)
-         :                    :                       :                                               :        +- ShuffleQueryStage (21), Statistics(X)
-         :                    :                       :                                               :           +- NativeShuffleExchange (20)
-         :                    :                       :                                               :              +- NativeProject (19)
-         :                    :                       :                                               :                 +- NativeSortMergeJoin Inner (18)
-         :                    :                       :                                               :                    :- NativeSort (8)
-         :                    :                       :                                               :                    :  +- InputAdapter (7)
-         :                    :                       :                                               :                    :     +- AQEShuffleRead (6)
-         :                    :                       :                                               :                    :        +- ShuffleQueryStage (5), Statistics(X)
-         :                    :                       :                                               :                    :           +- NativeShuffleExchange (4)
-         :                    :                       :                                               :                    :              +- NativeFilter (3)
-         :                    :                       :                                               :                    :                 +- InputAdapter (2)
-         :                    :                       :                                               :                    :                    +- NativeParquetScan  (1)
-         :                    :                       :                                               :                    +- NativeSort (17)
-         :                    :                       :                                               :                       +- InputAdapter (16)
-         :                    :                       :                                               :                          +- AQEShuffleRead (15)
-         :                    :                       :                                               :                             +- ShuffleQueryStage (14), Statistics(X)
-         :                    :                       :                                               :                                +- NativeShuffleExchange (13)
-         :                    :                       :                                               :                                   +- NativeProject (12)
-         :                    :                       :                                               :                                      +- NativeFilter (11)
-         :                    :                       :                                               :                                         +- InputAdapter (10)
-         :                    :                       :                                               :                                            +- NativeParquetScan  (9)
-         :                    :                       :                                               +- NativeSort (32)
-         :                    :                       :                                                  +- InputAdapter (31)
-         :                    :                       :                                                     +- AQEShuffleRead (30)
-         :                    :                       :                                                        +- ShuffleQueryStage (29), Statistics(X)
-         :                    :                       :                                                           +- NativeShuffleExchange (28)
-         :                    :                       :                                                              +- NativeFilter (27)
-         :                    :                       :                                                                 +- InputAdapter (26)
-         :                    :                       :                                                                    +- NativeParquetScan  (25)
-         :                    :                       +- NativeSort (94)
-         :                    :                          +- NativeFilter (93)
-         :                    :                             +- NativeProject (92)
-         :                    :                                +- NativeHashAggregate (91)
-         :                    :                                   +- InputAdapter (90)
-         :                    :                                      +- AQEShuffleRead (89)
-         :                    :                                         +- ShuffleQueryStage (88), Statistics(X)
-         :                    :                                            +- NativeShuffleExchange (87)
-         :                    :                                               +- NativeHashAggregate (86)
-         :                    :                                                  +- NativeProject (85)
-         :                    :                                                     +- NativeHashAggregate (84)
-         :                    :                                                        +- InputAdapter (83)
-         :                    :                                                           +- AQEShuffleRead (82)
-         :                    :                                                              +- ShuffleQueryStage (81), Statistics(X)
-         :                    :                                                                 +- NativeShuffleExchange (80)
-         :                    :                                                                    +- NativeHashAggregate (79)
-         :                    :                                                                       +- NativeProject (78)
-         :                    :                                                                          +- NativeProject (77)
-         :                    :                                                                             +- NativeSortMergeJoin Inner (76)
-         :                    :                                                                                :- NativeSort (69)
-         :                    :                                                                                :  +- InputAdapter (68)
-         :                    :                                                                                :     +- AQEShuffleRead (67)
-         :                    :                                                                                :        +- ShuffleQueryStage (66), Statistics(X)
-         :                    :                                                                                :           +- NativeShuffleExchange (65)
-         :                    :                                                                                :              +- NativeProject (64)
-         :                    :                                                                                :                 +- NativeSortMergeJoin Inner (63)
-         :                    :                                                                                :                    :- NativeSort (56)
-         :                    :                                                                                :                    :  +- InputAdapter (55)
-         :                    :                                                                                :                    :     +- AQEShuffleRead (54)
-         :                    :                                                                                :                    :        +- ShuffleQueryStage (53), Statistics(X)
-         :                    :                                                                                :                    :           +- NativeShuffleExchange (52)
-         :                    :                                                                                :                    :              +- NativeFilter (51)
-         :                    :                                                                                :                    :                 +- InputAdapter (50)
-         :                    :                                                                                :                    :                    +- NativeParquetScan  (49)
-         :                    :                                                                                :                    +- NativeSort (62)
-         :                    :                                                                                :                       +- InputAdapter (61)
-         :                    :                                                                                :                          +- InputAdapter (60)
-         :                    :                                                                                :                             +- AQEShuffleRead (59)
-         :                    :                                                                                :                                +- ShuffleQueryStage (58), Statistics(X)
-         :                    :                                                                                :                                   +- ReusedExchange (57)
-         :                    :                                                                                +- NativeSort (75)
-         :                    :                                                                                   +- InputAdapter (74)
-         :                    :                                                                                      +- InputAdapter (73)
-         :                    :                                                                                         +- AQEShuffleRead (72)
-         :                    :                                                                                            +- ShuffleQueryStage (71), Statistics(X)
-         :                    :                                                                                               +- ReusedExchange (70)
-         :                    +- NativeSort (110)
-         :                       +- InputAdapter (109)
-         :                          +- AQEShuffleRead (108)
-         :                             +- ShuffleQueryStage (107), Statistics(X)
-         :                                +- NativeShuffleExchange (106)
-         :                                   +- NativeFilter (105)
-         :                                      +- InputAdapter (104)
-         :                                         +- NativeParquetScan  (103)
-         +- NativeSort (126)
-            +- InputAdapter (125)
-               +- AQEShuffleRead (124)
-                  +- ShuffleQueryStage (123), Statistics(X)
-                     +- NativeShuffleExchange (122)
-                        +- NativeProject (121)
-                           +- NativeFilter (120)
-                              +- InputAdapter (119)
-                                 +- NativeParquetScan  (118)
+   NativeTakeOrdered (128)
+   +- NativeProject (127)
+      +- NativeSortMergeJoin Inner (126)
+         :- NativeSort (116)
+         :  +- InputAdapter (115)
+         :     +- AQEShuffleRead (114)
+         :        +- ShuffleQueryStage (113), Statistics(X)
+         :           +- NativeShuffleExchange (112)
+         :              +- NativeProject (111)
+         :                 +- NativeSortMergeJoin Inner (110)
+         :                    :- NativeSort (101)
+         :                    :  +- InputAdapter (100)
+         :                    :     +- AQEShuffleRead (99)
+         :                    :        +- ShuffleQueryStage (98), Statistics(X)
+         :                    :           +- NativeShuffleExchange (97)
+         :                    :              +- NativeProject (96)
+         :                    :                 +- NativeSortMergeJoin Inner (95)
+         :                    :                    :- NativeSort (48)
+         :                    :                    :  +- InputAdapter (47)
+         :                    :                    :     +- AQEShuffleRead (46)
+         :                    :                    :        +- ShuffleQueryStage (45), Statistics(X)
+         :                    :                    :           +- NativeShuffleExchange (44)
+         :                    :                    :              +- NativeFilter (43)
+         :                    :                    :                 +- NativeProject (42)
+         :                    :                    :                    +- NativeHashAggregate (41)
+         :                    :                    :                       +- InputAdapter (40)
+         :                    :                    :                          +- AQEShuffleRead (39)
+         :                    :                    :                             +- ShuffleQueryStage (38), Statistics(X)
+         :                    :                    :                                +- NativeShuffleExchange (37)
+         :                    :                    :                                   +- NativeHashAggregate (36)
+         :                    :                    :                                      +- NativeProject (35)
+         :                    :                    :                                         +- NativeProject (34)
+         :                    :                    :                                            +- NativeSortMergeJoin Inner (33)
+         :                    :                    :                                               :- NativeSort (24)
+         :                    :                    :                                               :  +- InputAdapter (23)
+         :                    :                    :                                               :     +- AQEShuffleRead (22)
+         :                    :                    :                                               :        +- ShuffleQueryStage (21), Statistics(X)
+         :                    :                    :                                               :           +- NativeShuffleExchange (20)
+         :                    :                    :                                               :              +- NativeProject (19)
+         :                    :                    :                                               :                 +- NativeSortMergeJoin Inner (18)
+         :                    :                    :                                               :                    :- NativeSort (8)
+         :                    :                    :                                               :                    :  +- InputAdapter (7)
+         :                    :                    :                                               :                    :     +- AQEShuffleRead (6)
+         :                    :                    :                                               :                    :        +- ShuffleQueryStage (5), Statistics(X)
+         :                    :                    :                                               :                    :           +- NativeShuffleExchange (4)
+         :                    :                    :                                               :                    :              +- NativeFilter (3)
+         :                    :                    :                                               :                    :                 +- InputAdapter (2)
+         :                    :                    :                                               :                    :                    +- NativeParquetScan  (1)
+         :                    :                    :                                               :                    +- NativeSort (17)
+         :                    :                    :                                               :                       +- InputAdapter (16)
+         :                    :                    :                                               :                          +- AQEShuffleRead (15)
+         :                    :                    :                                               :                             +- ShuffleQueryStage (14), Statistics(X)
+         :                    :                    :                                               :                                +- NativeShuffleExchange (13)
+         :                    :                    :                                               :                                   +- NativeProject (12)
+         :                    :                    :                                               :                                      +- NativeFilter (11)
+         :                    :                    :                                               :                                         +- InputAdapter (10)
+         :                    :                    :                                               :                                            +- NativeParquetScan  (9)
+         :                    :                    :                                               +- NativeSort (32)
+         :                    :                    :                                                  +- InputAdapter (31)
+         :                    :                    :                                                     +- AQEShuffleRead (30)
+         :                    :                    :                                                        +- ShuffleQueryStage (29), Statistics(X)
+         :                    :                    :                                                           +- NativeShuffleExchange (28)
+         :                    :                    :                                                              +- NativeFilter (27)
+         :                    :                    :                                                                 +- InputAdapter (26)
+         :                    :                    :                                                                    +- NativeParquetScan  (25)
+         :                    :                    +- NativeSort (94)
+         :                    :                       +- NativeFilter (93)
+         :                    :                          +- NativeProject (92)
+         :                    :                             +- NativeHashAggregate (91)
+         :                    :                                +- InputAdapter (90)
+         :                    :                                   +- AQEShuffleRead (89)
+         :                    :                                      +- ShuffleQueryStage (88), Statistics(X)
+         :                    :                                         +- NativeShuffleExchange (87)
+         :                    :                                            +- NativeHashAggregate (86)
+         :                    :                                               +- NativeProject (85)
+         :                    :                                                  +- NativeHashAggregate (84)
+         :                    :                                                     +- InputAdapter (83)
+         :                    :                                                        +- AQEShuffleRead (82)
+         :                    :                                                           +- ShuffleQueryStage (81), Statistics(X)
+         :                    :                                                              +- NativeShuffleExchange (80)
+         :                    :                                                                 +- NativeHashAggregate (79)
+         :                    :                                                                    +- NativeProject (78)
+         :                    :                                                                       +- NativeProject (77)
+         :                    :                                                                          +- NativeSortMergeJoin Inner (76)
+         :                    :                                                                             :- NativeSort (69)
+         :                    :                                                                             :  +- InputAdapter (68)
+         :                    :                                                                             :     +- AQEShuffleRead (67)
+         :                    :                                                                             :        +- ShuffleQueryStage (66), Statistics(X)
+         :                    :                                                                             :           +- NativeShuffleExchange (65)
+         :                    :                                                                             :              +- NativeProject (64)
+         :                    :                                                                             :                 +- NativeSortMergeJoin Inner (63)
+         :                    :                                                                             :                    :- NativeSort (56)
+         :                    :                                                                             :                    :  +- InputAdapter (55)
+         :                    :                                                                             :                    :     +- AQEShuffleRead (54)
+         :                    :                                                                             :                    :        +- ShuffleQueryStage (53), Statistics(X)
+         :                    :                                                                             :                    :           +- NativeShuffleExchange (52)
+         :                    :                                                                             :                    :              +- NativeFilter (51)
+         :                    :                                                                             :                    :                 +- InputAdapter (50)
+         :                    :                                                                             :                    :                    +- NativeParquetScan  (49)
+         :                    :                                                                             :                    +- NativeSort (62)
+         :                    :                                                                             :                       +- InputAdapter (61)
+         :                    :                                                                             :                          +- InputAdapter (60)
+         :                    :                                                                             :                             +- AQEShuffleRead (59)
+         :                    :                                                                             :                                +- ShuffleQueryStage (58), Statistics(X)
+         :                    :                                                                             :                                   +- ReusedExchange (57)
+         :                    :                                                                             +- NativeSort (75)
+         :                    :                                                                                +- InputAdapter (74)
+         :                    :                                                                                   +- InputAdapter (73)
+         :                    :                                                                                      +- AQEShuffleRead (72)
+         :                    :                                                                                         +- ShuffleQueryStage (71), Statistics(X)
+         :                    :                                                                                            +- ReusedExchange (70)
+         :                    +- NativeSort (109)
+         :                       +- InputAdapter (108)
+         :                          +- AQEShuffleRead (107)
+         :                             +- ShuffleQueryStage (106), Statistics(X)
+         :                                +- NativeShuffleExchange (105)
+         :                                   +- NativeFilter (104)
+         :                                      +- InputAdapter (103)
+         :                                         +- NativeParquetScan  (102)
+         +- NativeSort (125)
+            +- InputAdapter (124)
+               +- AQEShuffleRead (123)
+                  +- ShuffleQueryStage (122), Statistics(X)
+                     +- NativeShuffleExchange (121)
+                        +- NativeProject (120)
+                           +- NativeFilter (119)
+                              +- InputAdapter (118)
+                                 +- NativeParquetScan  (117)
 +- == Initial Plan ==
-   TakeOrderedAndProject (201)
-   +- Project (200)
-      +- SortMergeJoin Inner (199)
-         :- Sort (193)
-         :  +- Exchange (192)
-         :     +- Project (191)
-         :        +- SortMergeJoin Inner (190)
-         :           :- Sort (185)
-         :           :  +- Exchange (184)
-         :           :     +- Project (183)
-         :           :        +- SortMergeJoin Inner (182)
-         :           :           :- Sort (154)
-         :           :           :  +- Exchange (153)
-         :           :           :     +- Filter (152)
-         :           :           :        +- HashAggregate (151)
-         :           :           :           +- Exchange (150)
-         :           :           :              +- HashAggregate (149)
-         :           :           :                 +- Project (148)
-         :           :           :                    +- SortMergeJoin Inner (147)
-         :           :           :                       :- Sort (142)
-         :           :           :                       :  +- Exchange (141)
-         :           :           :                       :     +- Project (140)
-         :           :           :                       :        +- SortMergeJoin Inner (139)
-         :           :           :                       :           :- Sort (133)
-         :           :           :                       :           :  +- Exchange (132)
-         :           :           :                       :           :     +- Filter (131)
-         :           :           :                       :           :        +- Scan parquet (130)
-         :           :           :                       :           +- Sort (138)
-         :           :           :                       :              +- Exchange (137)
-         :           :           :                       :                 +- Project (136)
-         :           :           :                       :                    +- Filter (135)
-         :           :           :                       :                       +- Scan parquet (134)
-         :           :           :                       +- Sort (146)
-         :           :           :                          +- Exchange (145)
-         :           :           :                             +- Filter (144)
-         :           :           :                                +- Scan parquet (143)
-         :           :           +- Sort (181)
-         :           :              +- Filter (180)
-         :           :                 +- HashAggregate (179)
-         :           :                    +- Exchange (178)
-         :           :                       +- HashAggregate (177)
-         :           :                          +- HashAggregate (176)
-         :           :                             +- Exchange (175)
-         :           :                                +- HashAggregate (174)
-         :           :                                   +- Project (173)
-         :           :                                      +- SortMergeJoin Inner (172)
-         :           :                                         :- Sort (167)
-         :           :                                         :  +- Exchange (166)
-         :           :                                         :     +- Project (165)
-         :           :                                         :        +- SortMergeJoin Inner (164)
-         :           :                                         :           :- Sort (158)
-         :           :                                         :           :  +- Exchange (157)
-         :           :                                         :           :     +- Filter (156)
-         :           :                                         :           :        +- Scan parquet (155)
-         :           :                                         :           +- Sort (163)
-         :           :                                         :              +- Exchange (162)
-         :           :                                         :                 +- Project (161)
-         :           :                                         :                    +- Filter (160)
-         :           :                                         :                       +- Scan parquet (159)
-         :           :                                         +- Sort (171)
-         :           :                                            +- Exchange (170)
-         :           :                                               +- Filter (169)
-         :           :                                                  +- Scan parquet (168)
-         :           +- Sort (189)
-         :              +- Exchange (188)
-         :                 +- Filter (187)
-         :                    +- Scan parquet (186)
-         +- Sort (198)
-            +- Exchange (197)
-               +- Project (196)
-                  +- Filter (195)
-                     +- Scan parquet (194)
+   TakeOrderedAndProject (200)
+   +- Project (199)
+      +- SortMergeJoin Inner (198)
+         :- Sort (192)
+         :  +- Exchange (191)
+         :     +- Project (190)
+         :        +- SortMergeJoin Inner (189)
+         :           :- Sort (184)
+         :           :  +- Exchange (183)
+         :           :     +- Project (182)
+         :           :        +- SortMergeJoin Inner (181)
+         :           :           :- Sort (153)
+         :           :           :  +- Exchange (152)
+         :           :           :     +- Filter (151)
+         :           :           :        +- HashAggregate (150)
+         :           :           :           +- Exchange (149)
+         :           :           :              +- HashAggregate (148)
+         :           :           :                 +- Project (147)
+         :           :           :                    +- SortMergeJoin Inner (146)
+         :           :           :                       :- Sort (141)
+         :           :           :                       :  +- Exchange (140)
+         :           :           :                       :     +- Project (139)
+         :           :           :                       :        +- SortMergeJoin Inner (138)
+         :           :           :                       :           :- Sort (132)
+         :           :           :                       :           :  +- Exchange (131)
+         :           :           :                       :           :     +- Filter (130)
+         :           :           :                       :           :        +- Scan parquet (129)
+         :           :           :                       :           +- Sort (137)
+         :           :           :                       :              +- Exchange (136)
+         :           :           :                       :                 +- Project (135)
+         :           :           :                       :                    +- Filter (134)
+         :           :           :                       :                       +- Scan parquet (133)
+         :           :           :                       +- Sort (145)
+         :           :           :                          +- Exchange (144)
+         :           :           :                             +- Filter (143)
+         :           :           :                                +- Scan parquet (142)
+         :           :           +- Sort (180)
+         :           :              +- Filter (179)
+         :           :                 +- HashAggregate (178)
+         :           :                    +- Exchange (177)
+         :           :                       +- HashAggregate (176)
+         :           :                          +- HashAggregate (175)
+         :           :                             +- Exchange (174)
+         :           :                                +- HashAggregate (173)
+         :           :                                   +- Project (172)
+         :           :                                      +- SortMergeJoin Inner (171)
+         :           :                                         :- Sort (166)
+         :           :                                         :  +- Exchange (165)
+         :           :                                         :     +- Project (164)
+         :           :                                         :        +- SortMergeJoin Inner (163)
+         :           :                                         :           :- Sort (157)
+         :           :                                         :           :  +- Exchange (156)
+         :           :                                         :           :     +- Filter (155)
+         :           :                                         :           :        +- Scan parquet (154)
+         :           :                                         :           +- Sort (162)
+         :           :                                         :              +- Exchange (161)
+         :           :                                         :                 +- Project (160)
+         :           :                                         :                    +- Filter (159)
+         :           :                                         :                       +- Scan parquet (158)
+         :           :                                         +- Sort (170)
+         :           :                                            +- Exchange (169)
+         :           :                                               +- Filter (168)
+         :           :                                                  +- Scan parquet (167)
+         :           +- Sort (188)
+         :              +- Exchange (187)
+         :                 +- Filter (186)
+         :                    +- Scan parquet (185)
+         +- Sort (197)
+            +- Exchange (196)
+               +- Project (195)
+                  +- Filter (194)
+                     +- Scan parquet (193)
 
 
-(130) Scan parquet
+(129) Scan parquet
 Output [4]: [wr_returned_date_sk#1, wr_returning_customer_sk#2, wr_returning_addr_sk#3, wr_return_amt#4]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
@@ -239,7 +238,7 @@ Input [4]: [#1#1, #2#2, #3#3, #4#4]
 Input [4]: [#1#1, #2#2, #3#3, #4#4]
 Arguments: [wr_returned_date_sk#1 ASC NULLS FIRST], false
 
-(134) Scan parquet
+(133) Scan parquet
 Output [2]: [d_date_sk#5, d_year#6]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
@@ -306,7 +305,7 @@ Input [3]: [wr_returning_customer_sk#2, wr_returning_addr_sk#3, wr_return_amt#4]
 Input [3]: [wr_returning_customer_sk#2, wr_returning_addr_sk#3, wr_return_amt#4]
 Arguments: [wr_returning_addr_sk#3 ASC NULLS FIRST], false
 
-(143) Scan parquet
+(142) Scan parquet
 Output [2]: [ca_address_sk#7, ca_state#8]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
@@ -410,7 +409,7 @@ Input [3]: [ctr_customer_sk#13, ctr_state#14, ctr_total_return#15]
 Input [3]: [ctr_customer_sk#13, ctr_state#14, ctr_total_return#15]
 Arguments: [ctr_state#14 ASC NULLS FIRST], false
 
-(155) Scan parquet
+(154) Scan parquet
 Output [4]: [wr_returned_date_sk#16, wr_returning_customer_sk#17, wr_returning_addr_sk#18, wr_return_amt#19]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
@@ -605,498 +604,495 @@ Condition : isnotnull((avg(ctr_total_return) * 1.2)#31)
 Input [2]: [(avg(ctr_total_return) * 1.2)#31, ctr_state#25]
 Arguments: [ctr_state#25 ASC NULLS FIRST], false
 
-(95) SortMergeJoin [codegen id : X]
+(95) NativeSortMergeJoin
 Left keys [1]: [ctr_state#14]
 Right keys [1]: [ctr_state#25]
 Join type: Inner
 Join condition: (cast(ctr_total_return#15 as decimal(24,7)) > (avg(ctr_total_return) * 1.2)#31)
 
-(96) Project [codegen id : X]
+(96) NativeProject
 Output [2]: [ctr_customer_sk#13, ctr_total_return#15]
 Input [5]: [ctr_customer_sk#13, ctr_state#14, ctr_total_return#15, (avg(ctr_total_return) * 1.2)#31, ctr_state#25]
 
-(97) ConvertToNative
-Input [2]: [ctr_customer_sk#13, ctr_total_return#15]
-
-(98) NativeShuffleExchange
+(97) NativeShuffleExchange
 Input [2]: [ctr_customer_sk#13, ctr_total_return#15]
 Arguments: hashpartitioning(ctr_customer_sk#13, 100), ENSURE_REQUIREMENTS, [plan_id=11]
 
-(99) ShuffleQueryStage
+(98) ShuffleQueryStage
 Output [2]: [ctr_customer_sk#13, ctr_total_return#15]
 Arguments: X
 
-(100) AQEShuffleRead
+(99) AQEShuffleRead
 Input [2]: [ctr_customer_sk#13, ctr_total_return#15]
 Arguments: coalesced
 
-(101) InputAdapter
+(100) InputAdapter
 Input [2]: [ctr_customer_sk#13, ctr_total_return#15]
 
-(102) NativeSort
+(101) NativeSort
 Input [2]: [ctr_customer_sk#13, ctr_total_return#15]
 Arguments: [ctr_customer_sk#13 ASC NULLS FIRST], false
 
-(186) Scan parquet
+(185) Scan parquet
 Output [14]: [c_customer_sk#32, c_customer_id#33, c_current_addr_sk#34, c_salutation#35, c_first_name#36, c_last_name#37, c_preferred_cust_flag#38, c_birth_day#39, c_birth_month#40, c_birth_year#41, c_birth_country#42, c_login#43, c_email_address#44, c_last_review_date_sk#45]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_current_addr_sk)]
 ReadSchema: struct<c_customer_sk:int,c_customer_id:string,c_current_addr_sk:int,c_salutation:string,c_first_name:string,c_last_name:string,c_preferred_cust_flag:string,c_birth_day:int,c_birth_month:int,c_birth_year:int,c_birth_country:string,c_login:string,c_email_address:string,c_last_review_date_sk:int>
 
-(104) InputAdapter
+(103) InputAdapter
 Input [14]: [c_customer_sk#32, c_customer_id#33, c_current_addr_sk#34, c_salutation#35, c_first_name#36, c_last_name#37, c_preferred_cust_flag#38, c_birth_day#39, c_birth_month#40, c_birth_year#41, c_birth_country#42, c_login#43, c_email_address#44, c_last_review_date_sk#45]
 Arguments: [#32, #33, #34, #35, #36, #37, #38, #39, #40, #41, #42, #43, #44, #45]
 
-(105) NativeFilter
+(104) NativeFilter
 Input [14]: [#32#32, #33#33, #34#34, #35#35, #36#36, #37#37, #38#38, #39#39, #40#40, #41#41, #42#42, #43#43, #44#44, #45#45]
 Condition : (isnotnull(c_customer_sk#32) AND isnotnull(c_current_addr_sk#34))
 
-(106) NativeShuffleExchange
+(105) NativeShuffleExchange
 Input [14]: [#32#32, #33#33, #34#34, #35#35, #36#36, #37#37, #38#38, #39#39, #40#40, #41#41, #42#42, #43#43, #44#44, #45#45]
 Arguments: hashpartitioning(c_customer_sk#32, 100), ENSURE_REQUIREMENTS, [plan_id=12]
 
-(107) ShuffleQueryStage
+(106) ShuffleQueryStage
 Output [14]: [#32#32, #33#33, #34#34, #35#35, #36#36, #37#37, #38#38, #39#39, #40#40, #41#41, #42#42, #43#43, #44#44, #45#45]
 Arguments: X
 
-(108) AQEShuffleRead
+(107) AQEShuffleRead
 Input [14]: [#32#32, #33#33, #34#34, #35#35, #36#36, #37#37, #38#38, #39#39, #40#40, #41#41, #42#42, #43#43, #44#44, #45#45]
 Arguments: coalesced
 
-(109) InputAdapter
+(108) InputAdapter
 Input [14]: [#32#32, #33#33, #34#34, #35#35, #36#36, #37#37, #38#38, #39#39, #40#40, #41#41, #42#42, #43#43, #44#44, #45#45]
 
-(110) NativeSort
+(109) NativeSort
 Input [14]: [#32#32, #33#33, #34#34, #35#35, #36#36, #37#37, #38#38, #39#39, #40#40, #41#41, #42#42, #43#43, #44#44, #45#45]
 Arguments: [c_customer_sk#32 ASC NULLS FIRST], false
 
-(111) NativeSortMergeJoin
+(110) NativeSortMergeJoin
 Left keys [1]: [ctr_customer_sk#13]
 Right keys [1]: [c_customer_sk#32]
 Join type: Inner
 Join condition: None
 
-(112) NativeProject
+(111) NativeProject
 Output [14]: [ctr_total_return#15, c_customer_id#33, c_current_addr_sk#34, c_salutation#35, c_first_name#36, c_last_name#37, c_preferred_cust_flag#38, c_birth_day#39, c_birth_month#40, c_birth_year#41, c_birth_country#42, c_login#43, c_email_address#44, c_last_review_date_sk#45]
 Input [16]: [ctr_customer_sk#13, ctr_total_return#15, #32#32, #33#33, #34#34, #35#35, #36#36, #37#37, #38#38, #39#39, #40#40, #41#41, #42#42, #43#43, #44#44, #45#45]
 
-(113) NativeShuffleExchange
+(112) NativeShuffleExchange
 Input [14]: [ctr_total_return#15, c_customer_id#33, c_current_addr_sk#34, c_salutation#35, c_first_name#36, c_last_name#37, c_preferred_cust_flag#38, c_birth_day#39, c_birth_month#40, c_birth_year#41, c_birth_country#42, c_login#43, c_email_address#44, c_last_review_date_sk#45]
 Arguments: hashpartitioning(c_current_addr_sk#34, 100), ENSURE_REQUIREMENTS, [plan_id=13]
 
-(114) ShuffleQueryStage
+(113) ShuffleQueryStage
 Output [14]: [ctr_total_return#15, c_customer_id#33, c_current_addr_sk#34, c_salutation#35, c_first_name#36, c_last_name#37, c_preferred_cust_flag#38, c_birth_day#39, c_birth_month#40, c_birth_year#41, c_birth_country#42, c_login#43, c_email_address#44, c_last_review_date_sk#45]
 Arguments: X
 
-(115) AQEShuffleRead
+(114) AQEShuffleRead
 Input [14]: [ctr_total_return#15, c_customer_id#33, c_current_addr_sk#34, c_salutation#35, c_first_name#36, c_last_name#37, c_preferred_cust_flag#38, c_birth_day#39, c_birth_month#40, c_birth_year#41, c_birth_country#42, c_login#43, c_email_address#44, c_last_review_date_sk#45]
 Arguments: coalesced
 
-(116) InputAdapter
+(115) InputAdapter
 Input [14]: [ctr_total_return#15, c_customer_id#33, c_current_addr_sk#34, c_salutation#35, c_first_name#36, c_last_name#37, c_preferred_cust_flag#38, c_birth_day#39, c_birth_month#40, c_birth_year#41, c_birth_country#42, c_login#43, c_email_address#44, c_last_review_date_sk#45]
 
-(117) NativeSort
+(116) NativeSort
 Input [14]: [ctr_total_return#15, c_customer_id#33, c_current_addr_sk#34, c_salutation#35, c_first_name#36, c_last_name#37, c_preferred_cust_flag#38, c_birth_day#39, c_birth_month#40, c_birth_year#41, c_birth_country#42, c_login#43, c_email_address#44, c_last_review_date_sk#45]
 Arguments: [c_current_addr_sk#34 ASC NULLS FIRST], false
 
-(194) Scan parquet
+(193) Scan parquet
 Output [2]: [ca_address_sk#46, ca_state#47]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(ca_state), EqualTo(ca_state,GA), IsNotNull(ca_address_sk)]
 ReadSchema: struct<ca_address_sk:int,ca_state:string>
 
-(119) InputAdapter
+(118) InputAdapter
 Input [2]: [ca_address_sk#46, ca_state#47]
 Arguments: [#46, #47]
 
-(120) NativeFilter
+(119) NativeFilter
 Input [2]: [#46#46, #47#47]
 Condition : ((isnotnull(ca_state#47) AND (ca_state#47 = GA)) AND isnotnull(ca_address_sk#46))
 
-(121) NativeProject
+(120) NativeProject
 Output [1]: [ca_address_sk#46]
 Input [2]: [#46#46, #47#47]
 
-(122) NativeShuffleExchange
+(121) NativeShuffleExchange
 Input [1]: [ca_address_sk#46]
 Arguments: hashpartitioning(ca_address_sk#46, 100), ENSURE_REQUIREMENTS, [plan_id=14]
 
-(123) ShuffleQueryStage
+(122) ShuffleQueryStage
 Output [1]: [ca_address_sk#46]
 Arguments: X
 
-(124) AQEShuffleRead
+(123) AQEShuffleRead
 Input [1]: [ca_address_sk#46]
 Arguments: coalesced
 
-(125) InputAdapter
+(124) InputAdapter
 Input [1]: [ca_address_sk#46]
 
-(126) NativeSort
+(125) NativeSort
 Input [1]: [ca_address_sk#46]
 Arguments: [ca_address_sk#46 ASC NULLS FIRST], false
 
-(127) NativeSortMergeJoin
+(126) NativeSortMergeJoin
 Left keys [1]: [c_current_addr_sk#34]
 Right keys [1]: [ca_address_sk#46]
 Join type: Inner
 Join condition: None
 
-(128) NativeProject
+(127) NativeProject
 Output [13]: [c_customer_id#33, c_salutation#35, c_first_name#36, c_last_name#37, c_preferred_cust_flag#38, c_birth_day#39, c_birth_month#40, c_birth_year#41, c_birth_country#42, c_login#43, c_email_address#44, c_last_review_date_sk#45, ctr_total_return#15]
 Input [15]: [ctr_total_return#15, c_customer_id#33, c_current_addr_sk#34, c_salutation#35, c_first_name#36, c_last_name#37, c_preferred_cust_flag#38, c_birth_day#39, c_birth_month#40, c_birth_year#41, c_birth_country#42, c_login#43, c_email_address#44, c_last_review_date_sk#45, ca_address_sk#46]
 
-(129) NativeTakeOrdered
+(128) NativeTakeOrdered
 Input [13]: [c_customer_id#33, c_salutation#35, c_first_name#36, c_last_name#37, c_preferred_cust_flag#38, c_birth_day#39, c_birth_month#40, c_birth_year#41, c_birth_country#42, c_login#43, c_email_address#44, c_last_review_date_sk#45, ctr_total_return#15]
 Arguments: X, X, [c_customer_id#33 ASC NULLS FIRST, c_salutation#35 ASC NULLS FIRST, c_first_name#36 ASC NULLS FIRST, c_last_name#37 ASC NULLS FIRST, c_preferred_cust_flag#38 ASC NULLS FIRST, c_birth_day#39 ASC NULLS FIRST, c_birth_month#40 ASC NULLS FIRST, c_birth_year#41 ASC NULLS FIRST, c_birth_country#42 ASC NULLS FIRST, c_login#43 ASC NULLS FIRST, c_email_address#44 ASC NULLS FIRST, c_last_review_date_sk#45 ASC NULLS FIRST, ctr_total_return#15 ASC NULLS FIRST]
 
-(130) Scan parquet
+(129) Scan parquet
 Output [4]: [wr_returned_date_sk#1, wr_returning_customer_sk#2, wr_returning_addr_sk#3, wr_return_amt#4]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(wr_returned_date_sk), IsNotNull(wr_returning_addr_sk), IsNotNull(wr_returning_customer_sk)]
 ReadSchema: struct<wr_returned_date_sk:int,wr_returning_customer_sk:int,wr_returning_addr_sk:int,wr_return_amt:decimal(7,2)>
 
-(131) Filter
+(130) Filter
 Input [4]: [wr_returned_date_sk#1, wr_returning_customer_sk#2, wr_returning_addr_sk#3, wr_return_amt#4]
 Condition : ((isnotnull(wr_returned_date_sk#1) AND isnotnull(wr_returning_addr_sk#3)) AND isnotnull(wr_returning_customer_sk#2))
 
-(132) Exchange
+(131) Exchange
 Input [4]: [wr_returned_date_sk#1, wr_returning_customer_sk#2, wr_returning_addr_sk#3, wr_return_amt#4]
 Arguments: hashpartitioning(wr_returned_date_sk#1, 100), ENSURE_REQUIREMENTS, [plan_id=15]
 
-(133) Sort
+(132) Sort
 Input [4]: [wr_returned_date_sk#1, wr_returning_customer_sk#2, wr_returning_addr_sk#3, wr_return_amt#4]
 Arguments: [wr_returned_date_sk#1 ASC NULLS FIRST], false, 0
 
-(134) Scan parquet
+(133) Scan parquet
 Output [2]: [d_date_sk#5, d_year#6]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2002), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
-(135) Filter
+(134) Filter
 Input [2]: [d_date_sk#5, d_year#6]
 Condition : ((isnotnull(d_year#6) AND (d_year#6 = 2002)) AND isnotnull(d_date_sk#5))
 
-(136) Project
+(135) Project
 Output [1]: [d_date_sk#5]
 Input [2]: [d_date_sk#5, d_year#6]
 
-(137) Exchange
+(136) Exchange
 Input [1]: [d_date_sk#5]
 Arguments: hashpartitioning(d_date_sk#5, 100), ENSURE_REQUIREMENTS, [plan_id=16]
 
-(138) Sort
+(137) Sort
 Input [1]: [d_date_sk#5]
 Arguments: [d_date_sk#5 ASC NULLS FIRST], false, 0
 
-(139) SortMergeJoin
+(138) SortMergeJoin
 Left keys [1]: [wr_returned_date_sk#1]
 Right keys [1]: [d_date_sk#5]
 Join type: Inner
 Join condition: None
 
-(140) Project
+(139) Project
 Output [3]: [wr_returning_customer_sk#2, wr_returning_addr_sk#3, wr_return_amt#4]
 Input [5]: [wr_returned_date_sk#1, wr_returning_customer_sk#2, wr_returning_addr_sk#3, wr_return_amt#4, d_date_sk#5]
 
-(141) Exchange
+(140) Exchange
 Input [3]: [wr_returning_customer_sk#2, wr_returning_addr_sk#3, wr_return_amt#4]
 Arguments: hashpartitioning(wr_returning_addr_sk#3, 100), ENSURE_REQUIREMENTS, [plan_id=17]
 
-(142) Sort
+(141) Sort
 Input [3]: [wr_returning_customer_sk#2, wr_returning_addr_sk#3, wr_return_amt#4]
 Arguments: [wr_returning_addr_sk#3 ASC NULLS FIRST], false, 0
 
-(143) Scan parquet
+(142) Scan parquet
 Output [2]: [ca_address_sk#7, ca_state#8]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(ca_address_sk), IsNotNull(ca_state)]
 ReadSchema: struct<ca_address_sk:int,ca_state:string>
 
-(144) Filter
+(143) Filter
 Input [2]: [ca_address_sk#7, ca_state#8]
 Condition : (isnotnull(ca_address_sk#7) AND isnotnull(ca_state#8))
 
-(145) Exchange
+(144) Exchange
 Input [2]: [ca_address_sk#7, ca_state#8]
 Arguments: hashpartitioning(ca_address_sk#7, 100), ENSURE_REQUIREMENTS, [plan_id=18]
 
-(146) Sort
+(145) Sort
 Input [2]: [ca_address_sk#7, ca_state#8]
 Arguments: [ca_address_sk#7 ASC NULLS FIRST], false, 0
 
-(147) SortMergeJoin
+(146) SortMergeJoin
 Left keys [1]: [wr_returning_addr_sk#3]
 Right keys [1]: [ca_address_sk#7]
 Join type: Inner
 Join condition: None
 
-(148) Project
+(147) Project
 Output [3]: [wr_returning_customer_sk#2, wr_return_amt#4, ca_state#8]
 Input [5]: [wr_returning_customer_sk#2, wr_returning_addr_sk#3, wr_return_amt#4, ca_address_sk#7, ca_state#8]
 
-(149) HashAggregate
+(148) HashAggregate
 Input [3]: [wr_returning_customer_sk#2, wr_return_amt#4, ca_state#8]
 Keys [2]: [wr_returning_customer_sk#2, ca_state#8]
 Functions [1]: [partial_sum(UnscaledValue(wr_return_amt#4))]
 Aggregate Attributes [1]: [sum#10]
 Results [3]: [wr_returning_customer_sk#2, ca_state#8, sum#48]
 
-(150) Exchange
+(149) Exchange
 Input [3]: [wr_returning_customer_sk#2, ca_state#8, sum#48]
 Arguments: hashpartitioning(wr_returning_customer_sk#2, ca_state#8, 100), ENSURE_REQUIREMENTS, [plan_id=19]
 
-(151) HashAggregate
+(150) HashAggregate
 Input [3]: [wr_returning_customer_sk#2, ca_state#8, sum#48]
 Keys [2]: [wr_returning_customer_sk#2, ca_state#8]
 Functions [1]: [sum(UnscaledValue(wr_return_amt#4))]
 Aggregate Attributes [1]: [sum(UnscaledValue(wr_return_amt#4))#12]
 Results [3]: [wr_returning_customer_sk#2 AS ctr_customer_sk#13, ca_state#8 AS ctr_state#14, MakeDecimal(sum(UnscaledValue(wr_return_amt#4))#12,17,2) AS ctr_total_return#15]
 
-(152) Filter
+(151) Filter
 Input [3]: [ctr_customer_sk#13, ctr_state#14, ctr_total_return#15]
 Condition : isnotnull(ctr_total_return#15)
 
-(153) Exchange
+(152) Exchange
 Input [3]: [ctr_customer_sk#13, ctr_state#14, ctr_total_return#15]
 Arguments: hashpartitioning(ctr_state#14, 100), ENSURE_REQUIREMENTS, [plan_id=20]
 
-(154) Sort
+(153) Sort
 Input [3]: [ctr_customer_sk#13, ctr_state#14, ctr_total_return#15]
 Arguments: [ctr_state#14 ASC NULLS FIRST], false, 0
 
-(155) Scan parquet
+(154) Scan parquet
 Output [4]: [wr_returned_date_sk#16, wr_returning_customer_sk#17, wr_returning_addr_sk#18, wr_return_amt#19]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(wr_returned_date_sk), IsNotNull(wr_returning_addr_sk)]
 ReadSchema: struct<wr_returned_date_sk:int,wr_returning_customer_sk:int,wr_returning_addr_sk:int,wr_return_amt:decimal(7,2)>
 
-(156) Filter
+(155) Filter
 Input [4]: [wr_returned_date_sk#16, wr_returning_customer_sk#17, wr_returning_addr_sk#18, wr_return_amt#19]
 Condition : (isnotnull(wr_returned_date_sk#16) AND isnotnull(wr_returning_addr_sk#18))
 
-(157) Exchange
+(156) Exchange
 Input [4]: [wr_returned_date_sk#16, wr_returning_customer_sk#17, wr_returning_addr_sk#18, wr_return_amt#19]
 Arguments: hashpartitioning(wr_returned_date_sk#16, 100), ENSURE_REQUIREMENTS, [plan_id=21]
 
-(158) Sort
+(157) Sort
 Input [4]: [wr_returned_date_sk#16, wr_returning_customer_sk#17, wr_returning_addr_sk#18, wr_return_amt#19]
 Arguments: [wr_returned_date_sk#16 ASC NULLS FIRST], false, 0
 
-(159) Scan parquet
+(158) Scan parquet
 Output [2]: [d_date_sk#20, d_year#49]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2002), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
-(160) Filter
+(159) Filter
 Input [2]: [d_date_sk#20, d_year#49]
 Condition : ((isnotnull(d_year#49) AND (d_year#49 = 2002)) AND isnotnull(d_date_sk#20))
 
-(161) Project
+(160) Project
 Output [1]: [d_date_sk#20]
 Input [2]: [d_date_sk#20, d_year#49]
 
-(162) Exchange
+(161) Exchange
 Input [1]: [d_date_sk#20]
 Arguments: hashpartitioning(d_date_sk#20, 100), ENSURE_REQUIREMENTS, [plan_id=22]
 
-(163) Sort
+(162) Sort
 Input [1]: [d_date_sk#20]
 Arguments: [d_date_sk#20 ASC NULLS FIRST], false, 0
 
-(164) SortMergeJoin
+(163) SortMergeJoin
 Left keys [1]: [wr_returned_date_sk#16]
 Right keys [1]: [d_date_sk#20]
 Join type: Inner
 Join condition: None
 
-(165) Project
+(164) Project
 Output [3]: [wr_returning_customer_sk#17, wr_returning_addr_sk#18, wr_return_amt#19]
 Input [5]: [wr_returned_date_sk#16, wr_returning_customer_sk#17, wr_returning_addr_sk#18, wr_return_amt#19, d_date_sk#20]
 
-(166) Exchange
+(165) Exchange
 Input [3]: [wr_returning_customer_sk#17, wr_returning_addr_sk#18, wr_return_amt#19]
 Arguments: hashpartitioning(wr_returning_addr_sk#18, 100), ENSURE_REQUIREMENTS, [plan_id=23]
 
-(167) Sort
+(166) Sort
 Input [3]: [wr_returning_customer_sk#17, wr_returning_addr_sk#18, wr_return_amt#19]
 Arguments: [wr_returning_addr_sk#18 ASC NULLS FIRST], false, 0
 
-(168) Scan parquet
+(167) Scan parquet
 Output [2]: [ca_address_sk#21, ca_state#22]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(ca_address_sk), IsNotNull(ca_state)]
 ReadSchema: struct<ca_address_sk:int,ca_state:string>
 
-(169) Filter
+(168) Filter
 Input [2]: [ca_address_sk#21, ca_state#22]
 Condition : (isnotnull(ca_address_sk#21) AND isnotnull(ca_state#22))
 
-(170) Exchange
+(169) Exchange
 Input [2]: [ca_address_sk#21, ca_state#22]
 Arguments: hashpartitioning(ca_address_sk#21, 100), ENSURE_REQUIREMENTS, [plan_id=24]
 
-(171) Sort
+(170) Sort
 Input [2]: [ca_address_sk#21, ca_state#22]
 Arguments: [ca_address_sk#21 ASC NULLS FIRST], false, 0
 
-(172) SortMergeJoin
+(171) SortMergeJoin
 Left keys [1]: [wr_returning_addr_sk#18]
 Right keys [1]: [ca_address_sk#21]
 Join type: Inner
 Join condition: None
 
-(173) Project
+(172) Project
 Output [3]: [wr_returning_customer_sk#17, wr_return_amt#19, ca_state#22]
 Input [5]: [wr_returning_customer_sk#17, wr_returning_addr_sk#18, wr_return_amt#19, ca_address_sk#21, ca_state#22]
 
-(174) HashAggregate
+(173) HashAggregate
 Input [3]: [wr_returning_customer_sk#17, wr_return_amt#19, ca_state#22]
 Keys [2]: [wr_returning_customer_sk#17, ca_state#22]
 Functions [1]: [partial_sum(UnscaledValue(wr_return_amt#19))]
 Aggregate Attributes [1]: [sum#24]
 Results [3]: [wr_returning_customer_sk#17, ca_state#22, sum#50]
 
-(175) Exchange
+(174) Exchange
 Input [3]: [wr_returning_customer_sk#17, ca_state#22, sum#50]
 Arguments: hashpartitioning(wr_returning_customer_sk#17, ca_state#22, 100), ENSURE_REQUIREMENTS, [plan_id=25]
 
-(176) HashAggregate
+(175) HashAggregate
 Input [3]: [wr_returning_customer_sk#17, ca_state#22, sum#50]
 Keys [2]: [wr_returning_customer_sk#17, ca_state#22]
 Functions [1]: [sum(UnscaledValue(wr_return_amt#19))]
 Aggregate Attributes [1]: [sum(UnscaledValue(wr_return_amt#19))#12]
 Results [2]: [ca_state#22 AS ctr_state#25, MakeDecimal(sum(UnscaledValue(wr_return_amt#19))#12,17,2) AS ctr_total_return#26]
 
-(177) HashAggregate
+(176) HashAggregate
 Input [2]: [ctr_state#25, ctr_total_return#26]
 Keys [1]: [ctr_state#25]
 Functions [1]: [partial_avg(ctr_total_return#26)]
 Aggregate Attributes [2]: [sum#27, count#28]
 Results [3]: [ctr_state#25, sum#51, count#52]
 
-(178) Exchange
+(177) Exchange
 Input [3]: [ctr_state#25, sum#51, count#52]
 Arguments: hashpartitioning(ctr_state#25, 100), ENSURE_REQUIREMENTS, [plan_id=26]
 
-(179) HashAggregate
+(178) HashAggregate
 Input [3]: [ctr_state#25, sum#51, count#52]
 Keys [1]: [ctr_state#25]
 Functions [1]: [avg(ctr_total_return#26)]
 Aggregate Attributes [1]: [avg(ctr_total_return#26)#30]
 Results [2]: [(avg(ctr_total_return#26)#30 * 1.2) AS (avg(ctr_total_return) * 1.2)#31, ctr_state#25]
 
-(180) Filter
+(179) Filter
 Input [2]: [(avg(ctr_total_return) * 1.2)#31, ctr_state#25]
 Condition : isnotnull((avg(ctr_total_return) * 1.2)#31)
 
-(181) Sort
+(180) Sort
 Input [2]: [(avg(ctr_total_return) * 1.2)#31, ctr_state#25]
 Arguments: [ctr_state#25 ASC NULLS FIRST], false, 0
 
-(182) SortMergeJoin
+(181) SortMergeJoin
 Left keys [1]: [ctr_state#14]
 Right keys [1]: [ctr_state#25]
 Join type: Inner
 Join condition: (cast(ctr_total_return#15 as decimal(24,7)) > (avg(ctr_total_return) * 1.2)#31)
 
-(183) Project
+(182) Project
 Output [2]: [ctr_customer_sk#13, ctr_total_return#15]
 Input [5]: [ctr_customer_sk#13, ctr_state#14, ctr_total_return#15, (avg(ctr_total_return) * 1.2)#31, ctr_state#25]
 
-(184) Exchange
+(183) Exchange
 Input [2]: [ctr_customer_sk#13, ctr_total_return#15]
 Arguments: hashpartitioning(ctr_customer_sk#13, 100), ENSURE_REQUIREMENTS, [plan_id=27]
 
-(185) Sort
+(184) Sort
 Input [2]: [ctr_customer_sk#13, ctr_total_return#15]
 Arguments: [ctr_customer_sk#13 ASC NULLS FIRST], false, 0
 
-(186) Scan parquet
+(185) Scan parquet
 Output [14]: [c_customer_sk#32, c_customer_id#33, c_current_addr_sk#34, c_salutation#35, c_first_name#36, c_last_name#37, c_preferred_cust_flag#38, c_birth_day#39, c_birth_month#40, c_birth_year#41, c_birth_country#42, c_login#43, c_email_address#44, c_last_review_date_sk#45]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_current_addr_sk)]
 ReadSchema: struct<c_customer_sk:int,c_customer_id:string,c_current_addr_sk:int,c_salutation:string,c_first_name:string,c_last_name:string,c_preferred_cust_flag:string,c_birth_day:int,c_birth_month:int,c_birth_year:int,c_birth_country:string,c_login:string,c_email_address:string,c_last_review_date_sk:int>
 
-(187) Filter
+(186) Filter
 Input [14]: [c_customer_sk#32, c_customer_id#33, c_current_addr_sk#34, c_salutation#35, c_first_name#36, c_last_name#37, c_preferred_cust_flag#38, c_birth_day#39, c_birth_month#40, c_birth_year#41, c_birth_country#42, c_login#43, c_email_address#44, c_last_review_date_sk#45]
 Condition : (isnotnull(c_customer_sk#32) AND isnotnull(c_current_addr_sk#34))
 
-(188) Exchange
+(187) Exchange
 Input [14]: [c_customer_sk#32, c_customer_id#33, c_current_addr_sk#34, c_salutation#35, c_first_name#36, c_last_name#37, c_preferred_cust_flag#38, c_birth_day#39, c_birth_month#40, c_birth_year#41, c_birth_country#42, c_login#43, c_email_address#44, c_last_review_date_sk#45]
 Arguments: hashpartitioning(c_customer_sk#32, 100), ENSURE_REQUIREMENTS, [plan_id=28]
 
-(189) Sort
+(188) Sort
 Input [14]: [c_customer_sk#32, c_customer_id#33, c_current_addr_sk#34, c_salutation#35, c_first_name#36, c_last_name#37, c_preferred_cust_flag#38, c_birth_day#39, c_birth_month#40, c_birth_year#41, c_birth_country#42, c_login#43, c_email_address#44, c_last_review_date_sk#45]
 Arguments: [c_customer_sk#32 ASC NULLS FIRST], false, 0
 
-(190) SortMergeJoin
+(189) SortMergeJoin
 Left keys [1]: [ctr_customer_sk#13]
 Right keys [1]: [c_customer_sk#32]
 Join type: Inner
 Join condition: None
 
-(191) Project
+(190) Project
 Output [14]: [ctr_total_return#15, c_customer_id#33, c_current_addr_sk#34, c_salutation#35, c_first_name#36, c_last_name#37, c_preferred_cust_flag#38, c_birth_day#39, c_birth_month#40, c_birth_year#41, c_birth_country#42, c_login#43, c_email_address#44, c_last_review_date_sk#45]
 Input [16]: [ctr_customer_sk#13, ctr_total_return#15, c_customer_sk#32, c_customer_id#33, c_current_addr_sk#34, c_salutation#35, c_first_name#36, c_last_name#37, c_preferred_cust_flag#38, c_birth_day#39, c_birth_month#40, c_birth_year#41, c_birth_country#42, c_login#43, c_email_address#44, c_last_review_date_sk#45]
 
-(192) Exchange
+(191) Exchange
 Input [14]: [ctr_total_return#15, c_customer_id#33, c_current_addr_sk#34, c_salutation#35, c_first_name#36, c_last_name#37, c_preferred_cust_flag#38, c_birth_day#39, c_birth_month#40, c_birth_year#41, c_birth_country#42, c_login#43, c_email_address#44, c_last_review_date_sk#45]
 Arguments: hashpartitioning(c_current_addr_sk#34, 100), ENSURE_REQUIREMENTS, [plan_id=29]
 
-(193) Sort
+(192) Sort
 Input [14]: [ctr_total_return#15, c_customer_id#33, c_current_addr_sk#34, c_salutation#35, c_first_name#36, c_last_name#37, c_preferred_cust_flag#38, c_birth_day#39, c_birth_month#40, c_birth_year#41, c_birth_country#42, c_login#43, c_email_address#44, c_last_review_date_sk#45]
 Arguments: [c_current_addr_sk#34 ASC NULLS FIRST], false, 0
 
-(194) Scan parquet
+(193) Scan parquet
 Output [2]: [ca_address_sk#46, ca_state#47]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(ca_state), EqualTo(ca_state,GA), IsNotNull(ca_address_sk)]
 ReadSchema: struct<ca_address_sk:int,ca_state:string>
 
-(195) Filter
+(194) Filter
 Input [2]: [ca_address_sk#46, ca_state#47]
 Condition : ((isnotnull(ca_state#47) AND (ca_state#47 = GA)) AND isnotnull(ca_address_sk#46))
 
-(196) Project
+(195) Project
 Output [1]: [ca_address_sk#46]
 Input [2]: [ca_address_sk#46, ca_state#47]
 
-(197) Exchange
+(196) Exchange
 Input [1]: [ca_address_sk#46]
 Arguments: hashpartitioning(ca_address_sk#46, 100), ENSURE_REQUIREMENTS, [plan_id=30]
 
-(198) Sort
+(197) Sort
 Input [1]: [ca_address_sk#46]
 Arguments: [ca_address_sk#46 ASC NULLS FIRST], false, 0
 
-(199) SortMergeJoin
+(198) SortMergeJoin
 Left keys [1]: [c_current_addr_sk#34]
 Right keys [1]: [ca_address_sk#46]
 Join type: Inner
 Join condition: None
 
-(200) Project
+(199) Project
 Output [13]: [c_customer_id#33, c_salutation#35, c_first_name#36, c_last_name#37, c_preferred_cust_flag#38, c_birth_day#39, c_birth_month#40, c_birth_year#41, c_birth_country#42, c_login#43, c_email_address#44, c_last_review_date_sk#45, ctr_total_return#15]
 Input [15]: [ctr_total_return#15, c_customer_id#33, c_current_addr_sk#34, c_salutation#35, c_first_name#36, c_last_name#37, c_preferred_cust_flag#38, c_birth_day#39, c_birth_month#40, c_birth_year#41, c_birth_country#42, c_login#43, c_email_address#44, c_last_review_date_sk#45, ca_address_sk#46]
 
-(201) TakeOrderedAndProject
+(200) TakeOrderedAndProject
 Input [13]: [c_customer_id#33, c_salutation#35, c_first_name#36, c_last_name#37, c_preferred_cust_flag#38, c_birth_day#39, c_birth_month#40, c_birth_year#41, c_birth_country#42, c_login#43, c_email_address#44, c_last_review_date_sk#45, ctr_total_return#15]
 Arguments: X, [c_customer_id#33 ASC NULLS FIRST, c_salutation#35 ASC NULLS FIRST, c_first_name#36 ASC NULLS FIRST, c_last_name#37 ASC NULLS FIRST, c_preferred_cust_flag#38 ASC NULLS FIRST, c_birth_day#39 ASC NULLS FIRST, c_birth_month#40 ASC NULLS FIRST, c_birth_year#41 ASC NULLS FIRST, c_birth_country#42 ASC NULLS FIRST, c_login#43 ASC NULLS FIRST, c_email_address#44 ASC NULLS FIRST, c_last_review_date_sk#45 ASC NULLS FIRST, ctr_total_return#15 ASC NULLS FIRST], [c_customer_id#33, c_salutation#35, c_first_name#36, c_last_name#37, c_preferred_cust_flag#38, c_birth_day#39, c_birth_month#40, c_birth_year#41, c_birth_country#42, c_login#43, c_email_address#44, c_last_review_date_sk#45, ctr_total_return#15]
 
-(202) AdaptiveSparkPlan
+(201) AdaptiveSparkPlan
 Output [13]: [c_customer_id#33, c_salutation#35, c_first_name#36, c_last_name#37, c_preferred_cust_flag#38, c_birth_day#39, c_birth_month#40, c_birth_year#41, c_birth_country#42, c_login#43, c_email_address#44, c_last_review_date_sk#45, ctr_total_return#15]
 Arguments: isFinalPlan=true
 

--- a/dev/auron-it/src/main/resources/tpcds-plan-stability/spark-3.5/q31.txt
+++ b/dev/auron-it/src/main/resources/tpcds-plan-stability/spark-3.5/q31.txt
@@ -1,424 +1,423 @@
 == Physical Plan ==
-AdaptiveSparkPlan (415)
+AdaptiveSparkPlan (414)
 +- == Final Plan ==
-   NativeSort (266)
-   +- InputAdapter (265)
-      +- AQEShuffleRead (264)
-         +- ShuffleQueryStage (263), Statistics(X)
-            +- NativeShuffleExchange (262)
-               +- ConvertToNative (261)
-                  +- * Project (260)
-                     +- * SortMergeJoin Inner (259)
-                        :- * Project (218)
-                        :  +- * SortMergeJoin Inner (217)
-                        :     :- NativeSortMergeJoin Inner (176)
-                        :     :  :- NativeProject (133)
-                        :     :  :  +- NativeSortMergeJoin Inner (132)
-                        :     :  :     :- NativeSortMergeJoin Inner (89)
-                        :     :  :     :  :- NativeSort (46)
-                        :     :  :     :  :  +- InputAdapter (45)
-                        :     :  :     :  :     +- AQEShuffleRead (44)
-                        :     :  :     :  :        +- ShuffleQueryStage (43), Statistics(X)
-                        :     :  :     :  :           +- NativeShuffleExchange (42)
-                        :     :  :     :  :              +- NativeProject (41)
-                        :     :  :     :  :                 +- NativeHashAggregate (40)
-                        :     :  :     :  :                    +- InputAdapter (39)
-                        :     :  :     :  :                       +- AQEShuffleRead (38)
-                        :     :  :     :  :                          +- ShuffleQueryStage (37), Statistics(X)
-                        :     :  :     :  :                             +- NativeShuffleExchange (36)
-                        :     :  :     :  :                                +- NativeHashAggregate (35)
-                        :     :  :     :  :                                   +- NativeProject (34)
-                        :     :  :     :  :                                      +- NativeProject (33)
-                        :     :  :     :  :                                         +- NativeSortMergeJoin Inner (32)
-                        :     :  :     :  :                                            :- NativeSort (23)
-                        :     :  :     :  :                                            :  +- InputAdapter (22)
-                        :     :  :     :  :                                            :     +- AQEShuffleRead (21)
-                        :     :  :     :  :                                            :        +- ShuffleQueryStage (20), Statistics(X)
-                        :     :  :     :  :                                            :           +- NativeShuffleExchange (19)
-                        :     :  :     :  :                                            :              +- NativeProject (18)
-                        :     :  :     :  :                                            :                 +- NativeSortMergeJoin Inner (17)
-                        :     :  :     :  :                                            :                    :- NativeSort (8)
-                        :     :  :     :  :                                            :                    :  +- InputAdapter (7)
-                        :     :  :     :  :                                            :                    :     +- AQEShuffleRead (6)
-                        :     :  :     :  :                                            :                    :        +- ShuffleQueryStage (5), Statistics(X)
-                        :     :  :     :  :                                            :                    :           +- NativeShuffleExchange (4)
-                        :     :  :     :  :                                            :                    :              +- NativeFilter (3)
-                        :     :  :     :  :                                            :                    :                 +- InputAdapter (2)
-                        :     :  :     :  :                                            :                    :                    +- NativeParquetScan  (1)
-                        :     :  :     :  :                                            :                    +- NativeSort (16)
-                        :     :  :     :  :                                            :                       +- InputAdapter (15)
-                        :     :  :     :  :                                            :                          +- AQEShuffleRead (14)
-                        :     :  :     :  :                                            :                             +- ShuffleQueryStage (13), Statistics(X)
-                        :     :  :     :  :                                            :                                +- NativeShuffleExchange (12)
-                        :     :  :     :  :                                            :                                   +- NativeFilter (11)
-                        :     :  :     :  :                                            :                                      +- InputAdapter (10)
-                        :     :  :     :  :                                            :                                         +- NativeParquetScan  (9)
-                        :     :  :     :  :                                            +- NativeSort (31)
-                        :     :  :     :  :                                               +- InputAdapter (30)
-                        :     :  :     :  :                                                  +- AQEShuffleRead (29)
-                        :     :  :     :  :                                                     +- ShuffleQueryStage (28), Statistics(X)
-                        :     :  :     :  :                                                        +- NativeShuffleExchange (27)
-                        :     :  :     :  :                                                           +- NativeFilter (26)
-                        :     :  :     :  :                                                              +- InputAdapter (25)
-                        :     :  :     :  :                                                                 +- NativeParquetScan  (24)
-                        :     :  :     :  +- NativeSort (88)
-                        :     :  :     :     +- InputAdapter (87)
-                        :     :  :     :        +- AQEShuffleRead (86)
-                        :     :  :     :           +- ShuffleQueryStage (85), Statistics(X)
-                        :     :  :     :              +- NativeShuffleExchange (84)
-                        :     :  :     :                 +- NativeProject (83)
-                        :     :  :     :                    +- NativeHashAggregate (82)
-                        :     :  :     :                       +- InputAdapter (81)
-                        :     :  :     :                          +- AQEShuffleRead (80)
-                        :     :  :     :                             +- ShuffleQueryStage (79), Statistics(X)
-                        :     :  :     :                                +- NativeShuffleExchange (78)
-                        :     :  :     :                                   +- NativeHashAggregate (77)
-                        :     :  :     :                                      +- NativeProject (76)
-                        :     :  :     :                                         +- NativeProject (75)
-                        :     :  :     :                                            +- NativeSortMergeJoin Inner (74)
-                        :     :  :     :                                               :- NativeSort (67)
-                        :     :  :     :                                               :  +- InputAdapter (66)
-                        :     :  :     :                                               :     +- AQEShuffleRead (65)
-                        :     :  :     :                                               :        +- ShuffleQueryStage (64), Statistics(X)
-                        :     :  :     :                                               :           +- NativeShuffleExchange (63)
-                        :     :  :     :                                               :              +- NativeProject (62)
-                        :     :  :     :                                               :                 +- NativeSortMergeJoin Inner (61)
-                        :     :  :     :                                               :                    :- NativeSort (52)
-                        :     :  :     :                                               :                    :  +- InputAdapter (51)
-                        :     :  :     :                                               :                    :     +- InputAdapter (50)
-                        :     :  :     :                                               :                    :        +- AQEShuffleRead (49)
-                        :     :  :     :                                               :                    :           +- ShuffleQueryStage (48), Statistics(X)
-                        :     :  :     :                                               :                    :              +- ReusedExchange (47)
-                        :     :  :     :                                               :                    +- NativeSort (60)
-                        :     :  :     :                                               :                       +- InputAdapter (59)
-                        :     :  :     :                                               :                          +- AQEShuffleRead (58)
-                        :     :  :     :                                               :                             +- ShuffleQueryStage (57), Statistics(X)
-                        :     :  :     :                                               :                                +- NativeShuffleExchange (56)
-                        :     :  :     :                                               :                                   +- NativeFilter (55)
-                        :     :  :     :                                               :                                      +- InputAdapter (54)
-                        :     :  :     :                                               :                                         +- NativeParquetScan  (53)
-                        :     :  :     :                                               +- NativeSort (73)
-                        :     :  :     :                                                  +- InputAdapter (72)
-                        :     :  :     :                                                     +- InputAdapter (71)
-                        :     :  :     :                                                        +- AQEShuffleRead (70)
-                        :     :  :     :                                                           +- ShuffleQueryStage (69), Statistics(X)
-                        :     :  :     :                                                              +- ReusedExchange (68)
-                        :     :  :     +- NativeSort (131)
-                        :     :  :        +- InputAdapter (130)
-                        :     :  :           +- AQEShuffleRead (129)
-                        :     :  :              +- ShuffleQueryStage (128), Statistics(X)
-                        :     :  :                 +- NativeShuffleExchange (127)
-                        :     :  :                    +- NativeProject (126)
-                        :     :  :                       +- NativeHashAggregate (125)
-                        :     :  :                          +- InputAdapter (124)
-                        :     :  :                             +- AQEShuffleRead (123)
-                        :     :  :                                +- ShuffleQueryStage (122), Statistics(X)
-                        :     :  :                                   +- NativeShuffleExchange (121)
-                        :     :  :                                      +- NativeHashAggregate (120)
-                        :     :  :                                         +- NativeProject (119)
-                        :     :  :                                            +- NativeProject (118)
-                        :     :  :                                               +- NativeSortMergeJoin Inner (117)
-                        :     :  :                                                  :- NativeSort (110)
-                        :     :  :                                                  :  +- InputAdapter (109)
-                        :     :  :                                                  :     +- AQEShuffleRead (108)
-                        :     :  :                                                  :        +- ShuffleQueryStage (107), Statistics(X)
-                        :     :  :                                                  :           +- NativeShuffleExchange (106)
-                        :     :  :                                                  :              +- NativeProject (105)
-                        :     :  :                                                  :                 +- NativeSortMergeJoin Inner (104)
-                        :     :  :                                                  :                    :- NativeSort (95)
-                        :     :  :                                                  :                    :  +- InputAdapter (94)
-                        :     :  :                                                  :                    :     +- InputAdapter (93)
-                        :     :  :                                                  :                    :        +- AQEShuffleRead (92)
-                        :     :  :                                                  :                    :           +- ShuffleQueryStage (91), Statistics(X)
-                        :     :  :                                                  :                    :              +- ReusedExchange (90)
-                        :     :  :                                                  :                    +- NativeSort (103)
-                        :     :  :                                                  :                       +- InputAdapter (102)
-                        :     :  :                                                  :                          +- AQEShuffleRead (101)
-                        :     :  :                                                  :                             +- ShuffleQueryStage (100), Statistics(X)
-                        :     :  :                                                  :                                +- NativeShuffleExchange (99)
-                        :     :  :                                                  :                                   +- NativeFilter (98)
-                        :     :  :                                                  :                                      +- InputAdapter (97)
-                        :     :  :                                                  :                                         +- NativeParquetScan  (96)
-                        :     :  :                                                  +- NativeSort (116)
-                        :     :  :                                                     +- InputAdapter (115)
-                        :     :  :                                                        +- InputAdapter (114)
-                        :     :  :                                                           +- AQEShuffleRead (113)
-                        :     :  :                                                              +- ShuffleQueryStage (112), Statistics(X)
-                        :     :  :                                                                 +- ReusedExchange (111)
-                        :     :  +- NativeSort (175)
-                        :     :     +- InputAdapter (174)
-                        :     :        +- AQEShuffleRead (173)
-                        :     :           +- ShuffleQueryStage (172), Statistics(X)
-                        :     :              +- NativeShuffleExchange (171)
-                        :     :                 +- NativeProject (170)
-                        :     :                    +- NativeHashAggregate (169)
-                        :     :                       +- InputAdapter (168)
-                        :     :                          +- AQEShuffleRead (167)
-                        :     :                             +- ShuffleQueryStage (166), Statistics(X)
-                        :     :                                +- NativeShuffleExchange (165)
-                        :     :                                   +- NativeHashAggregate (164)
-                        :     :                                      +- NativeProject (163)
-                        :     :                                         +- NativeProject (162)
-                        :     :                                            +- NativeSortMergeJoin Inner (161)
-                        :     :                                               :- NativeSort (154)
-                        :     :                                               :  +- InputAdapter (153)
-                        :     :                                               :     +- AQEShuffleRead (152)
-                        :     :                                               :        +- ShuffleQueryStage (151), Statistics(X)
-                        :     :                                               :           +- NativeShuffleExchange (150)
-                        :     :                                               :              +- NativeProject (149)
-                        :     :                                               :                 +- NativeSortMergeJoin Inner (148)
-                        :     :                                               :                    :- NativeSort (141)
-                        :     :                                               :                    :  +- InputAdapter (140)
-                        :     :                                               :                    :     +- AQEShuffleRead (139)
-                        :     :                                               :                    :        +- ShuffleQueryStage (138), Statistics(X)
-                        :     :                                               :                    :           +- NativeShuffleExchange (137)
-                        :     :                                               :                    :              +- NativeFilter (136)
-                        :     :                                               :                    :                 +- InputAdapter (135)
-                        :     :                                               :                    :                    +- NativeParquetScan  (134)
-                        :     :                                               :                    +- NativeSort (147)
-                        :     :                                               :                       +- InputAdapter (146)
-                        :     :                                               :                          +- InputAdapter (145)
-                        :     :                                               :                             +- AQEShuffleRead (144)
-                        :     :                                               :                                +- ShuffleQueryStage (143), Statistics(X)
-                        :     :                                               :                                   +- ReusedExchange (142)
-                        :     :                                               +- NativeSort (160)
-                        :     :                                                  +- InputAdapter (159)
-                        :     :                                                     +- InputAdapter (158)
-                        :     :                                                        +- AQEShuffleRead (157)
-                        :     :                                                           +- ShuffleQueryStage (156), Statistics(X)
-                        :     :                                                              +- ReusedExchange (155)
-                        :     +- NativeSort (216)
-                        :        +- InputAdapter (215)
-                        :           +- AQEShuffleRead (214)
-                        :              +- ShuffleQueryStage (213), Statistics(X)
-                        :                 +- NativeShuffleExchange (212)
-                        :                    +- NativeProject (211)
-                        :                       +- NativeHashAggregate (210)
-                        :                          +- InputAdapter (209)
-                        :                             +- AQEShuffleRead (208)
-                        :                                +- ShuffleQueryStage (207), Statistics(X)
-                        :                                   +- NativeShuffleExchange (206)
-                        :                                      +- NativeHashAggregate (205)
-                        :                                         +- NativeProject (204)
-                        :                                            +- NativeProject (203)
-                        :                                               +- NativeSortMergeJoin Inner (202)
-                        :                                                  :- NativeSort (195)
-                        :                                                  :  +- InputAdapter (194)
-                        :                                                  :     +- AQEShuffleRead (193)
-                        :                                                  :        +- ShuffleQueryStage (192), Statistics(X)
-                        :                                                  :           +- NativeShuffleExchange (191)
-                        :                                                  :              +- NativeProject (190)
-                        :                                                  :                 +- NativeSortMergeJoin Inner (189)
-                        :                                                  :                    :- NativeSort (182)
-                        :                                                  :                    :  +- InputAdapter (181)
-                        :                                                  :                    :     +- InputAdapter (180)
-                        :                                                  :                    :        +- AQEShuffleRead (179)
-                        :                                                  :                    :           +- ShuffleQueryStage (178), Statistics(X)
-                        :                                                  :                    :              +- ReusedExchange (177)
-                        :                                                  :                    +- NativeSort (188)
-                        :                                                  :                       +- InputAdapter (187)
-                        :                                                  :                          +- InputAdapter (186)
-                        :                                                  :                             +- AQEShuffleRead (185)
-                        :                                                  :                                +- ShuffleQueryStage (184), Statistics(X)
-                        :                                                  :                                   +- ReusedExchange (183)
-                        :                                                  +- NativeSort (201)
-                        :                                                     +- InputAdapter (200)
-                        :                                                        +- InputAdapter (199)
-                        :                                                           +- AQEShuffleRead (198)
-                        :                                                              +- ShuffleQueryStage (197), Statistics(X)
-                        :                                                                 +- ReusedExchange (196)
-                        +- NativeSort (258)
-                           +- InputAdapter (257)
-                              +- AQEShuffleRead (256)
-                                 +- ShuffleQueryStage (255), Statistics(X)
-                                    +- NativeShuffleExchange (254)
-                                       +- NativeProject (253)
-                                          +- NativeHashAggregate (252)
-                                             +- InputAdapter (251)
-                                                +- AQEShuffleRead (250)
-                                                   +- ShuffleQueryStage (249), Statistics(X)
-                                                      +- NativeShuffleExchange (248)
-                                                         +- NativeHashAggregate (247)
-                                                            +- NativeProject (246)
-                                                               +- NativeProject (245)
-                                                                  +- NativeSortMergeJoin Inner (244)
-                                                                     :- NativeSort (237)
-                                                                     :  +- InputAdapter (236)
-                                                                     :     +- AQEShuffleRead (235)
-                                                                     :        +- ShuffleQueryStage (234), Statistics(X)
-                                                                     :           +- NativeShuffleExchange (233)
-                                                                     :              +- NativeProject (232)
-                                                                     :                 +- NativeSortMergeJoin Inner (231)
-                                                                     :                    :- NativeSort (224)
-                                                                     :                    :  +- InputAdapter (223)
-                                                                     :                    :     +- InputAdapter (222)
-                                                                     :                    :        +- AQEShuffleRead (221)
-                                                                     :                    :           +- ShuffleQueryStage (220), Statistics(X)
-                                                                     :                    :              +- ReusedExchange (219)
-                                                                     :                    +- NativeSort (230)
-                                                                     :                       +- InputAdapter (229)
-                                                                     :                          +- InputAdapter (228)
-                                                                     :                             +- AQEShuffleRead (227)
-                                                                     :                                +- ShuffleQueryStage (226), Statistics(X)
-                                                                     :                                   +- ReusedExchange (225)
-                                                                     +- NativeSort (243)
-                                                                        +- InputAdapter (242)
-                                                                           +- InputAdapter (241)
-                                                                              +- AQEShuffleRead (240)
-                                                                                 +- ShuffleQueryStage (239), Statistics(X)
-                                                                                    +- ReusedExchange (238)
+   NativeSort (265)
+   +- InputAdapter (264)
+      +- AQEShuffleRead (263)
+         +- ShuffleQueryStage (262), Statistics(X)
+            +- NativeShuffleExchange (261)
+               +- NativeProject (260)
+                  +- NativeSortMergeJoin Inner (259)
+                     :- NativeProject (218)
+                     :  +- NativeSortMergeJoin Inner (217)
+                     :     :- NativeSortMergeJoin Inner (176)
+                     :     :  :- NativeProject (133)
+                     :     :  :  +- NativeSortMergeJoin Inner (132)
+                     :     :  :     :- NativeSortMergeJoin Inner (89)
+                     :     :  :     :  :- NativeSort (46)
+                     :     :  :     :  :  +- InputAdapter (45)
+                     :     :  :     :  :     +- AQEShuffleRead (44)
+                     :     :  :     :  :        +- ShuffleQueryStage (43), Statistics(X)
+                     :     :  :     :  :           +- NativeShuffleExchange (42)
+                     :     :  :     :  :              +- NativeProject (41)
+                     :     :  :     :  :                 +- NativeHashAggregate (40)
+                     :     :  :     :  :                    +- InputAdapter (39)
+                     :     :  :     :  :                       +- AQEShuffleRead (38)
+                     :     :  :     :  :                          +- ShuffleQueryStage (37), Statistics(X)
+                     :     :  :     :  :                             +- NativeShuffleExchange (36)
+                     :     :  :     :  :                                +- NativeHashAggregate (35)
+                     :     :  :     :  :                                   +- NativeProject (34)
+                     :     :  :     :  :                                      +- NativeProject (33)
+                     :     :  :     :  :                                         +- NativeSortMergeJoin Inner (32)
+                     :     :  :     :  :                                            :- NativeSort (23)
+                     :     :  :     :  :                                            :  +- InputAdapter (22)
+                     :     :  :     :  :                                            :     +- AQEShuffleRead (21)
+                     :     :  :     :  :                                            :        +- ShuffleQueryStage (20), Statistics(X)
+                     :     :  :     :  :                                            :           +- NativeShuffleExchange (19)
+                     :     :  :     :  :                                            :              +- NativeProject (18)
+                     :     :  :     :  :                                            :                 +- NativeSortMergeJoin Inner (17)
+                     :     :  :     :  :                                            :                    :- NativeSort (8)
+                     :     :  :     :  :                                            :                    :  +- InputAdapter (7)
+                     :     :  :     :  :                                            :                    :     +- AQEShuffleRead (6)
+                     :     :  :     :  :                                            :                    :        +- ShuffleQueryStage (5), Statistics(X)
+                     :     :  :     :  :                                            :                    :           +- NativeShuffleExchange (4)
+                     :     :  :     :  :                                            :                    :              +- NativeFilter (3)
+                     :     :  :     :  :                                            :                    :                 +- InputAdapter (2)
+                     :     :  :     :  :                                            :                    :                    +- NativeParquetScan  (1)
+                     :     :  :     :  :                                            :                    +- NativeSort (16)
+                     :     :  :     :  :                                            :                       +- InputAdapter (15)
+                     :     :  :     :  :                                            :                          +- AQEShuffleRead (14)
+                     :     :  :     :  :                                            :                             +- ShuffleQueryStage (13), Statistics(X)
+                     :     :  :     :  :                                            :                                +- NativeShuffleExchange (12)
+                     :     :  :     :  :                                            :                                   +- NativeFilter (11)
+                     :     :  :     :  :                                            :                                      +- InputAdapter (10)
+                     :     :  :     :  :                                            :                                         +- NativeParquetScan  (9)
+                     :     :  :     :  :                                            +- NativeSort (31)
+                     :     :  :     :  :                                               +- InputAdapter (30)
+                     :     :  :     :  :                                                  +- AQEShuffleRead (29)
+                     :     :  :     :  :                                                     +- ShuffleQueryStage (28), Statistics(X)
+                     :     :  :     :  :                                                        +- NativeShuffleExchange (27)
+                     :     :  :     :  :                                                           +- NativeFilter (26)
+                     :     :  :     :  :                                                              +- InputAdapter (25)
+                     :     :  :     :  :                                                                 +- NativeParquetScan  (24)
+                     :     :  :     :  +- NativeSort (88)
+                     :     :  :     :     +- InputAdapter (87)
+                     :     :  :     :        +- AQEShuffleRead (86)
+                     :     :  :     :           +- ShuffleQueryStage (85), Statistics(X)
+                     :     :  :     :              +- NativeShuffleExchange (84)
+                     :     :  :     :                 +- NativeProject (83)
+                     :     :  :     :                    +- NativeHashAggregate (82)
+                     :     :  :     :                       +- InputAdapter (81)
+                     :     :  :     :                          +- AQEShuffleRead (80)
+                     :     :  :     :                             +- ShuffleQueryStage (79), Statistics(X)
+                     :     :  :     :                                +- NativeShuffleExchange (78)
+                     :     :  :     :                                   +- NativeHashAggregate (77)
+                     :     :  :     :                                      +- NativeProject (76)
+                     :     :  :     :                                         +- NativeProject (75)
+                     :     :  :     :                                            +- NativeSortMergeJoin Inner (74)
+                     :     :  :     :                                               :- NativeSort (67)
+                     :     :  :     :                                               :  +- InputAdapter (66)
+                     :     :  :     :                                               :     +- AQEShuffleRead (65)
+                     :     :  :     :                                               :        +- ShuffleQueryStage (64), Statistics(X)
+                     :     :  :     :                                               :           +- NativeShuffleExchange (63)
+                     :     :  :     :                                               :              +- NativeProject (62)
+                     :     :  :     :                                               :                 +- NativeSortMergeJoin Inner (61)
+                     :     :  :     :                                               :                    :- NativeSort (52)
+                     :     :  :     :                                               :                    :  +- InputAdapter (51)
+                     :     :  :     :                                               :                    :     +- InputAdapter (50)
+                     :     :  :     :                                               :                    :        +- AQEShuffleRead (49)
+                     :     :  :     :                                               :                    :           +- ShuffleQueryStage (48), Statistics(X)
+                     :     :  :     :                                               :                    :              +- ReusedExchange (47)
+                     :     :  :     :                                               :                    +- NativeSort (60)
+                     :     :  :     :                                               :                       +- InputAdapter (59)
+                     :     :  :     :                                               :                          +- AQEShuffleRead (58)
+                     :     :  :     :                                               :                             +- ShuffleQueryStage (57), Statistics(X)
+                     :     :  :     :                                               :                                +- NativeShuffleExchange (56)
+                     :     :  :     :                                               :                                   +- NativeFilter (55)
+                     :     :  :     :                                               :                                      +- InputAdapter (54)
+                     :     :  :     :                                               :                                         +- NativeParquetScan  (53)
+                     :     :  :     :                                               +- NativeSort (73)
+                     :     :  :     :                                                  +- InputAdapter (72)
+                     :     :  :     :                                                     +- InputAdapter (71)
+                     :     :  :     :                                                        +- AQEShuffleRead (70)
+                     :     :  :     :                                                           +- ShuffleQueryStage (69), Statistics(X)
+                     :     :  :     :                                                              +- ReusedExchange (68)
+                     :     :  :     +- NativeSort (131)
+                     :     :  :        +- InputAdapter (130)
+                     :     :  :           +- AQEShuffleRead (129)
+                     :     :  :              +- ShuffleQueryStage (128), Statistics(X)
+                     :     :  :                 +- NativeShuffleExchange (127)
+                     :     :  :                    +- NativeProject (126)
+                     :     :  :                       +- NativeHashAggregate (125)
+                     :     :  :                          +- InputAdapter (124)
+                     :     :  :                             +- AQEShuffleRead (123)
+                     :     :  :                                +- ShuffleQueryStage (122), Statistics(X)
+                     :     :  :                                   +- NativeShuffleExchange (121)
+                     :     :  :                                      +- NativeHashAggregate (120)
+                     :     :  :                                         +- NativeProject (119)
+                     :     :  :                                            +- NativeProject (118)
+                     :     :  :                                               +- NativeSortMergeJoin Inner (117)
+                     :     :  :                                                  :- NativeSort (110)
+                     :     :  :                                                  :  +- InputAdapter (109)
+                     :     :  :                                                  :     +- AQEShuffleRead (108)
+                     :     :  :                                                  :        +- ShuffleQueryStage (107), Statistics(X)
+                     :     :  :                                                  :           +- NativeShuffleExchange (106)
+                     :     :  :                                                  :              +- NativeProject (105)
+                     :     :  :                                                  :                 +- NativeSortMergeJoin Inner (104)
+                     :     :  :                                                  :                    :- NativeSort (95)
+                     :     :  :                                                  :                    :  +- InputAdapter (94)
+                     :     :  :                                                  :                    :     +- InputAdapter (93)
+                     :     :  :                                                  :                    :        +- AQEShuffleRead (92)
+                     :     :  :                                                  :                    :           +- ShuffleQueryStage (91), Statistics(X)
+                     :     :  :                                                  :                    :              +- ReusedExchange (90)
+                     :     :  :                                                  :                    +- NativeSort (103)
+                     :     :  :                                                  :                       +- InputAdapter (102)
+                     :     :  :                                                  :                          +- AQEShuffleRead (101)
+                     :     :  :                                                  :                             +- ShuffleQueryStage (100), Statistics(X)
+                     :     :  :                                                  :                                +- NativeShuffleExchange (99)
+                     :     :  :                                                  :                                   +- NativeFilter (98)
+                     :     :  :                                                  :                                      +- InputAdapter (97)
+                     :     :  :                                                  :                                         +- NativeParquetScan  (96)
+                     :     :  :                                                  +- NativeSort (116)
+                     :     :  :                                                     +- InputAdapter (115)
+                     :     :  :                                                        +- InputAdapter (114)
+                     :     :  :                                                           +- AQEShuffleRead (113)
+                     :     :  :                                                              +- ShuffleQueryStage (112), Statistics(X)
+                     :     :  :                                                                 +- ReusedExchange (111)
+                     :     :  +- NativeSort (175)
+                     :     :     +- InputAdapter (174)
+                     :     :        +- AQEShuffleRead (173)
+                     :     :           +- ShuffleQueryStage (172), Statistics(X)
+                     :     :              +- NativeShuffleExchange (171)
+                     :     :                 +- NativeProject (170)
+                     :     :                    +- NativeHashAggregate (169)
+                     :     :                       +- InputAdapter (168)
+                     :     :                          +- AQEShuffleRead (167)
+                     :     :                             +- ShuffleQueryStage (166), Statistics(X)
+                     :     :                                +- NativeShuffleExchange (165)
+                     :     :                                   +- NativeHashAggregate (164)
+                     :     :                                      +- NativeProject (163)
+                     :     :                                         +- NativeProject (162)
+                     :     :                                            +- NativeSortMergeJoin Inner (161)
+                     :     :                                               :- NativeSort (154)
+                     :     :                                               :  +- InputAdapter (153)
+                     :     :                                               :     +- AQEShuffleRead (152)
+                     :     :                                               :        +- ShuffleQueryStage (151), Statistics(X)
+                     :     :                                               :           +- NativeShuffleExchange (150)
+                     :     :                                               :              +- NativeProject (149)
+                     :     :                                               :                 +- NativeSortMergeJoin Inner (148)
+                     :     :                                               :                    :- NativeSort (141)
+                     :     :                                               :                    :  +- InputAdapter (140)
+                     :     :                                               :                    :     +- AQEShuffleRead (139)
+                     :     :                                               :                    :        +- ShuffleQueryStage (138), Statistics(X)
+                     :     :                                               :                    :           +- NativeShuffleExchange (137)
+                     :     :                                               :                    :              +- NativeFilter (136)
+                     :     :                                               :                    :                 +- InputAdapter (135)
+                     :     :                                               :                    :                    +- NativeParquetScan  (134)
+                     :     :                                               :                    +- NativeSort (147)
+                     :     :                                               :                       +- InputAdapter (146)
+                     :     :                                               :                          +- InputAdapter (145)
+                     :     :                                               :                             +- AQEShuffleRead (144)
+                     :     :                                               :                                +- ShuffleQueryStage (143), Statistics(X)
+                     :     :                                               :                                   +- ReusedExchange (142)
+                     :     :                                               +- NativeSort (160)
+                     :     :                                                  +- InputAdapter (159)
+                     :     :                                                     +- InputAdapter (158)
+                     :     :                                                        +- AQEShuffleRead (157)
+                     :     :                                                           +- ShuffleQueryStage (156), Statistics(X)
+                     :     :                                                              +- ReusedExchange (155)
+                     :     +- NativeSort (216)
+                     :        +- InputAdapter (215)
+                     :           +- AQEShuffleRead (214)
+                     :              +- ShuffleQueryStage (213), Statistics(X)
+                     :                 +- NativeShuffleExchange (212)
+                     :                    +- NativeProject (211)
+                     :                       +- NativeHashAggregate (210)
+                     :                          +- InputAdapter (209)
+                     :                             +- AQEShuffleRead (208)
+                     :                                +- ShuffleQueryStage (207), Statistics(X)
+                     :                                   +- NativeShuffleExchange (206)
+                     :                                      +- NativeHashAggregate (205)
+                     :                                         +- NativeProject (204)
+                     :                                            +- NativeProject (203)
+                     :                                               +- NativeSortMergeJoin Inner (202)
+                     :                                                  :- NativeSort (195)
+                     :                                                  :  +- InputAdapter (194)
+                     :                                                  :     +- AQEShuffleRead (193)
+                     :                                                  :        +- ShuffleQueryStage (192), Statistics(X)
+                     :                                                  :           +- NativeShuffleExchange (191)
+                     :                                                  :              +- NativeProject (190)
+                     :                                                  :                 +- NativeSortMergeJoin Inner (189)
+                     :                                                  :                    :- NativeSort (182)
+                     :                                                  :                    :  +- InputAdapter (181)
+                     :                                                  :                    :     +- InputAdapter (180)
+                     :                                                  :                    :        +- AQEShuffleRead (179)
+                     :                                                  :                    :           +- ShuffleQueryStage (178), Statistics(X)
+                     :                                                  :                    :              +- ReusedExchange (177)
+                     :                                                  :                    +- NativeSort (188)
+                     :                                                  :                       +- InputAdapter (187)
+                     :                                                  :                          +- InputAdapter (186)
+                     :                                                  :                             +- AQEShuffleRead (185)
+                     :                                                  :                                +- ShuffleQueryStage (184), Statistics(X)
+                     :                                                  :                                   +- ReusedExchange (183)
+                     :                                                  +- NativeSort (201)
+                     :                                                     +- InputAdapter (200)
+                     :                                                        +- InputAdapter (199)
+                     :                                                           +- AQEShuffleRead (198)
+                     :                                                              +- ShuffleQueryStage (197), Statistics(X)
+                     :                                                                 +- ReusedExchange (196)
+                     +- NativeSort (258)
+                        +- InputAdapter (257)
+                           +- AQEShuffleRead (256)
+                              +- ShuffleQueryStage (255), Statistics(X)
+                                 +- NativeShuffleExchange (254)
+                                    +- NativeProject (253)
+                                       +- NativeHashAggregate (252)
+                                          +- InputAdapter (251)
+                                             +- AQEShuffleRead (250)
+                                                +- ShuffleQueryStage (249), Statistics(X)
+                                                   +- NativeShuffleExchange (248)
+                                                      +- NativeHashAggregate (247)
+                                                         +- NativeProject (246)
+                                                            +- NativeProject (245)
+                                                               +- NativeSortMergeJoin Inner (244)
+                                                                  :- NativeSort (237)
+                                                                  :  +- InputAdapter (236)
+                                                                  :     +- AQEShuffleRead (235)
+                                                                  :        +- ShuffleQueryStage (234), Statistics(X)
+                                                                  :           +- NativeShuffleExchange (233)
+                                                                  :              +- NativeProject (232)
+                                                                  :                 +- NativeSortMergeJoin Inner (231)
+                                                                  :                    :- NativeSort (224)
+                                                                  :                    :  +- InputAdapter (223)
+                                                                  :                    :     +- InputAdapter (222)
+                                                                  :                    :        +- AQEShuffleRead (221)
+                                                                  :                    :           +- ShuffleQueryStage (220), Statistics(X)
+                                                                  :                    :              +- ReusedExchange (219)
+                                                                  :                    +- NativeSort (230)
+                                                                  :                       +- InputAdapter (229)
+                                                                  :                          +- InputAdapter (228)
+                                                                  :                             +- AQEShuffleRead (227)
+                                                                  :                                +- ShuffleQueryStage (226), Statistics(X)
+                                                                  :                                   +- ReusedExchange (225)
+                                                                  +- NativeSort (243)
+                                                                     +- InputAdapter (242)
+                                                                        +- InputAdapter (241)
+                                                                           +- AQEShuffleRead (240)
+                                                                              +- ShuffleQueryStage (239), Statistics(X)
+                                                                                 +- ReusedExchange (238)
 +- == Initial Plan ==
-   Sort (414)
-   +- Exchange (413)
-      +- Project (412)
-         +- SortMergeJoin Inner (411)
-            :- Project (387)
-            :  +- SortMergeJoin Inner (386)
-            :     :- SortMergeJoin Inner (362)
-            :     :  :- Project (338)
-            :     :  :  +- SortMergeJoin Inner (337)
-            :     :  :     :- SortMergeJoin Inner (313)
-            :     :  :     :  :- Sort (289)
-            :     :  :     :  :  +- Exchange (288)
-            :     :  :     :  :     +- HashAggregate (287)
-            :     :  :     :  :        +- Exchange (286)
-            :     :  :     :  :           +- HashAggregate (285)
-            :     :  :     :  :              +- Project (284)
-            :     :  :     :  :                 +- SortMergeJoin Inner (283)
-            :     :  :     :  :                    :- Sort (278)
-            :     :  :     :  :                    :  +- Exchange (277)
-            :     :  :     :  :                    :     +- Project (276)
-            :     :  :     :  :                    :        +- SortMergeJoin Inner (275)
-            :     :  :     :  :                    :           :- Sort (270)
-            :     :  :     :  :                    :           :  +- Exchange (269)
-            :     :  :     :  :                    :           :     +- Filter (268)
-            :     :  :     :  :                    :           :        +- Scan parquet (267)
-            :     :  :     :  :                    :           +- Sort (274)
-            :     :  :     :  :                    :              +- Exchange (273)
-            :     :  :     :  :                    :                 +- Filter (272)
-            :     :  :     :  :                    :                    +- Scan parquet (271)
-            :     :  :     :  :                    +- Sort (282)
-            :     :  :     :  :                       +- Exchange (281)
-            :     :  :     :  :                          +- Filter (280)
-            :     :  :     :  :                             +- Scan parquet (279)
-            :     :  :     :  +- Sort (312)
-            :     :  :     :     +- Exchange (311)
-            :     :  :     :        +- HashAggregate (310)
-            :     :  :     :           +- Exchange (309)
-            :     :  :     :              +- HashAggregate (308)
-            :     :  :     :                 +- Project (307)
-            :     :  :     :                    +- SortMergeJoin Inner (306)
-            :     :  :     :                       :- Sort (301)
-            :     :  :     :                       :  +- Exchange (300)
-            :     :  :     :                       :     +- Project (299)
-            :     :  :     :                       :        +- SortMergeJoin Inner (298)
-            :     :  :     :                       :           :- Sort (293)
-            :     :  :     :                       :           :  +- Exchange (292)
-            :     :  :     :                       :           :     +- Filter (291)
-            :     :  :     :                       :           :        +- Scan parquet (290)
-            :     :  :     :                       :           +- Sort (297)
-            :     :  :     :                       :              +- Exchange (296)
-            :     :  :     :                       :                 +- Filter (295)
-            :     :  :     :                       :                    +- Scan parquet (294)
-            :     :  :     :                       +- Sort (305)
-            :     :  :     :                          +- Exchange (304)
-            :     :  :     :                             +- Filter (303)
-            :     :  :     :                                +- Scan parquet (302)
-            :     :  :     +- Sort (336)
-            :     :  :        +- Exchange (335)
-            :     :  :           +- HashAggregate (334)
-            :     :  :              +- Exchange (333)
-            :     :  :                 +- HashAggregate (332)
-            :     :  :                    +- Project (331)
-            :     :  :                       +- SortMergeJoin Inner (330)
-            :     :  :                          :- Sort (325)
-            :     :  :                          :  +- Exchange (324)
-            :     :  :                          :     +- Project (323)
-            :     :  :                          :        +- SortMergeJoin Inner (322)
-            :     :  :                          :           :- Sort (317)
-            :     :  :                          :           :  +- Exchange (316)
-            :     :  :                          :           :     +- Filter (315)
-            :     :  :                          :           :        +- Scan parquet (314)
-            :     :  :                          :           +- Sort (321)
-            :     :  :                          :              +- Exchange (320)
-            :     :  :                          :                 +- Filter (319)
-            :     :  :                          :                    +- Scan parquet (318)
-            :     :  :                          +- Sort (329)
-            :     :  :                             +- Exchange (328)
-            :     :  :                                +- Filter (327)
-            :     :  :                                   +- Scan parquet (326)
-            :     :  +- Sort (361)
-            :     :     +- Exchange (360)
-            :     :        +- HashAggregate (359)
-            :     :           +- Exchange (358)
-            :     :              +- HashAggregate (357)
-            :     :                 +- Project (356)
-            :     :                    +- SortMergeJoin Inner (355)
-            :     :                       :- Sort (350)
-            :     :                       :  +- Exchange (349)
-            :     :                       :     +- Project (348)
-            :     :                       :        +- SortMergeJoin Inner (347)
-            :     :                       :           :- Sort (342)
-            :     :                       :           :  +- Exchange (341)
-            :     :                       :           :     +- Filter (340)
-            :     :                       :           :        +- Scan parquet (339)
-            :     :                       :           +- Sort (346)
-            :     :                       :              +- Exchange (345)
-            :     :                       :                 +- Filter (344)
-            :     :                       :                    +- Scan parquet (343)
-            :     :                       +- Sort (354)
-            :     :                          +- Exchange (353)
-            :     :                             +- Filter (352)
-            :     :                                +- Scan parquet (351)
-            :     +- Sort (385)
-            :        +- Exchange (384)
-            :           +- HashAggregate (383)
-            :              +- Exchange (382)
-            :                 +- HashAggregate (381)
-            :                    +- Project (380)
-            :                       +- SortMergeJoin Inner (379)
-            :                          :- Sort (374)
-            :                          :  +- Exchange (373)
-            :                          :     +- Project (372)
-            :                          :        +- SortMergeJoin Inner (371)
-            :                          :           :- Sort (366)
-            :                          :           :  +- Exchange (365)
-            :                          :           :     +- Filter (364)
-            :                          :           :        +- Scan parquet (363)
-            :                          :           +- Sort (370)
-            :                          :              +- Exchange (369)
-            :                          :                 +- Filter (368)
-            :                          :                    +- Scan parquet (367)
-            :                          +- Sort (378)
-            :                             +- Exchange (377)
-            :                                +- Filter (376)
-            :                                   +- Scan parquet (375)
-            +- Sort (410)
-               +- Exchange (409)
-                  +- HashAggregate (408)
-                     +- Exchange (407)
-                        +- HashAggregate (406)
-                           +- Project (405)
-                              +- SortMergeJoin Inner (404)
-                                 :- Sort (399)
-                                 :  +- Exchange (398)
-                                 :     +- Project (397)
-                                 :        +- SortMergeJoin Inner (396)
-                                 :           :- Sort (391)
-                                 :           :  +- Exchange (390)
-                                 :           :     +- Filter (389)
-                                 :           :        +- Scan parquet (388)
-                                 :           +- Sort (395)
-                                 :              +- Exchange (394)
-                                 :                 +- Filter (393)
-                                 :                    +- Scan parquet (392)
-                                 +- Sort (403)
-                                    +- Exchange (402)
-                                       +- Filter (401)
-                                          +- Scan parquet (400)
+   Sort (413)
+   +- Exchange (412)
+      +- Project (411)
+         +- SortMergeJoin Inner (410)
+            :- Project (386)
+            :  +- SortMergeJoin Inner (385)
+            :     :- SortMergeJoin Inner (361)
+            :     :  :- Project (337)
+            :     :  :  +- SortMergeJoin Inner (336)
+            :     :  :     :- SortMergeJoin Inner (312)
+            :     :  :     :  :- Sort (288)
+            :     :  :     :  :  +- Exchange (287)
+            :     :  :     :  :     +- HashAggregate (286)
+            :     :  :     :  :        +- Exchange (285)
+            :     :  :     :  :           +- HashAggregate (284)
+            :     :  :     :  :              +- Project (283)
+            :     :  :     :  :                 +- SortMergeJoin Inner (282)
+            :     :  :     :  :                    :- Sort (277)
+            :     :  :     :  :                    :  +- Exchange (276)
+            :     :  :     :  :                    :     +- Project (275)
+            :     :  :     :  :                    :        +- SortMergeJoin Inner (274)
+            :     :  :     :  :                    :           :- Sort (269)
+            :     :  :     :  :                    :           :  +- Exchange (268)
+            :     :  :     :  :                    :           :     +- Filter (267)
+            :     :  :     :  :                    :           :        +- Scan parquet (266)
+            :     :  :     :  :                    :           +- Sort (273)
+            :     :  :     :  :                    :              +- Exchange (272)
+            :     :  :     :  :                    :                 +- Filter (271)
+            :     :  :     :  :                    :                    +- Scan parquet (270)
+            :     :  :     :  :                    +- Sort (281)
+            :     :  :     :  :                       +- Exchange (280)
+            :     :  :     :  :                          +- Filter (279)
+            :     :  :     :  :                             +- Scan parquet (278)
+            :     :  :     :  +- Sort (311)
+            :     :  :     :     +- Exchange (310)
+            :     :  :     :        +- HashAggregate (309)
+            :     :  :     :           +- Exchange (308)
+            :     :  :     :              +- HashAggregate (307)
+            :     :  :     :                 +- Project (306)
+            :     :  :     :                    +- SortMergeJoin Inner (305)
+            :     :  :     :                       :- Sort (300)
+            :     :  :     :                       :  +- Exchange (299)
+            :     :  :     :                       :     +- Project (298)
+            :     :  :     :                       :        +- SortMergeJoin Inner (297)
+            :     :  :     :                       :           :- Sort (292)
+            :     :  :     :                       :           :  +- Exchange (291)
+            :     :  :     :                       :           :     +- Filter (290)
+            :     :  :     :                       :           :        +- Scan parquet (289)
+            :     :  :     :                       :           +- Sort (296)
+            :     :  :     :                       :              +- Exchange (295)
+            :     :  :     :                       :                 +- Filter (294)
+            :     :  :     :                       :                    +- Scan parquet (293)
+            :     :  :     :                       +- Sort (304)
+            :     :  :     :                          +- Exchange (303)
+            :     :  :     :                             +- Filter (302)
+            :     :  :     :                                +- Scan parquet (301)
+            :     :  :     +- Sort (335)
+            :     :  :        +- Exchange (334)
+            :     :  :           +- HashAggregate (333)
+            :     :  :              +- Exchange (332)
+            :     :  :                 +- HashAggregate (331)
+            :     :  :                    +- Project (330)
+            :     :  :                       +- SortMergeJoin Inner (329)
+            :     :  :                          :- Sort (324)
+            :     :  :                          :  +- Exchange (323)
+            :     :  :                          :     +- Project (322)
+            :     :  :                          :        +- SortMergeJoin Inner (321)
+            :     :  :                          :           :- Sort (316)
+            :     :  :                          :           :  +- Exchange (315)
+            :     :  :                          :           :     +- Filter (314)
+            :     :  :                          :           :        +- Scan parquet (313)
+            :     :  :                          :           +- Sort (320)
+            :     :  :                          :              +- Exchange (319)
+            :     :  :                          :                 +- Filter (318)
+            :     :  :                          :                    +- Scan parquet (317)
+            :     :  :                          +- Sort (328)
+            :     :  :                             +- Exchange (327)
+            :     :  :                                +- Filter (326)
+            :     :  :                                   +- Scan parquet (325)
+            :     :  +- Sort (360)
+            :     :     +- Exchange (359)
+            :     :        +- HashAggregate (358)
+            :     :           +- Exchange (357)
+            :     :              +- HashAggregate (356)
+            :     :                 +- Project (355)
+            :     :                    +- SortMergeJoin Inner (354)
+            :     :                       :- Sort (349)
+            :     :                       :  +- Exchange (348)
+            :     :                       :     +- Project (347)
+            :     :                       :        +- SortMergeJoin Inner (346)
+            :     :                       :           :- Sort (341)
+            :     :                       :           :  +- Exchange (340)
+            :     :                       :           :     +- Filter (339)
+            :     :                       :           :        +- Scan parquet (338)
+            :     :                       :           +- Sort (345)
+            :     :                       :              +- Exchange (344)
+            :     :                       :                 +- Filter (343)
+            :     :                       :                    +- Scan parquet (342)
+            :     :                       +- Sort (353)
+            :     :                          +- Exchange (352)
+            :     :                             +- Filter (351)
+            :     :                                +- Scan parquet (350)
+            :     +- Sort (384)
+            :        +- Exchange (383)
+            :           +- HashAggregate (382)
+            :              +- Exchange (381)
+            :                 +- HashAggregate (380)
+            :                    +- Project (379)
+            :                       +- SortMergeJoin Inner (378)
+            :                          :- Sort (373)
+            :                          :  +- Exchange (372)
+            :                          :     +- Project (371)
+            :                          :        +- SortMergeJoin Inner (370)
+            :                          :           :- Sort (365)
+            :                          :           :  +- Exchange (364)
+            :                          :           :     +- Filter (363)
+            :                          :           :        +- Scan parquet (362)
+            :                          :           +- Sort (369)
+            :                          :              +- Exchange (368)
+            :                          :                 +- Filter (367)
+            :                          :                    +- Scan parquet (366)
+            :                          +- Sort (377)
+            :                             +- Exchange (376)
+            :                                +- Filter (375)
+            :                                   +- Scan parquet (374)
+            +- Sort (409)
+               +- Exchange (408)
+                  +- HashAggregate (407)
+                     +- Exchange (406)
+                        +- HashAggregate (405)
+                           +- Project (404)
+                              +- SortMergeJoin Inner (403)
+                                 :- Sort (398)
+                                 :  +- Exchange (397)
+                                 :     +- Project (396)
+                                 :        +- SortMergeJoin Inner (395)
+                                 :           :- Sort (390)
+                                 :           :  +- Exchange (389)
+                                 :           :     +- Filter (388)
+                                 :           :        +- Scan parquet (387)
+                                 :           +- Sort (394)
+                                 :              +- Exchange (393)
+                                 :                 +- Filter (392)
+                                 :                    +- Scan parquet (391)
+                                 +- Sort (402)
+                                    +- Exchange (401)
+                                       +- Filter (400)
+                                          +- Scan parquet (399)
 
 
-(267) Scan parquet
+(266) Scan parquet
 Output [3]: [ss_sold_date_sk#1, ss_addr_sk#2, ss_ext_sales_price#3]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
@@ -452,7 +451,7 @@ Input [3]: [#1#1, #2#2, #3#3]
 Input [3]: [#1#1, #2#2, #3#3]
 Arguments: [ss_sold_date_sk#1 ASC NULLS FIRST], false
 
-(271) Scan parquet
+(270) Scan parquet
 Output [3]: [d_date_sk#4, d_year#5, d_qoy#6]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
@@ -515,7 +514,7 @@ Input [4]: [ss_addr_sk#2, ss_ext_sales_price#3, d_year#5, d_qoy#6]
 Input [4]: [ss_addr_sk#2, ss_ext_sales_price#3, d_year#5, d_qoy#6]
 Arguments: [ss_addr_sk#2 ASC NULLS FIRST], false
 
-(279) Scan parquet
+(278) Scan parquet
 Output [2]: [ca_address_sk#7, ca_county#8]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
@@ -637,7 +636,7 @@ Input [3]: [#14#14, #15#15, #16#16]
 Input [3]: [#14#14, #15#15, #16#16]
 Arguments: [ss_sold_date_sk#14 ASC NULLS FIRST], false
 
-(294) Scan parquet
+(293) Scan parquet
 Output [3]: [d_date_sk#17, d_year#18, d_qoy#19]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
@@ -816,7 +815,7 @@ Input [3]: [#25#25, #26#26, #27#27]
 Input [3]: [#25#25, #26#26, #27#27]
 Arguments: [ss_sold_date_sk#25 ASC NULLS FIRST], false
 
-(318) Scan parquet
+(317) Scan parquet
 Output [3]: [d_date_sk#28, d_year#29, d_qoy#30]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
@@ -977,7 +976,7 @@ Join condition: None
 Output [5]: [ca_county#8, d_year#5, store_sales#13, store_sales#24, store_sales#35]
 Input [7]: [ca_county#8, d_year#5, store_sales#13, ca_county#21, store_sales#24, ca_county#32, store_sales#35]
 
-(339) Scan parquet
+(338) Scan parquet
 Output [3]: [ws_sold_date_sk#36, ws_bill_addr_sk#37, ws_ext_sales_price#38]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
@@ -1317,13 +1316,13 @@ Input [2]: [ca_county#55, web_sales#58]
 Input [2]: [ca_county#55, web_sales#58]
 Arguments: [ca_county#55 ASC NULLS FIRST], false
 
-(217) SortMergeJoin [codegen id : X]
+(217) NativeSortMergeJoin
 Left keys [1]: [ca_county#43]
 Right keys [1]: [ca_county#55]
 Join type: Inner
 Join condition: (CASE WHEN (web_sales#47 > 0.00) THEN (web_sales#58 / web_sales#47) END > CASE WHEN (store_sales#13 > 0.00) THEN (store_sales#24 / store_sales#13) END)
 
-(218) Project [codegen id : X]
+(218) NativeProject
 Output [8]: [ca_county#8, d_year#5, store_sales#13, store_sales#24, store_sales#35, ca_county#43, web_sales#47, web_sales#58]
 Input [9]: [ca_county#8, d_year#5, store_sales#13, store_sales#24, store_sales#35, ca_county#43, web_sales#47, ca_county#55, web_sales#58]
 
@@ -1488,755 +1487,752 @@ Input [2]: [ca_county#66, web_sales#69]
 Input [2]: [ca_county#66, web_sales#69]
 Arguments: [ca_county#66 ASC NULLS FIRST], false
 
-(259) SortMergeJoin [codegen id : X]
+(259) NativeSortMergeJoin
 Left keys [1]: [ca_county#43]
 Right keys [1]: [ca_county#66]
 Join type: Inner
 Join condition: (CASE WHEN (web_sales#58 > 0.00) THEN (web_sales#69 / web_sales#58) END > CASE WHEN (store_sales#24 > 0.00) THEN (store_sales#35 / store_sales#24) END)
 
-(260) Project [codegen id : X]
+(260) NativeProject
 Output [6]: [ca_county#8, d_year#5, (web_sales#58 / web_sales#47) AS web_q1_q2_increase#70, (store_sales#24 / store_sales#13) AS store_q1_q2_increase#71, (web_sales#69 / web_sales#58) AS web_q2_q3_increase#72, (store_sales#35 / store_sales#24) AS store_q2_q3_increase#73]
 Input [10]: [ca_county#8, d_year#5, store_sales#13, store_sales#24, store_sales#35, ca_county#43, web_sales#47, web_sales#58, ca_county#66, web_sales#69]
 
-(261) ConvertToNative
-Input [6]: [ca_county#8, d_year#5, web_q1_q2_increase#70, store_q1_q2_increase#71, web_q2_q3_increase#72, store_q2_q3_increase#73]
-
-(262) NativeShuffleExchange
+(261) NativeShuffleExchange
 Input [6]: [ca_county#8, d_year#5, web_q1_q2_increase#70, store_q1_q2_increase#71, web_q2_q3_increase#72, store_q2_q3_increase#73]
 Arguments: rangepartitioning(ca_county#8 ASC NULLS FIRST, 100), ENSURE_REQUIREMENTS, [plan_id=25]
 
-(263) ShuffleQueryStage
+(262) ShuffleQueryStage
 Output [6]: [ca_county#8, d_year#5, web_q1_q2_increase#70, store_q1_q2_increase#71, web_q2_q3_increase#72, store_q2_q3_increase#73]
 Arguments: X
 
-(264) AQEShuffleRead
+(263) AQEShuffleRead
 Input [6]: [ca_county#8, d_year#5, web_q1_q2_increase#70, store_q1_q2_increase#71, web_q2_q3_increase#72, store_q2_q3_increase#73]
 Arguments: coalesced
 
-(265) InputAdapter
+(264) InputAdapter
 Input [6]: [ca_county#8, d_year#5, web_q1_q2_increase#70, store_q1_q2_increase#71, web_q2_q3_increase#72, store_q2_q3_increase#73]
 
-(266) NativeSort
+(265) NativeSort
 Input [6]: [ca_county#8, d_year#5, web_q1_q2_increase#70, store_q1_q2_increase#71, web_q2_q3_increase#72, store_q2_q3_increase#73]
 Arguments: [ca_county#8 ASC NULLS FIRST], true
 
-(267) Scan parquet
+(266) Scan parquet
 Output [3]: [ss_sold_date_sk#1, ss_addr_sk#2, ss_ext_sales_price#3]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(ss_sold_date_sk), IsNotNull(ss_addr_sk)]
 ReadSchema: struct<ss_sold_date_sk:int,ss_addr_sk:int,ss_ext_sales_price:decimal(7,2)>
 
-(268) Filter
+(267) Filter
 Input [3]: [ss_sold_date_sk#1, ss_addr_sk#2, ss_ext_sales_price#3]
 Condition : (isnotnull(ss_sold_date_sk#1) AND isnotnull(ss_addr_sk#2))
 
-(269) Exchange
+(268) Exchange
 Input [3]: [ss_sold_date_sk#1, ss_addr_sk#2, ss_ext_sales_price#3]
 Arguments: hashpartitioning(ss_sold_date_sk#1, 100), ENSURE_REQUIREMENTS, [plan_id=26]
 
-(270) Sort
+(269) Sort
 Input [3]: [ss_sold_date_sk#1, ss_addr_sk#2, ss_ext_sales_price#3]
 Arguments: [ss_sold_date_sk#1 ASC NULLS FIRST], false, 0
 
-(271) Scan parquet
+(270) Scan parquet
 Output [3]: [d_date_sk#4, d_year#5, d_qoy#6]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(d_qoy), IsNotNull(d_year), EqualTo(d_qoy,1), EqualTo(d_year,2000), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_qoy:int>
 
-(272) Filter
+(271) Filter
 Input [3]: [d_date_sk#4, d_year#5, d_qoy#6]
 Condition : ((((isnotnull(d_qoy#6) AND isnotnull(d_year#5)) AND (d_qoy#6 = 1)) AND (d_year#5 = 2000)) AND isnotnull(d_date_sk#4))
 
-(273) Exchange
+(272) Exchange
 Input [3]: [d_date_sk#4, d_year#5, d_qoy#6]
 Arguments: hashpartitioning(d_date_sk#4, 100), ENSURE_REQUIREMENTS, [plan_id=27]
 
-(274) Sort
+(273) Sort
 Input [3]: [d_date_sk#4, d_year#5, d_qoy#6]
 Arguments: [d_date_sk#4 ASC NULLS FIRST], false, 0
 
-(275) SortMergeJoin
+(274) SortMergeJoin
 Left keys [1]: [ss_sold_date_sk#1]
 Right keys [1]: [d_date_sk#4]
 Join type: Inner
 Join condition: None
 
-(276) Project
+(275) Project
 Output [4]: [ss_addr_sk#2, ss_ext_sales_price#3, d_year#5, d_qoy#6]
 Input [6]: [ss_sold_date_sk#1, ss_addr_sk#2, ss_ext_sales_price#3, d_date_sk#4, d_year#5, d_qoy#6]
 
-(277) Exchange
+(276) Exchange
 Input [4]: [ss_addr_sk#2, ss_ext_sales_price#3, d_year#5, d_qoy#6]
 Arguments: hashpartitioning(ss_addr_sk#2, 100), ENSURE_REQUIREMENTS, [plan_id=28]
 
-(278) Sort
+(277) Sort
 Input [4]: [ss_addr_sk#2, ss_ext_sales_price#3, d_year#5, d_qoy#6]
 Arguments: [ss_addr_sk#2 ASC NULLS FIRST], false, 0
 
-(279) Scan parquet
+(278) Scan parquet
 Output [2]: [ca_address_sk#7, ca_county#8]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(ca_address_sk), IsNotNull(ca_county)]
 ReadSchema: struct<ca_address_sk:int,ca_county:string>
 
-(280) Filter
+(279) Filter
 Input [2]: [ca_address_sk#7, ca_county#8]
 Condition : (isnotnull(ca_address_sk#7) AND isnotnull(ca_county#8))
 
-(281) Exchange
+(280) Exchange
 Input [2]: [ca_address_sk#7, ca_county#8]
 Arguments: hashpartitioning(ca_address_sk#7, 100), ENSURE_REQUIREMENTS, [plan_id=29]
 
-(282) Sort
+(281) Sort
 Input [2]: [ca_address_sk#7, ca_county#8]
 Arguments: [ca_address_sk#7 ASC NULLS FIRST], false, 0
 
-(283) SortMergeJoin
+(282) SortMergeJoin
 Left keys [1]: [ss_addr_sk#2]
 Right keys [1]: [ca_address_sk#7]
 Join type: Inner
 Join condition: None
 
-(284) Project
+(283) Project
 Output [4]: [ss_ext_sales_price#3, d_year#5, d_qoy#6, ca_county#8]
 Input [6]: [ss_addr_sk#2, ss_ext_sales_price#3, d_year#5, d_qoy#6, ca_address_sk#7, ca_county#8]
 
-(285) HashAggregate
+(284) HashAggregate
 Input [4]: [ss_ext_sales_price#3, d_year#5, d_qoy#6, ca_county#8]
 Keys [3]: [ca_county#8, d_qoy#6, d_year#5]
 Functions [1]: [partial_sum(UnscaledValue(ss_ext_sales_price#3))]
 Aggregate Attributes [1]: [sum#10]
 Results [4]: [ca_county#8, d_qoy#6, d_year#5, sum#74]
 
-(286) Exchange
+(285) Exchange
 Input [4]: [ca_county#8, d_qoy#6, d_year#5, sum#74]
 Arguments: hashpartitioning(ca_county#8, d_qoy#6, d_year#5, 100), ENSURE_REQUIREMENTS, [plan_id=30]
 
-(287) HashAggregate
+(286) HashAggregate
 Input [4]: [ca_county#8, d_qoy#6, d_year#5, sum#74]
 Keys [3]: [ca_county#8, d_qoy#6, d_year#5]
 Functions [1]: [sum(UnscaledValue(ss_ext_sales_price#3))]
 Aggregate Attributes [1]: [sum(UnscaledValue(ss_ext_sales_price#3))#12]
 Results [3]: [ca_county#8, d_year#5, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#3))#12,17,2) AS store_sales#13]
 
-(288) Exchange
+(287) Exchange
 Input [3]: [ca_county#8, d_year#5, store_sales#13]
 Arguments: hashpartitioning(ca_county#8, 100), ENSURE_REQUIREMENTS, [plan_id=31]
 
-(289) Sort
+(288) Sort
 Input [3]: [ca_county#8, d_year#5, store_sales#13]
 Arguments: [ca_county#8 ASC NULLS FIRST], false, 0
 
-(290) Scan parquet
+(289) Scan parquet
 Output [3]: [ss_sold_date_sk#14, ss_addr_sk#15, ss_ext_sales_price#16]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(ss_sold_date_sk), IsNotNull(ss_addr_sk)]
 ReadSchema: struct<ss_sold_date_sk:int,ss_addr_sk:int,ss_ext_sales_price:decimal(7,2)>
 
-(291) Filter
+(290) Filter
 Input [3]: [ss_sold_date_sk#14, ss_addr_sk#15, ss_ext_sales_price#16]
 Condition : (isnotnull(ss_sold_date_sk#14) AND isnotnull(ss_addr_sk#15))
 
-(292) Exchange
+(291) Exchange
 Input [3]: [ss_sold_date_sk#14, ss_addr_sk#15, ss_ext_sales_price#16]
 Arguments: hashpartitioning(ss_sold_date_sk#14, 100), ENSURE_REQUIREMENTS, [plan_id=32]
 
-(293) Sort
+(292) Sort
 Input [3]: [ss_sold_date_sk#14, ss_addr_sk#15, ss_ext_sales_price#16]
 Arguments: [ss_sold_date_sk#14 ASC NULLS FIRST], false, 0
 
-(294) Scan parquet
+(293) Scan parquet
 Output [3]: [d_date_sk#17, d_year#18, d_qoy#19]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(d_qoy), IsNotNull(d_year), EqualTo(d_qoy,2), EqualTo(d_year,2000), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_qoy:int>
 
-(295) Filter
+(294) Filter
 Input [3]: [d_date_sk#17, d_year#18, d_qoy#19]
 Condition : ((((isnotnull(d_qoy#19) AND isnotnull(d_year#18)) AND (d_qoy#19 = 2)) AND (d_year#18 = 2000)) AND isnotnull(d_date_sk#17))
 
-(296) Exchange
+(295) Exchange
 Input [3]: [d_date_sk#17, d_year#18, d_qoy#19]
 Arguments: hashpartitioning(d_date_sk#17, 100), ENSURE_REQUIREMENTS, [plan_id=33]
 
-(297) Sort
+(296) Sort
 Input [3]: [d_date_sk#17, d_year#18, d_qoy#19]
 Arguments: [d_date_sk#17 ASC NULLS FIRST], false, 0
 
-(298) SortMergeJoin
+(297) SortMergeJoin
 Left keys [1]: [ss_sold_date_sk#14]
 Right keys [1]: [d_date_sk#17]
 Join type: Inner
 Join condition: None
 
-(299) Project
+(298) Project
 Output [4]: [ss_addr_sk#15, ss_ext_sales_price#16, d_year#18, d_qoy#19]
 Input [6]: [ss_sold_date_sk#14, ss_addr_sk#15, ss_ext_sales_price#16, d_date_sk#17, d_year#18, d_qoy#19]
 
-(300) Exchange
+(299) Exchange
 Input [4]: [ss_addr_sk#15, ss_ext_sales_price#16, d_year#18, d_qoy#19]
 Arguments: hashpartitioning(ss_addr_sk#15, 100), ENSURE_REQUIREMENTS, [plan_id=34]
 
-(301) Sort
+(300) Sort
 Input [4]: [ss_addr_sk#15, ss_ext_sales_price#16, d_year#18, d_qoy#19]
 Arguments: [ss_addr_sk#15 ASC NULLS FIRST], false, 0
 
-(302) Scan parquet
+(301) Scan parquet
 Output [2]: [ca_address_sk#20, ca_county#21]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(ca_address_sk), IsNotNull(ca_county)]
 ReadSchema: struct<ca_address_sk:int,ca_county:string>
 
-(303) Filter
+(302) Filter
 Input [2]: [ca_address_sk#20, ca_county#21]
 Condition : (isnotnull(ca_address_sk#20) AND isnotnull(ca_county#21))
 
-(304) Exchange
+(303) Exchange
 Input [2]: [ca_address_sk#20, ca_county#21]
 Arguments: hashpartitioning(ca_address_sk#20, 100), ENSURE_REQUIREMENTS, [plan_id=35]
 
-(305) Sort
+(304) Sort
 Input [2]: [ca_address_sk#20, ca_county#21]
 Arguments: [ca_address_sk#20 ASC NULLS FIRST], false, 0
 
-(306) SortMergeJoin
+(305) SortMergeJoin
 Left keys [1]: [ss_addr_sk#15]
 Right keys [1]: [ca_address_sk#20]
 Join type: Inner
 Join condition: None
 
-(307) Project
+(306) Project
 Output [4]: [ss_ext_sales_price#16, d_year#18, d_qoy#19, ca_county#21]
 Input [6]: [ss_addr_sk#15, ss_ext_sales_price#16, d_year#18, d_qoy#19, ca_address_sk#20, ca_county#21]
 
-(308) HashAggregate
+(307) HashAggregate
 Input [4]: [ss_ext_sales_price#16, d_year#18, d_qoy#19, ca_county#21]
 Keys [3]: [ca_county#21, d_qoy#19, d_year#18]
 Functions [1]: [partial_sum(UnscaledValue(ss_ext_sales_price#16))]
 Aggregate Attributes [1]: [sum#23]
 Results [4]: [ca_county#21, d_qoy#19, d_year#18, sum#75]
 
-(309) Exchange
+(308) Exchange
 Input [4]: [ca_county#21, d_qoy#19, d_year#18, sum#75]
 Arguments: hashpartitioning(ca_county#21, d_qoy#19, d_year#18, 100), ENSURE_REQUIREMENTS, [plan_id=36]
 
-(310) HashAggregate
+(309) HashAggregate
 Input [4]: [ca_county#21, d_qoy#19, d_year#18, sum#75]
 Keys [3]: [ca_county#21, d_qoy#19, d_year#18]
 Functions [1]: [sum(UnscaledValue(ss_ext_sales_price#16))]
 Aggregate Attributes [1]: [sum(UnscaledValue(ss_ext_sales_price#16))#12]
 Results [2]: [ca_county#21, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#16))#12,17,2) AS store_sales#24]
 
-(311) Exchange
+(310) Exchange
 Input [2]: [ca_county#21, store_sales#24]
 Arguments: hashpartitioning(ca_county#21, 100), ENSURE_REQUIREMENTS, [plan_id=37]
 
-(312) Sort
+(311) Sort
 Input [2]: [ca_county#21, store_sales#24]
 Arguments: [ca_county#21 ASC NULLS FIRST], false, 0
 
-(313) SortMergeJoin
+(312) SortMergeJoin
 Left keys [1]: [ca_county#8]
 Right keys [1]: [ca_county#21]
 Join type: Inner
 Join condition: None
 
-(314) Scan parquet
+(313) Scan parquet
 Output [3]: [ss_sold_date_sk#25, ss_addr_sk#26, ss_ext_sales_price#27]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(ss_sold_date_sk), IsNotNull(ss_addr_sk)]
 ReadSchema: struct<ss_sold_date_sk:int,ss_addr_sk:int,ss_ext_sales_price:decimal(7,2)>
 
-(315) Filter
+(314) Filter
 Input [3]: [ss_sold_date_sk#25, ss_addr_sk#26, ss_ext_sales_price#27]
 Condition : (isnotnull(ss_sold_date_sk#25) AND isnotnull(ss_addr_sk#26))
 
-(316) Exchange
+(315) Exchange
 Input [3]: [ss_sold_date_sk#25, ss_addr_sk#26, ss_ext_sales_price#27]
 Arguments: hashpartitioning(ss_sold_date_sk#25, 100), ENSURE_REQUIREMENTS, [plan_id=38]
 
-(317) Sort
+(316) Sort
 Input [3]: [ss_sold_date_sk#25, ss_addr_sk#26, ss_ext_sales_price#27]
 Arguments: [ss_sold_date_sk#25 ASC NULLS FIRST], false, 0
 
-(318) Scan parquet
+(317) Scan parquet
 Output [3]: [d_date_sk#28, d_year#29, d_qoy#30]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(d_qoy), IsNotNull(d_year), EqualTo(d_qoy,3), EqualTo(d_year,2000), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_qoy:int>
 
-(319) Filter
+(318) Filter
 Input [3]: [d_date_sk#28, d_year#29, d_qoy#30]
 Condition : ((((isnotnull(d_qoy#30) AND isnotnull(d_year#29)) AND (d_qoy#30 = 3)) AND (d_year#29 = 2000)) AND isnotnull(d_date_sk#28))
 
-(320) Exchange
+(319) Exchange
 Input [3]: [d_date_sk#28, d_year#29, d_qoy#30]
 Arguments: hashpartitioning(d_date_sk#28, 100), ENSURE_REQUIREMENTS, [plan_id=39]
 
-(321) Sort
+(320) Sort
 Input [3]: [d_date_sk#28, d_year#29, d_qoy#30]
 Arguments: [d_date_sk#28 ASC NULLS FIRST], false, 0
 
-(322) SortMergeJoin
+(321) SortMergeJoin
 Left keys [1]: [ss_sold_date_sk#25]
 Right keys [1]: [d_date_sk#28]
 Join type: Inner
 Join condition: None
 
-(323) Project
+(322) Project
 Output [4]: [ss_addr_sk#26, ss_ext_sales_price#27, d_year#29, d_qoy#30]
 Input [6]: [ss_sold_date_sk#25, ss_addr_sk#26, ss_ext_sales_price#27, d_date_sk#28, d_year#29, d_qoy#30]
 
-(324) Exchange
+(323) Exchange
 Input [4]: [ss_addr_sk#26, ss_ext_sales_price#27, d_year#29, d_qoy#30]
 Arguments: hashpartitioning(ss_addr_sk#26, 100), ENSURE_REQUIREMENTS, [plan_id=40]
 
-(325) Sort
+(324) Sort
 Input [4]: [ss_addr_sk#26, ss_ext_sales_price#27, d_year#29, d_qoy#30]
 Arguments: [ss_addr_sk#26 ASC NULLS FIRST], false, 0
 
-(326) Scan parquet
+(325) Scan parquet
 Output [2]: [ca_address_sk#31, ca_county#32]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(ca_address_sk), IsNotNull(ca_county)]
 ReadSchema: struct<ca_address_sk:int,ca_county:string>
 
-(327) Filter
+(326) Filter
 Input [2]: [ca_address_sk#31, ca_county#32]
 Condition : (isnotnull(ca_address_sk#31) AND isnotnull(ca_county#32))
 
-(328) Exchange
+(327) Exchange
 Input [2]: [ca_address_sk#31, ca_county#32]
 Arguments: hashpartitioning(ca_address_sk#31, 100), ENSURE_REQUIREMENTS, [plan_id=41]
 
-(329) Sort
+(328) Sort
 Input [2]: [ca_address_sk#31, ca_county#32]
 Arguments: [ca_address_sk#31 ASC NULLS FIRST], false, 0
 
-(330) SortMergeJoin
+(329) SortMergeJoin
 Left keys [1]: [ss_addr_sk#26]
 Right keys [1]: [ca_address_sk#31]
 Join type: Inner
 Join condition: None
 
-(331) Project
+(330) Project
 Output [4]: [ss_ext_sales_price#27, d_year#29, d_qoy#30, ca_county#32]
 Input [6]: [ss_addr_sk#26, ss_ext_sales_price#27, d_year#29, d_qoy#30, ca_address_sk#31, ca_county#32]
 
-(332) HashAggregate
+(331) HashAggregate
 Input [4]: [ss_ext_sales_price#27, d_year#29, d_qoy#30, ca_county#32]
 Keys [3]: [ca_county#32, d_qoy#30, d_year#29]
 Functions [1]: [partial_sum(UnscaledValue(ss_ext_sales_price#27))]
 Aggregate Attributes [1]: [sum#34]
 Results [4]: [ca_county#32, d_qoy#30, d_year#29, sum#76]
 
-(333) Exchange
+(332) Exchange
 Input [4]: [ca_county#32, d_qoy#30, d_year#29, sum#76]
 Arguments: hashpartitioning(ca_county#32, d_qoy#30, d_year#29, 100), ENSURE_REQUIREMENTS, [plan_id=42]
 
-(334) HashAggregate
+(333) HashAggregate
 Input [4]: [ca_county#32, d_qoy#30, d_year#29, sum#76]
 Keys [3]: [ca_county#32, d_qoy#30, d_year#29]
 Functions [1]: [sum(UnscaledValue(ss_ext_sales_price#27))]
 Aggregate Attributes [1]: [sum(UnscaledValue(ss_ext_sales_price#27))#12]
 Results [2]: [ca_county#32, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#27))#12,17,2) AS store_sales#35]
 
-(335) Exchange
+(334) Exchange
 Input [2]: [ca_county#32, store_sales#35]
 Arguments: hashpartitioning(ca_county#32, 100), ENSURE_REQUIREMENTS, [plan_id=43]
 
-(336) Sort
+(335) Sort
 Input [2]: [ca_county#32, store_sales#35]
 Arguments: [ca_county#32 ASC NULLS FIRST], false, 0
 
-(337) SortMergeJoin
+(336) SortMergeJoin
 Left keys [1]: [ca_county#21]
 Right keys [1]: [ca_county#32]
 Join type: Inner
 Join condition: None
 
-(338) Project
+(337) Project
 Output [5]: [ca_county#8, d_year#5, store_sales#13, store_sales#24, store_sales#35]
 Input [7]: [ca_county#8, d_year#5, store_sales#13, ca_county#21, store_sales#24, ca_county#32, store_sales#35]
 
-(339) Scan parquet
+(338) Scan parquet
 Output [3]: [ws_sold_date_sk#36, ws_bill_addr_sk#37, ws_ext_sales_price#38]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(ws_sold_date_sk), IsNotNull(ws_bill_addr_sk)]
 ReadSchema: struct<ws_sold_date_sk:int,ws_bill_addr_sk:int,ws_ext_sales_price:decimal(7,2)>
 
-(340) Filter
+(339) Filter
 Input [3]: [ws_sold_date_sk#36, ws_bill_addr_sk#37, ws_ext_sales_price#38]
 Condition : (isnotnull(ws_sold_date_sk#36) AND isnotnull(ws_bill_addr_sk#37))
 
-(341) Exchange
+(340) Exchange
 Input [3]: [ws_sold_date_sk#36, ws_bill_addr_sk#37, ws_ext_sales_price#38]
 Arguments: hashpartitioning(ws_sold_date_sk#36, 100), ENSURE_REQUIREMENTS, [plan_id=44]
 
-(342) Sort
+(341) Sort
 Input [3]: [ws_sold_date_sk#36, ws_bill_addr_sk#37, ws_ext_sales_price#38]
 Arguments: [ws_sold_date_sk#36 ASC NULLS FIRST], false, 0
 
-(343) Scan parquet
+(342) Scan parquet
 Output [3]: [d_date_sk#39, d_year#40, d_qoy#41]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(d_qoy), IsNotNull(d_year), EqualTo(d_qoy,1), EqualTo(d_year,2000), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_qoy:int>
 
-(344) Filter
+(343) Filter
 Input [3]: [d_date_sk#39, d_year#40, d_qoy#41]
 Condition : ((((isnotnull(d_qoy#41) AND isnotnull(d_year#40)) AND (d_qoy#41 = 1)) AND (d_year#40 = 2000)) AND isnotnull(d_date_sk#39))
 
-(345) Exchange
+(344) Exchange
 Input [3]: [d_date_sk#39, d_year#40, d_qoy#41]
 Arguments: hashpartitioning(d_date_sk#39, 100), ENSURE_REQUIREMENTS, [plan_id=45]
 
-(346) Sort
+(345) Sort
 Input [3]: [d_date_sk#39, d_year#40, d_qoy#41]
 Arguments: [d_date_sk#39 ASC NULLS FIRST], false, 0
 
-(347) SortMergeJoin
+(346) SortMergeJoin
 Left keys [1]: [ws_sold_date_sk#36]
 Right keys [1]: [d_date_sk#39]
 Join type: Inner
 Join condition: None
 
-(348) Project
+(347) Project
 Output [4]: [ws_bill_addr_sk#37, ws_ext_sales_price#38, d_year#40, d_qoy#41]
 Input [6]: [ws_sold_date_sk#36, ws_bill_addr_sk#37, ws_ext_sales_price#38, d_date_sk#39, d_year#40, d_qoy#41]
 
-(349) Exchange
+(348) Exchange
 Input [4]: [ws_bill_addr_sk#37, ws_ext_sales_price#38, d_year#40, d_qoy#41]
 Arguments: hashpartitioning(ws_bill_addr_sk#37, 100), ENSURE_REQUIREMENTS, [plan_id=46]
 
-(350) Sort
+(349) Sort
 Input [4]: [ws_bill_addr_sk#37, ws_ext_sales_price#38, d_year#40, d_qoy#41]
 Arguments: [ws_bill_addr_sk#37 ASC NULLS FIRST], false, 0
 
-(351) Scan parquet
+(350) Scan parquet
 Output [2]: [ca_address_sk#42, ca_county#43]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(ca_address_sk), IsNotNull(ca_county)]
 ReadSchema: struct<ca_address_sk:int,ca_county:string>
 
-(352) Filter
+(351) Filter
 Input [2]: [ca_address_sk#42, ca_county#43]
 Condition : (isnotnull(ca_address_sk#42) AND isnotnull(ca_county#43))
 
-(353) Exchange
+(352) Exchange
 Input [2]: [ca_address_sk#42, ca_county#43]
 Arguments: hashpartitioning(ca_address_sk#42, 100), ENSURE_REQUIREMENTS, [plan_id=47]
 
-(354) Sort
+(353) Sort
 Input [2]: [ca_address_sk#42, ca_county#43]
 Arguments: [ca_address_sk#42 ASC NULLS FIRST], false, 0
 
-(355) SortMergeJoin
+(354) SortMergeJoin
 Left keys [1]: [ws_bill_addr_sk#37]
 Right keys [1]: [ca_address_sk#42]
 Join type: Inner
 Join condition: None
 
-(356) Project
+(355) Project
 Output [4]: [ws_ext_sales_price#38, d_year#40, d_qoy#41, ca_county#43]
 Input [6]: [ws_bill_addr_sk#37, ws_ext_sales_price#38, d_year#40, d_qoy#41, ca_address_sk#42, ca_county#43]
 
-(357) HashAggregate
+(356) HashAggregate
 Input [4]: [ws_ext_sales_price#38, d_year#40, d_qoy#41, ca_county#43]
 Keys [3]: [ca_county#43, d_qoy#41, d_year#40]
 Functions [1]: [partial_sum(UnscaledValue(ws_ext_sales_price#38))]
 Aggregate Attributes [1]: [sum#45]
 Results [4]: [ca_county#43, d_qoy#41, d_year#40, sum#77]
 
-(358) Exchange
+(357) Exchange
 Input [4]: [ca_county#43, d_qoy#41, d_year#40, sum#77]
 Arguments: hashpartitioning(ca_county#43, d_qoy#41, d_year#40, 100), ENSURE_REQUIREMENTS, [plan_id=48]
 
-(359) HashAggregate
+(358) HashAggregate
 Input [4]: [ca_county#43, d_qoy#41, d_year#40, sum#77]
 Keys [3]: [ca_county#43, d_qoy#41, d_year#40]
 Functions [1]: [sum(UnscaledValue(ws_ext_sales_price#38))]
 Aggregate Attributes [1]: [sum(UnscaledValue(ws_ext_sales_price#38))#46]
 Results [2]: [ca_county#43, MakeDecimal(sum(UnscaledValue(ws_ext_sales_price#38))#46,17,2) AS web_sales#47]
 
-(360) Exchange
+(359) Exchange
 Input [2]: [ca_county#43, web_sales#47]
 Arguments: hashpartitioning(ca_county#43, 100), ENSURE_REQUIREMENTS, [plan_id=49]
 
-(361) Sort
+(360) Sort
 Input [2]: [ca_county#43, web_sales#47]
 Arguments: [ca_county#43 ASC NULLS FIRST], false, 0
 
-(362) SortMergeJoin
+(361) SortMergeJoin
 Left keys [1]: [ca_county#8]
 Right keys [1]: [ca_county#43]
 Join type: Inner
 Join condition: None
 
-(363) Scan parquet
+(362) Scan parquet
 Output [3]: [ws_sold_date_sk#48, ws_bill_addr_sk#49, ws_ext_sales_price#50]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(ws_sold_date_sk), IsNotNull(ws_bill_addr_sk)]
 ReadSchema: struct<ws_sold_date_sk:int,ws_bill_addr_sk:int,ws_ext_sales_price:decimal(7,2)>
 
-(364) Filter
+(363) Filter
 Input [3]: [ws_sold_date_sk#48, ws_bill_addr_sk#49, ws_ext_sales_price#50]
 Condition : (isnotnull(ws_sold_date_sk#48) AND isnotnull(ws_bill_addr_sk#49))
 
-(365) Exchange
+(364) Exchange
 Input [3]: [ws_sold_date_sk#48, ws_bill_addr_sk#49, ws_ext_sales_price#50]
 Arguments: hashpartitioning(ws_sold_date_sk#48, 100), ENSURE_REQUIREMENTS, [plan_id=50]
 
-(366) Sort
+(365) Sort
 Input [3]: [ws_sold_date_sk#48, ws_bill_addr_sk#49, ws_ext_sales_price#50]
 Arguments: [ws_sold_date_sk#48 ASC NULLS FIRST], false, 0
 
-(367) Scan parquet
+(366) Scan parquet
 Output [3]: [d_date_sk#51, d_year#52, d_qoy#53]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(d_qoy), IsNotNull(d_year), EqualTo(d_qoy,2), EqualTo(d_year,2000), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_qoy:int>
 
-(368) Filter
+(367) Filter
 Input [3]: [d_date_sk#51, d_year#52, d_qoy#53]
 Condition : ((((isnotnull(d_qoy#53) AND isnotnull(d_year#52)) AND (d_qoy#53 = 2)) AND (d_year#52 = 2000)) AND isnotnull(d_date_sk#51))
 
-(369) Exchange
+(368) Exchange
 Input [3]: [d_date_sk#51, d_year#52, d_qoy#53]
 Arguments: hashpartitioning(d_date_sk#51, 100), ENSURE_REQUIREMENTS, [plan_id=51]
 
-(370) Sort
+(369) Sort
 Input [3]: [d_date_sk#51, d_year#52, d_qoy#53]
 Arguments: [d_date_sk#51 ASC NULLS FIRST], false, 0
 
-(371) SortMergeJoin
+(370) SortMergeJoin
 Left keys [1]: [ws_sold_date_sk#48]
 Right keys [1]: [d_date_sk#51]
 Join type: Inner
 Join condition: None
 
-(372) Project
+(371) Project
 Output [4]: [ws_bill_addr_sk#49, ws_ext_sales_price#50, d_year#52, d_qoy#53]
 Input [6]: [ws_sold_date_sk#48, ws_bill_addr_sk#49, ws_ext_sales_price#50, d_date_sk#51, d_year#52, d_qoy#53]
 
-(373) Exchange
+(372) Exchange
 Input [4]: [ws_bill_addr_sk#49, ws_ext_sales_price#50, d_year#52, d_qoy#53]
 Arguments: hashpartitioning(ws_bill_addr_sk#49, 100), ENSURE_REQUIREMENTS, [plan_id=52]
 
-(374) Sort
+(373) Sort
 Input [4]: [ws_bill_addr_sk#49, ws_ext_sales_price#50, d_year#52, d_qoy#53]
 Arguments: [ws_bill_addr_sk#49 ASC NULLS FIRST], false, 0
 
-(375) Scan parquet
+(374) Scan parquet
 Output [2]: [ca_address_sk#54, ca_county#55]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(ca_address_sk), IsNotNull(ca_county)]
 ReadSchema: struct<ca_address_sk:int,ca_county:string>
 
-(376) Filter
+(375) Filter
 Input [2]: [ca_address_sk#54, ca_county#55]
 Condition : (isnotnull(ca_address_sk#54) AND isnotnull(ca_county#55))
 
-(377) Exchange
+(376) Exchange
 Input [2]: [ca_address_sk#54, ca_county#55]
 Arguments: hashpartitioning(ca_address_sk#54, 100), ENSURE_REQUIREMENTS, [plan_id=53]
 
-(378) Sort
+(377) Sort
 Input [2]: [ca_address_sk#54, ca_county#55]
 Arguments: [ca_address_sk#54 ASC NULLS FIRST], false, 0
 
-(379) SortMergeJoin
+(378) SortMergeJoin
 Left keys [1]: [ws_bill_addr_sk#49]
 Right keys [1]: [ca_address_sk#54]
 Join type: Inner
 Join condition: None
 
-(380) Project
+(379) Project
 Output [4]: [ws_ext_sales_price#50, d_year#52, d_qoy#53, ca_county#55]
 Input [6]: [ws_bill_addr_sk#49, ws_ext_sales_price#50, d_year#52, d_qoy#53, ca_address_sk#54, ca_county#55]
 
-(381) HashAggregate
+(380) HashAggregate
 Input [4]: [ws_ext_sales_price#50, d_year#52, d_qoy#53, ca_county#55]
 Keys [3]: [ca_county#55, d_qoy#53, d_year#52]
 Functions [1]: [partial_sum(UnscaledValue(ws_ext_sales_price#50))]
 Aggregate Attributes [1]: [sum#57]
 Results [4]: [ca_county#55, d_qoy#53, d_year#52, sum#78]
 
-(382) Exchange
+(381) Exchange
 Input [4]: [ca_county#55, d_qoy#53, d_year#52, sum#78]
 Arguments: hashpartitioning(ca_county#55, d_qoy#53, d_year#52, 100), ENSURE_REQUIREMENTS, [plan_id=54]
 
-(383) HashAggregate
+(382) HashAggregate
 Input [4]: [ca_county#55, d_qoy#53, d_year#52, sum#78]
 Keys [3]: [ca_county#55, d_qoy#53, d_year#52]
 Functions [1]: [sum(UnscaledValue(ws_ext_sales_price#50))]
 Aggregate Attributes [1]: [sum(UnscaledValue(ws_ext_sales_price#50))#46]
 Results [2]: [ca_county#55, MakeDecimal(sum(UnscaledValue(ws_ext_sales_price#50))#46,17,2) AS web_sales#58]
 
-(384) Exchange
+(383) Exchange
 Input [2]: [ca_county#55, web_sales#58]
 Arguments: hashpartitioning(ca_county#55, 100), ENSURE_REQUIREMENTS, [plan_id=55]
 
-(385) Sort
+(384) Sort
 Input [2]: [ca_county#55, web_sales#58]
 Arguments: [ca_county#55 ASC NULLS FIRST], false, 0
 
-(386) SortMergeJoin
+(385) SortMergeJoin
 Left keys [1]: [ca_county#43]
 Right keys [1]: [ca_county#55]
 Join type: Inner
 Join condition: (CASE WHEN (web_sales#47 > 0.00) THEN (web_sales#58 / web_sales#47) END > CASE WHEN (store_sales#13 > 0.00) THEN (store_sales#24 / store_sales#13) END)
 
-(387) Project
+(386) Project
 Output [8]: [ca_county#8, d_year#5, store_sales#13, store_sales#24, store_sales#35, ca_county#43, web_sales#47, web_sales#58]
 Input [9]: [ca_county#8, d_year#5, store_sales#13, store_sales#24, store_sales#35, ca_county#43, web_sales#47, ca_county#55, web_sales#58]
 
-(388) Scan parquet
+(387) Scan parquet
 Output [3]: [ws_sold_date_sk#59, ws_bill_addr_sk#60, ws_ext_sales_price#61]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(ws_sold_date_sk), IsNotNull(ws_bill_addr_sk)]
 ReadSchema: struct<ws_sold_date_sk:int,ws_bill_addr_sk:int,ws_ext_sales_price:decimal(7,2)>
 
-(389) Filter
+(388) Filter
 Input [3]: [ws_sold_date_sk#59, ws_bill_addr_sk#60, ws_ext_sales_price#61]
 Condition : (isnotnull(ws_sold_date_sk#59) AND isnotnull(ws_bill_addr_sk#60))
 
-(390) Exchange
+(389) Exchange
 Input [3]: [ws_sold_date_sk#59, ws_bill_addr_sk#60, ws_ext_sales_price#61]
 Arguments: hashpartitioning(ws_sold_date_sk#59, 100), ENSURE_REQUIREMENTS, [plan_id=56]
 
-(391) Sort
+(390) Sort
 Input [3]: [ws_sold_date_sk#59, ws_bill_addr_sk#60, ws_ext_sales_price#61]
 Arguments: [ws_sold_date_sk#59 ASC NULLS FIRST], false, 0
 
-(392) Scan parquet
+(391) Scan parquet
 Output [3]: [d_date_sk#62, d_year#63, d_qoy#64]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(d_qoy), IsNotNull(d_year), EqualTo(d_qoy,3), EqualTo(d_year,2000), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_qoy:int>
 
-(393) Filter
+(392) Filter
 Input [3]: [d_date_sk#62, d_year#63, d_qoy#64]
 Condition : ((((isnotnull(d_qoy#64) AND isnotnull(d_year#63)) AND (d_qoy#64 = 3)) AND (d_year#63 = 2000)) AND isnotnull(d_date_sk#62))
 
-(394) Exchange
+(393) Exchange
 Input [3]: [d_date_sk#62, d_year#63, d_qoy#64]
 Arguments: hashpartitioning(d_date_sk#62, 100), ENSURE_REQUIREMENTS, [plan_id=57]
 
-(395) Sort
+(394) Sort
 Input [3]: [d_date_sk#62, d_year#63, d_qoy#64]
 Arguments: [d_date_sk#62 ASC NULLS FIRST], false, 0
 
-(396) SortMergeJoin
+(395) SortMergeJoin
 Left keys [1]: [ws_sold_date_sk#59]
 Right keys [1]: [d_date_sk#62]
 Join type: Inner
 Join condition: None
 
-(397) Project
+(396) Project
 Output [4]: [ws_bill_addr_sk#60, ws_ext_sales_price#61, d_year#63, d_qoy#64]
 Input [6]: [ws_sold_date_sk#59, ws_bill_addr_sk#60, ws_ext_sales_price#61, d_date_sk#62, d_year#63, d_qoy#64]
 
-(398) Exchange
+(397) Exchange
 Input [4]: [ws_bill_addr_sk#60, ws_ext_sales_price#61, d_year#63, d_qoy#64]
 Arguments: hashpartitioning(ws_bill_addr_sk#60, 100), ENSURE_REQUIREMENTS, [plan_id=58]
 
-(399) Sort
+(398) Sort
 Input [4]: [ws_bill_addr_sk#60, ws_ext_sales_price#61, d_year#63, d_qoy#64]
 Arguments: [ws_bill_addr_sk#60 ASC NULLS FIRST], false, 0
 
-(400) Scan parquet
+(399) Scan parquet
 Output [2]: [ca_address_sk#65, ca_county#66]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(ca_address_sk), IsNotNull(ca_county)]
 ReadSchema: struct<ca_address_sk:int,ca_county:string>
 
-(401) Filter
+(400) Filter
 Input [2]: [ca_address_sk#65, ca_county#66]
 Condition : (isnotnull(ca_address_sk#65) AND isnotnull(ca_county#66))
 
-(402) Exchange
+(401) Exchange
 Input [2]: [ca_address_sk#65, ca_county#66]
 Arguments: hashpartitioning(ca_address_sk#65, 100), ENSURE_REQUIREMENTS, [plan_id=59]
 
-(403) Sort
+(402) Sort
 Input [2]: [ca_address_sk#65, ca_county#66]
 Arguments: [ca_address_sk#65 ASC NULLS FIRST], false, 0
 
-(404) SortMergeJoin
+(403) SortMergeJoin
 Left keys [1]: [ws_bill_addr_sk#60]
 Right keys [1]: [ca_address_sk#65]
 Join type: Inner
 Join condition: None
 
-(405) Project
+(404) Project
 Output [4]: [ws_ext_sales_price#61, d_year#63, d_qoy#64, ca_county#66]
 Input [6]: [ws_bill_addr_sk#60, ws_ext_sales_price#61, d_year#63, d_qoy#64, ca_address_sk#65, ca_county#66]
 
-(406) HashAggregate
+(405) HashAggregate
 Input [4]: [ws_ext_sales_price#61, d_year#63, d_qoy#64, ca_county#66]
 Keys [3]: [ca_county#66, d_qoy#64, d_year#63]
 Functions [1]: [partial_sum(UnscaledValue(ws_ext_sales_price#61))]
 Aggregate Attributes [1]: [sum#68]
 Results [4]: [ca_county#66, d_qoy#64, d_year#63, sum#79]
 
-(407) Exchange
+(406) Exchange
 Input [4]: [ca_county#66, d_qoy#64, d_year#63, sum#79]
 Arguments: hashpartitioning(ca_county#66, d_qoy#64, d_year#63, 100), ENSURE_REQUIREMENTS, [plan_id=60]
 
-(408) HashAggregate
+(407) HashAggregate
 Input [4]: [ca_county#66, d_qoy#64, d_year#63, sum#79]
 Keys [3]: [ca_county#66, d_qoy#64, d_year#63]
 Functions [1]: [sum(UnscaledValue(ws_ext_sales_price#61))]
 Aggregate Attributes [1]: [sum(UnscaledValue(ws_ext_sales_price#61))#46]
 Results [2]: [ca_county#66, MakeDecimal(sum(UnscaledValue(ws_ext_sales_price#61))#46,17,2) AS web_sales#69]
 
-(409) Exchange
+(408) Exchange
 Input [2]: [ca_county#66, web_sales#69]
 Arguments: hashpartitioning(ca_county#66, 100), ENSURE_REQUIREMENTS, [plan_id=61]
 
-(410) Sort
+(409) Sort
 Input [2]: [ca_county#66, web_sales#69]
 Arguments: [ca_county#66 ASC NULLS FIRST], false, 0
 
-(411) SortMergeJoin
+(410) SortMergeJoin
 Left keys [1]: [ca_county#43]
 Right keys [1]: [ca_county#66]
 Join type: Inner
 Join condition: (CASE WHEN (web_sales#58 > 0.00) THEN (web_sales#69 / web_sales#58) END > CASE WHEN (store_sales#24 > 0.00) THEN (store_sales#35 / store_sales#24) END)
 
-(412) Project
+(411) Project
 Output [6]: [ca_county#8, d_year#5, (web_sales#58 / web_sales#47) AS web_q1_q2_increase#70, (store_sales#24 / store_sales#13) AS store_q1_q2_increase#71, (web_sales#69 / web_sales#58) AS web_q2_q3_increase#72, (store_sales#35 / store_sales#24) AS store_q2_q3_increase#73]
 Input [10]: [ca_county#8, d_year#5, store_sales#13, store_sales#24, store_sales#35, ca_county#43, web_sales#47, web_sales#58, ca_county#66, web_sales#69]
 
-(413) Exchange
+(412) Exchange
 Input [6]: [ca_county#8, d_year#5, web_q1_q2_increase#70, store_q1_q2_increase#71, web_q2_q3_increase#72, store_q2_q3_increase#73]
 Arguments: rangepartitioning(ca_county#8 ASC NULLS FIRST, 100), ENSURE_REQUIREMENTS, [plan_id=62]
 
-(414) Sort
+(413) Sort
 Input [6]: [ca_county#8, d_year#5, web_q1_q2_increase#70, store_q1_q2_increase#71, web_q2_q3_increase#72, store_q2_q3_increase#73]
 Arguments: [ca_county#8 ASC NULLS FIRST], true, 0
 
-(415) AdaptiveSparkPlan
+(414) AdaptiveSparkPlan
 Output [6]: [ca_county#8, d_year#5, web_q1_q2_increase#70, store_q1_q2_increase#71, web_q2_q3_increase#72, store_q2_q3_increase#73]
 Arguments: isFinalPlan=true
 

--- a/dev/auron-it/src/main/resources/tpcds-plan-stability/spark-3.5/q32.txt
+++ b/dev/auron-it/src/main/resources/tpcds-plan-stability/spark-3.5/q32.txt
@@ -1,121 +1,120 @@
 == Physical Plan ==
-AdaptiveSparkPlan (112)
+AdaptiveSparkPlan (111)
 +- == Final Plan ==
-   NativeProject (70)
-   +- NativeHashAggregate (69)
-      +- ShuffleQueryStage (68), Statistics(X)
-         +- NativeShuffleExchange (67)
-            +- NativeHashAggregate (66)
-               +- NativeProject (65)
-                  +- NativeProject (64)
-                     +- NativeSortMergeJoin Inner (63)
-                        :- NativeSort (56)
-                        :  +- InputAdapter (55)
-                        :     +- AQEShuffleRead (54)
-                        :        +- ShuffleQueryStage (53), Statistics(X)
-                        :           +- NativeShuffleExchange (52)
-                        :              +- ConvertToNative (51)
-                        :                 +- * Project (50)
-                        :                    +- * SortMergeJoin Inner (49)
-                        :                       :- NativeProject (19)
-                        :                       :  +- NativeSortMergeJoin Inner (18)
-                        :                       :     :- NativeSort (8)
-                        :                       :     :  +- InputAdapter (7)
-                        :                       :     :     +- AQEShuffleRead (6)
-                        :                       :     :        +- ShuffleQueryStage (5), Statistics(X)
-                        :                       :     :           +- NativeShuffleExchange (4)
-                        :                       :     :              +- NativeFilter (3)
-                        :                       :     :                 +- InputAdapter (2)
-                        :                       :     :                    +- NativeParquetScan  (1)
-                        :                       :     +- NativeSort (17)
-                        :                       :        +- InputAdapter (16)
-                        :                       :           +- AQEShuffleRead (15)
-                        :                       :              +- ShuffleQueryStage (14), Statistics(X)
-                        :                       :                 +- NativeShuffleExchange (13)
-                        :                       :                    +- NativeProject (12)
-                        :                       :                       +- NativeFilter (11)
-                        :                       :                          +- InputAdapter (10)
-                        :                       :                             +- NativeParquetScan  (9)
-                        :                       +- NativeSort (48)
-                        :                          +- NativeFilter (47)
-                        :                             +- NativeProject (46)
-                        :                                +- NativeHashAggregate (45)
-                        :                                   +- InputAdapter (44)
-                        :                                      +- AQEShuffleRead (43)
-                        :                                         +- ShuffleQueryStage (42), Statistics(X)
-                        :                                            +- NativeShuffleExchange (41)
-                        :                                               +- NativeHashAggregate (40)
-                        :                                                  +- NativeProject (39)
-                        :                                                     +- NativeProject (38)
-                        :                                                        +- NativeSortMergeJoin Inner (37)
-                        :                                                           :- NativeSort (27)
-                        :                                                           :  +- InputAdapter (26)
-                        :                                                           :     +- AQEShuffleRead (25)
-                        :                                                           :        +- ShuffleQueryStage (24), Statistics(X)
-                        :                                                           :           +- NativeShuffleExchange (23)
-                        :                                                           :              +- NativeFilter (22)
-                        :                                                           :                 +- InputAdapter (21)
-                        :                                                           :                    +- NativeParquetScan  (20)
-                        :                                                           +- NativeSort (36)
-                        :                                                              +- InputAdapter (35)
-                        :                                                                 +- AQEShuffleRead (34)
-                        :                                                                    +- ShuffleQueryStage (33), Statistics(X)
-                        :                                                                       +- NativeShuffleExchange (32)
-                        :                                                                          +- NativeProject (31)
-                        :                                                                             +- NativeFilter (30)
-                        :                                                                                +- InputAdapter (29)
-                        :                                                                                   +- NativeParquetScan  (28)
-                        +- NativeSort (62)
-                           +- InputAdapter (61)
-                              +- InputAdapter (60)
-                                 +- AQEShuffleRead (59)
-                                    +- ShuffleQueryStage (58), Statistics(X)
-                                       +- ReusedExchange (57)
+   NativeProject (69)
+   +- NativeHashAggregate (68)
+      +- ShuffleQueryStage (67), Statistics(X)
+         +- NativeShuffleExchange (66)
+            +- NativeHashAggregate (65)
+               +- NativeProject (64)
+                  +- NativeProject (63)
+                     +- NativeSortMergeJoin Inner (62)
+                        :- NativeSort (55)
+                        :  +- InputAdapter (54)
+                        :     +- AQEShuffleRead (53)
+                        :        +- ShuffleQueryStage (52), Statistics(X)
+                        :           +- NativeShuffleExchange (51)
+                        :              +- NativeProject (50)
+                        :                 +- NativeSortMergeJoin Inner (49)
+                        :                    :- NativeProject (19)
+                        :                    :  +- NativeSortMergeJoin Inner (18)
+                        :                    :     :- NativeSort (8)
+                        :                    :     :  +- InputAdapter (7)
+                        :                    :     :     +- AQEShuffleRead (6)
+                        :                    :     :        +- ShuffleQueryStage (5), Statistics(X)
+                        :                    :     :           +- NativeShuffleExchange (4)
+                        :                    :     :              +- NativeFilter (3)
+                        :                    :     :                 +- InputAdapter (2)
+                        :                    :     :                    +- NativeParquetScan  (1)
+                        :                    :     +- NativeSort (17)
+                        :                    :        +- InputAdapter (16)
+                        :                    :           +- AQEShuffleRead (15)
+                        :                    :              +- ShuffleQueryStage (14), Statistics(X)
+                        :                    :                 +- NativeShuffleExchange (13)
+                        :                    :                    +- NativeProject (12)
+                        :                    :                       +- NativeFilter (11)
+                        :                    :                          +- InputAdapter (10)
+                        :                    :                             +- NativeParquetScan  (9)
+                        :                    +- NativeSort (48)
+                        :                       +- NativeFilter (47)
+                        :                          +- NativeProject (46)
+                        :                             +- NativeHashAggregate (45)
+                        :                                +- InputAdapter (44)
+                        :                                   +- AQEShuffleRead (43)
+                        :                                      +- ShuffleQueryStage (42), Statistics(X)
+                        :                                         +- NativeShuffleExchange (41)
+                        :                                            +- NativeHashAggregate (40)
+                        :                                               +- NativeProject (39)
+                        :                                                  +- NativeProject (38)
+                        :                                                     +- NativeSortMergeJoin Inner (37)
+                        :                                                        :- NativeSort (27)
+                        :                                                        :  +- InputAdapter (26)
+                        :                                                        :     +- AQEShuffleRead (25)
+                        :                                                        :        +- ShuffleQueryStage (24), Statistics(X)
+                        :                                                        :           +- NativeShuffleExchange (23)
+                        :                                                        :              +- NativeFilter (22)
+                        :                                                        :                 +- InputAdapter (21)
+                        :                                                        :                    +- NativeParquetScan  (20)
+                        :                                                        +- NativeSort (36)
+                        :                                                           +- InputAdapter (35)
+                        :                                                              +- AQEShuffleRead (34)
+                        :                                                                 +- ShuffleQueryStage (33), Statistics(X)
+                        :                                                                    +- NativeShuffleExchange (32)
+                        :                                                                       +- NativeProject (31)
+                        :                                                                          +- NativeFilter (30)
+                        :                                                                             +- InputAdapter (29)
+                        :                                                                                +- NativeParquetScan  (28)
+                        +- NativeSort (61)
+                           +- InputAdapter (60)
+                              +- InputAdapter (59)
+                                 +- AQEShuffleRead (58)
+                                    +- ShuffleQueryStage (57), Statistics(X)
+                                       +- ReusedExchange (56)
 +- == Initial Plan ==
-   HashAggregate (111)
-   +- Exchange (110)
-      +- HashAggregate (109)
-         +- Project (108)
-            +- SortMergeJoin Inner (107)
-               :- Sort (101)
-               :  +- Exchange (100)
-               :     +- Project (99)
-               :        +- SortMergeJoin Inner (98)
-               :           :- Project (81)
-               :           :  +- SortMergeJoin Inner (80)
-               :           :     :- Sort (74)
-               :           :     :  +- Exchange (73)
-               :           :     :     +- Filter (72)
-               :           :     :        +- Scan parquet (71)
-               :           :     +- Sort (79)
-               :           :        +- Exchange (78)
-               :           :           +- Project (77)
-               :           :              +- Filter (76)
-               :           :                 +- Scan parquet (75)
-               :           +- Sort (97)
-               :              +- Filter (96)
-               :                 +- HashAggregate (95)
-               :                    +- Exchange (94)
-               :                       +- HashAggregate (93)
-               :                          +- Project (92)
-               :                             +- SortMergeJoin Inner (91)
-               :                                :- Sort (85)
-               :                                :  +- Exchange (84)
-               :                                :     +- Filter (83)
-               :                                :        +- Scan parquet (82)
-               :                                +- Sort (90)
-               :                                   +- Exchange (89)
-               :                                      +- Project (88)
-               :                                         +- Filter (87)
-               :                                            +- Scan parquet (86)
-               +- Sort (106)
-                  +- Exchange (105)
-                     +- Project (104)
-                        +- Filter (103)
-                           +- Scan parquet (102)
+   HashAggregate (110)
+   +- Exchange (109)
+      +- HashAggregate (108)
+         +- Project (107)
+            +- SortMergeJoin Inner (106)
+               :- Sort (100)
+               :  +- Exchange (99)
+               :     +- Project (98)
+               :        +- SortMergeJoin Inner (97)
+               :           :- Project (80)
+               :           :  +- SortMergeJoin Inner (79)
+               :           :     :- Sort (73)
+               :           :     :  +- Exchange (72)
+               :           :     :     +- Filter (71)
+               :           :     :        +- Scan parquet (70)
+               :           :     +- Sort (78)
+               :           :        +- Exchange (77)
+               :           :           +- Project (76)
+               :           :              +- Filter (75)
+               :           :                 +- Scan parquet (74)
+               :           +- Sort (96)
+               :              +- Filter (95)
+               :                 +- HashAggregate (94)
+               :                    +- Exchange (93)
+               :                       +- HashAggregate (92)
+               :                          +- Project (91)
+               :                             +- SortMergeJoin Inner (90)
+               :                                :- Sort (84)
+               :                                :  +- Exchange (83)
+               :                                :     +- Filter (82)
+               :                                :        +- Scan parquet (81)
+               :                                +- Sort (89)
+               :                                   +- Exchange (88)
+               :                                      +- Project (87)
+               :                                         +- Filter (86)
+               :                                            +- Scan parquet (85)
+               +- Sort (105)
+                  +- Exchange (104)
+                     +- Project (103)
+                        +- Filter (102)
+                           +- Scan parquet (101)
 
 
-(71) Scan parquet
+(70) Scan parquet
 Output [3]: [cs_sold_date_sk#1, cs_item_sk#2, cs_ext_discount_amt#3]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
@@ -149,7 +148,7 @@ Input [3]: [#1#1, #2#2, #3#3]
 Input [3]: [#1#1, #2#2, #3#3]
 Arguments: [cs_item_sk#2 ASC NULLS FIRST], false
 
-(75) Scan parquet
+(74) Scan parquet
 Output [2]: [i_item_sk#4, i_manufact_id#5]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
@@ -197,7 +196,7 @@ Join condition: None
 Output [3]: [cs_sold_date_sk#1, cs_ext_discount_amt#3, i_item_sk#4]
 Input [4]: [#1#1, #2#2, #3#3, i_item_sk#4]
 
-(82) Scan parquet
+(81) Scan parquet
 Output [3]: [cs_sold_date_sk#6, cs_item_sk#7, cs_ext_discount_amt#8]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
@@ -231,7 +230,7 @@ Input [3]: [#6#6, #7#7, #8#8]
 Input [3]: [#6#6, #7#7, #8#8]
 Arguments: [cs_sold_date_sk#6 ASC NULLS FIRST], false
 
-(86) Scan parquet
+(85) Scan parquet
 Output [2]: [d_date_sk#9, d_date#10]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
@@ -324,300 +323,297 @@ Condition : isnotnull((1.3 * avg(cs_ext_discount_amt))#17)
 Input [2]: [(1.3 * avg(cs_ext_discount_amt))#17, cs_item_sk#7]
 Arguments: [cs_item_sk#7 ASC NULLS FIRST], false
 
-(49) SortMergeJoin [codegen id : X]
+(49) NativeSortMergeJoin
 Left keys [1]: [i_item_sk#4]
 Right keys [1]: [cs_item_sk#7]
 Join type: Inner
 Join condition: (cast(cs_ext_discount_amt#3 as decimal(14,7)) > (1.3 * avg(cs_ext_discount_amt))#17)
 
-(50) Project [codegen id : X]
+(50) NativeProject
 Output [2]: [cs_sold_date_sk#1, cs_ext_discount_amt#3]
 Input [5]: [cs_sold_date_sk#1, cs_ext_discount_amt#3, i_item_sk#4, (1.3 * avg(cs_ext_discount_amt))#17, cs_item_sk#7]
 
-(51) ConvertToNative
-Input [2]: [cs_sold_date_sk#1, cs_ext_discount_amt#3]
-
-(52) NativeShuffleExchange
+(51) NativeShuffleExchange
 Input [2]: [cs_sold_date_sk#1, cs_ext_discount_amt#3]
 Arguments: hashpartitioning(cs_sold_date_sk#1, 100), ENSURE_REQUIREMENTS, [plan_id=6]
 
-(53) ShuffleQueryStage
+(52) ShuffleQueryStage
 Output [2]: [cs_sold_date_sk#1, cs_ext_discount_amt#3]
 Arguments: X
 
-(54) AQEShuffleRead
+(53) AQEShuffleRead
 Input [2]: [cs_sold_date_sk#1, cs_ext_discount_amt#3]
 Arguments: coalesced
 
-(55) InputAdapter
+(54) InputAdapter
 Input [2]: [cs_sold_date_sk#1, cs_ext_discount_amt#3]
 
-(56) NativeSort
+(55) NativeSort
 Input [2]: [cs_sold_date_sk#1, cs_ext_discount_amt#3]
 Arguments: [cs_sold_date_sk#1 ASC NULLS FIRST], false
 
-(57) ReusedExchange [Reuses operator id: 32]
+(56) ReusedExchange [Reuses operator id: 32]
 Output [1]: [d_date_sk#18]
 
-(58) ShuffleQueryStage
+(57) ShuffleQueryStage
 Output [1]: [d_date_sk#18]
 Arguments: X
 
-(59) AQEShuffleRead
+(58) AQEShuffleRead
 Input [1]: [d_date_sk#18]
 Arguments: coalesced
 
-(60) InputAdapter
+(59) InputAdapter
 Input [1]: [d_date_sk#18]
 Arguments: [#18]
 
-(61) InputAdapter
+(60) InputAdapter
 Input [1]: [#18#18]
 
-(62) NativeSort
+(61) NativeSort
 Input [1]: [#18#18]
 Arguments: [d_date_sk#18 ASC NULLS FIRST], false
 
-(63) NativeSortMergeJoin
+(62) NativeSortMergeJoin
 Left keys [1]: [cs_sold_date_sk#1]
 Right keys [1]: [d_date_sk#18]
 Join type: Inner
 Join condition: None
 
-(64) NativeProject
+(63) NativeProject
 Output [1]: [cs_ext_discount_amt#3]
 Input [3]: [cs_sold_date_sk#1, cs_ext_discount_amt#3, #18#18]
 
-(65) NativeProject
+(64) NativeProject
 Output [1]: [UnscaledValue(cs_ext_discount_amt#3) AS _c0#19]
 Input [1]: [cs_ext_discount_amt#3]
 
-(66) NativeHashAggregate
+(65) NativeHashAggregate
 Input [1]: [_c0#19]
 Keys: []
 Functions [1]: [partial_sum(_c0#19)]
 Aggregate Attributes [1]: [sum#20]
 Results [1]: [#15]
 
-(67) NativeShuffleExchange
+(66) NativeShuffleExchange
 Input [1]: [#15]
 Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=7]
 
-(68) ShuffleQueryStage
+(67) ShuffleQueryStage
 Output [1]: [#15]
 Arguments: X
 
-(69) NativeHashAggregate
+(68) NativeHashAggregate
 Input [1]: [#15]
 Keys: []
 Functions [1]: [sum(UnscaledValue(cs_ext_discount_amt#3))]
 Aggregate Attributes [1]: [sum(UnscaledValue(cs_ext_discount_amt#3))#21]
 Results [1]: [sum(UnscaledValue(cs_ext_discount_amt#3))#21]
 
-(70) NativeProject
+(69) NativeProject
 Output [1]: [MakeDecimal(sum(UnscaledValue(cs_ext_discount_amt#3))#21,17,2) AS excess discount amount#22]
 Input [1]: [sum(UnscaledValue(cs_ext_discount_amt#3))#21]
 
-(71) Scan parquet
+(70) Scan parquet
 Output [3]: [cs_sold_date_sk#1, cs_item_sk#2, cs_ext_discount_amt#3]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(cs_item_sk), IsNotNull(cs_ext_discount_amt), IsNotNull(cs_sold_date_sk)]
 ReadSchema: struct<cs_sold_date_sk:int,cs_item_sk:int,cs_ext_discount_amt:decimal(7,2)>
 
-(72) Filter
+(71) Filter
 Input [3]: [cs_sold_date_sk#1, cs_item_sk#2, cs_ext_discount_amt#3]
 Condition : ((isnotnull(cs_item_sk#2) AND isnotnull(cs_ext_discount_amt#3)) AND isnotnull(cs_sold_date_sk#1))
 
-(73) Exchange
+(72) Exchange
 Input [3]: [cs_sold_date_sk#1, cs_item_sk#2, cs_ext_discount_amt#3]
 Arguments: hashpartitioning(cs_item_sk#2, 100), ENSURE_REQUIREMENTS, [plan_id=8]
 
-(74) Sort
+(73) Sort
 Input [3]: [cs_sold_date_sk#1, cs_item_sk#2, cs_ext_discount_amt#3]
 Arguments: [cs_item_sk#2 ASC NULLS FIRST], false, 0
 
-(75) Scan parquet
+(74) Scan parquet
 Output [2]: [i_item_sk#4, i_manufact_id#5]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(i_manufact_id), EqualTo(i_manufact_id,269), IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_manufact_id:int>
 
-(76) Filter
+(75) Filter
 Input [2]: [i_item_sk#4, i_manufact_id#5]
 Condition : ((isnotnull(i_manufact_id#5) AND (i_manufact_id#5 = 269)) AND isnotnull(i_item_sk#4))
 
-(77) Project
+(76) Project
 Output [1]: [i_item_sk#4]
 Input [2]: [i_item_sk#4, i_manufact_id#5]
 
-(78) Exchange
+(77) Exchange
 Input [1]: [i_item_sk#4]
 Arguments: hashpartitioning(i_item_sk#4, 100), ENSURE_REQUIREMENTS, [plan_id=9]
 
-(79) Sort
+(78) Sort
 Input [1]: [i_item_sk#4]
 Arguments: [i_item_sk#4 ASC NULLS FIRST], false, 0
 
-(80) SortMergeJoin
+(79) SortMergeJoin
 Left keys [1]: [cs_item_sk#2]
 Right keys [1]: [i_item_sk#4]
 Join type: Inner
 Join condition: None
 
-(81) Project
+(80) Project
 Output [3]: [cs_sold_date_sk#1, cs_ext_discount_amt#3, i_item_sk#4]
 Input [4]: [cs_sold_date_sk#1, cs_item_sk#2, cs_ext_discount_amt#3, i_item_sk#4]
 
-(82) Scan parquet
+(81) Scan parquet
 Output [3]: [cs_sold_date_sk#6, cs_item_sk#7, cs_ext_discount_amt#8]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(cs_sold_date_sk), IsNotNull(cs_item_sk)]
 ReadSchema: struct<cs_sold_date_sk:int,cs_item_sk:int,cs_ext_discount_amt:decimal(7,2)>
 
-(83) Filter
+(82) Filter
 Input [3]: [cs_sold_date_sk#6, cs_item_sk#7, cs_ext_discount_amt#8]
 Condition : (isnotnull(cs_sold_date_sk#6) AND isnotnull(cs_item_sk#7))
 
-(84) Exchange
+(83) Exchange
 Input [3]: [cs_sold_date_sk#6, cs_item_sk#7, cs_ext_discount_amt#8]
 Arguments: hashpartitioning(cs_sold_date_sk#6, 100), ENSURE_REQUIREMENTS, [plan_id=10]
 
-(85) Sort
+(84) Sort
 Input [3]: [cs_sold_date_sk#6, cs_item_sk#7, cs_ext_discount_amt#8]
 Arguments: [cs_sold_date_sk#6 ASC NULLS FIRST], false, 0
 
-(86) Scan parquet
+(85) Scan parquet
 Output [2]: [d_date_sk#9, d_date#10]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(d_date), GreaterThanOrEqual(d_date,1998-03-18), LessThanOrEqual(d_date,1998-06-16), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date>
 
-(87) Filter
+(86) Filter
 Input [2]: [d_date_sk#9, d_date#10]
 Condition : (((isnotnull(d_date#10) AND (d_date#10 >= 1998-03-18)) AND (d_date#10 <= 1998-06-16)) AND isnotnull(d_date_sk#9))
 
-(88) Project
+(87) Project
 Output [1]: [d_date_sk#9]
 Input [2]: [d_date_sk#9, d_date#10]
 
-(89) Exchange
+(88) Exchange
 Input [1]: [d_date_sk#9]
 Arguments: hashpartitioning(d_date_sk#9, 100), ENSURE_REQUIREMENTS, [plan_id=11]
 
-(90) Sort
+(89) Sort
 Input [1]: [d_date_sk#9]
 Arguments: [d_date_sk#9 ASC NULLS FIRST], false, 0
 
-(91) SortMergeJoin
+(90) SortMergeJoin
 Left keys [1]: [cs_sold_date_sk#6]
 Right keys [1]: [d_date_sk#9]
 Join type: Inner
 Join condition: None
 
-(92) Project
+(91) Project
 Output [2]: [cs_item_sk#7, cs_ext_discount_amt#8]
 Input [4]: [cs_sold_date_sk#6, cs_item_sk#7, cs_ext_discount_amt#8, d_date_sk#9]
 
-(93) HashAggregate
+(92) HashAggregate
 Input [2]: [cs_item_sk#7, cs_ext_discount_amt#8]
 Keys [1]: [cs_item_sk#7]
 Functions [1]: [partial_avg(UnscaledValue(cs_ext_discount_amt#8))]
 Aggregate Attributes [2]: [sum#12, count#13]
 Results [3]: [cs_item_sk#7, sum#23, count#24]
 
-(94) Exchange
+(93) Exchange
 Input [3]: [cs_item_sk#7, sum#23, count#24]
 Arguments: hashpartitioning(cs_item_sk#7, 100), ENSURE_REQUIREMENTS, [plan_id=12]
 
-(95) HashAggregate
+(94) HashAggregate
 Input [3]: [cs_item_sk#7, sum#23, count#24]
 Keys [1]: [cs_item_sk#7]
 Functions [1]: [avg(UnscaledValue(cs_ext_discount_amt#8))]
 Aggregate Attributes [1]: [avg(UnscaledValue(cs_ext_discount_amt#8))#16]
 Results [2]: [(1.3 * cast((avg(UnscaledValue(cs_ext_discount_amt#8))#16 / 100.0) as decimal(11,6))) AS (1.3 * avg(cs_ext_discount_amt))#17, cs_item_sk#7]
 
-(96) Filter
+(95) Filter
 Input [2]: [(1.3 * avg(cs_ext_discount_amt))#17, cs_item_sk#7]
 Condition : isnotnull((1.3 * avg(cs_ext_discount_amt))#17)
 
-(97) Sort
+(96) Sort
 Input [2]: [(1.3 * avg(cs_ext_discount_amt))#17, cs_item_sk#7]
 Arguments: [cs_item_sk#7 ASC NULLS FIRST], false, 0
 
-(98) SortMergeJoin
+(97) SortMergeJoin
 Left keys [1]: [i_item_sk#4]
 Right keys [1]: [cs_item_sk#7]
 Join type: Inner
 Join condition: (cast(cs_ext_discount_amt#3 as decimal(14,7)) > (1.3 * avg(cs_ext_discount_amt))#17)
 
-(99) Project
+(98) Project
 Output [2]: [cs_sold_date_sk#1, cs_ext_discount_amt#3]
 Input [5]: [cs_sold_date_sk#1, cs_ext_discount_amt#3, i_item_sk#4, (1.3 * avg(cs_ext_discount_amt))#17, cs_item_sk#7]
 
-(100) Exchange
+(99) Exchange
 Input [2]: [cs_sold_date_sk#1, cs_ext_discount_amt#3]
 Arguments: hashpartitioning(cs_sold_date_sk#1, 100), ENSURE_REQUIREMENTS, [plan_id=13]
 
-(101) Sort
+(100) Sort
 Input [2]: [cs_sold_date_sk#1, cs_ext_discount_amt#3]
 Arguments: [cs_sold_date_sk#1 ASC NULLS FIRST], false, 0
 
-(102) Scan parquet
+(101) Scan parquet
 Output [2]: [d_date_sk#18, d_date#25]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(d_date), GreaterThanOrEqual(d_date,1998-03-18), LessThanOrEqual(d_date,1998-06-16), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date>
 
-(103) Filter
+(102) Filter
 Input [2]: [d_date_sk#18, d_date#25]
 Condition : (((isnotnull(d_date#25) AND (d_date#25 >= 1998-03-18)) AND (d_date#25 <= 1998-06-16)) AND isnotnull(d_date_sk#18))
 
-(104) Project
+(103) Project
 Output [1]: [d_date_sk#18]
 Input [2]: [d_date_sk#18, d_date#25]
 
-(105) Exchange
+(104) Exchange
 Input [1]: [d_date_sk#18]
 Arguments: hashpartitioning(d_date_sk#18, 100), ENSURE_REQUIREMENTS, [plan_id=14]
 
-(106) Sort
+(105) Sort
 Input [1]: [d_date_sk#18]
 Arguments: [d_date_sk#18 ASC NULLS FIRST], false, 0
 
-(107) SortMergeJoin
+(106) SortMergeJoin
 Left keys [1]: [cs_sold_date_sk#1]
 Right keys [1]: [d_date_sk#18]
 Join type: Inner
 Join condition: None
 
-(108) Project
+(107) Project
 Output [1]: [cs_ext_discount_amt#3]
 Input [3]: [cs_sold_date_sk#1, cs_ext_discount_amt#3, d_date_sk#18]
 
-(109) HashAggregate
+(108) HashAggregate
 Input [1]: [cs_ext_discount_amt#3]
 Keys: []
 Functions [1]: [partial_sum(UnscaledValue(cs_ext_discount_amt#3))]
 Aggregate Attributes [1]: [sum#20]
 Results [1]: [sum#26]
 
-(110) Exchange
+(109) Exchange
 Input [1]: [sum#26]
 Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=15]
 
-(111) HashAggregate
+(110) HashAggregate
 Input [1]: [sum#26]
 Keys: []
 Functions [1]: [sum(UnscaledValue(cs_ext_discount_amt#3))]
 Aggregate Attributes [1]: [sum(UnscaledValue(cs_ext_discount_amt#3))#21]
 Results [1]: [MakeDecimal(sum(UnscaledValue(cs_ext_discount_amt#3))#21,17,2) AS excess discount amount#22]
 
-(112) AdaptiveSparkPlan
+(111) AdaptiveSparkPlan
 Output [1]: [excess discount amount#22]
 Arguments: isFinalPlan=true
 

--- a/dev/auron-it/src/main/resources/tpcds-plan-stability/spark-3.5/q4.txt
+++ b/dev/auron-it/src/main/resources/tpcds-plan-stability/spark-3.5/q4.txt
@@ -1,388 +1,387 @@
 == Physical Plan ==
-AdaptiveSparkPlan (379)
+AdaptiveSparkPlan (378)
 +- == Final Plan ==
-   TakeOrderedAndProject (227)
-   +- * Project (226)
-      +- * SortMergeJoin Inner (225)
-         :- NativeProject (197)
-         :  +- NativeSortMergeJoin Inner (196)
-         :     :- ConvertToNative (152)
-         :     :  +- * Project (151)
-         :     :     +- * SortMergeJoin Inner (150)
-         :     :        :- NativeProject (122)
-         :     :        :  +- NativeSortMergeJoin Inner (121)
-         :     :        :     :- NativeSortMergeJoin Inner (77)
-         :     :        :     :  :- NativeSort (47)
-         :     :        :     :  :  +- InputAdapter (46)
-         :     :        :     :  :     +- AQEShuffleRead (45)
-         :     :        :     :  :        +- ShuffleQueryStage (44), Statistics(X)
-         :     :        :     :  :           +- NativeShuffleExchange (43)
-         :     :        :     :  :              +- NativeFilter (42)
-         :     :        :     :  :                 +- NativeProject (41)
-         :     :        :     :  :                    +- NativeHashAggregate (40)
-         :     :        :     :  :                       +- InputAdapter (39)
-         :     :        :     :  :                          +- AQEShuffleRead (38)
-         :     :        :     :  :                             +- ShuffleQueryStage (37), Statistics(X)
-         :     :        :     :  :                                +- NativeShuffleExchange (36)
-         :     :        :     :  :                                   +- NativeHashAggregate (35)
-         :     :        :     :  :                                      +- NativeProject (34)
-         :     :        :     :  :                                         +- NativeProject (33)
-         :     :        :     :  :                                            +- NativeSortMergeJoin Inner (32)
-         :     :        :     :  :                                               :- NativeSort (23)
-         :     :        :     :  :                                               :  +- InputAdapter (22)
-         :     :        :     :  :                                               :     +- AQEShuffleRead (21)
-         :     :        :     :  :                                               :        +- ShuffleQueryStage (20), Statistics(X)
-         :     :        :     :  :                                               :           +- NativeShuffleExchange (19)
-         :     :        :     :  :                                               :              +- NativeProject (18)
-         :     :        :     :  :                                               :                 +- NativeSortMergeJoin Inner (17)
-         :     :        :     :  :                                               :                    :- NativeSort (8)
-         :     :        :     :  :                                               :                    :  +- InputAdapter (7)
-         :     :        :     :  :                                               :                    :     +- AQEShuffleRead (6)
-         :     :        :     :  :                                               :                    :        +- ShuffleQueryStage (5), Statistics(X)
-         :     :        :     :  :                                               :                    :           +- NativeShuffleExchange (4)
-         :     :        :     :  :                                               :                    :              +- NativeFilter (3)
-         :     :        :     :  :                                               :                    :                 +- InputAdapter (2)
-         :     :        :     :  :                                               :                    :                    +- NativeParquetScan  (1)
-         :     :        :     :  :                                               :                    +- NativeSort (16)
-         :     :        :     :  :                                               :                       +- InputAdapter (15)
-         :     :        :     :  :                                               :                          +- AQEShuffleRead (14)
-         :     :        :     :  :                                               :                             +- ShuffleQueryStage (13), Statistics(X)
-         :     :        :     :  :                                               :                                +- NativeShuffleExchange (12)
-         :     :        :     :  :                                               :                                   +- NativeFilter (11)
-         :     :        :     :  :                                               :                                      +- InputAdapter (10)
-         :     :        :     :  :                                               :                                         +- NativeParquetScan  (9)
-         :     :        :     :  :                                               +- NativeSort (31)
-         :     :        :     :  :                                                  +- InputAdapter (30)
-         :     :        :     :  :                                                     +- AQEShuffleRead (29)
-         :     :        :     :  :                                                        +- ShuffleQueryStage (28), Statistics(X)
-         :     :        :     :  :                                                           +- NativeShuffleExchange (27)
-         :     :        :     :  :                                                              +- NativeFilter (26)
-         :     :        :     :  :                                                                 +- InputAdapter (25)
-         :     :        :     :  :                                                                    +- NativeParquetScan  (24)
-         :     :        :     :  +- NativeSort (76)
-         :     :        :     :     +- InputAdapter (75)
-         :     :        :     :        +- AQEShuffleRead (74)
-         :     :        :     :           +- ShuffleQueryStage (73), Statistics(X)
-         :     :        :     :              +- NativeShuffleExchange (72)
-         :     :        :     :                 +- NativeProject (71)
-         :     :        :     :                    +- NativeHashAggregate (70)
-         :     :        :     :                       +- InputAdapter (69)
-         :     :        :     :                          +- AQEShuffleRead (68)
-         :     :        :     :                             +- ShuffleQueryStage (67), Statistics(X)
-         :     :        :     :                                +- NativeShuffleExchange (66)
-         :     :        :     :                                   +- NativeHashAggregate (65)
-         :     :        :     :                                      +- NativeProject (64)
-         :     :        :     :                                         +- NativeProject (63)
-         :     :        :     :                                            +- NativeSortMergeJoin Inner (62)
-         :     :        :     :                                               :- NativeSort (53)
-         :     :        :     :                                               :  +- InputAdapter (52)
-         :     :        :     :                                               :     +- InputAdapter (51)
-         :     :        :     :                                               :        +- AQEShuffleRead (50)
-         :     :        :     :                                               :           +- ShuffleQueryStage (49), Statistics(X)
-         :     :        :     :                                               :              +- ReusedExchange (48)
-         :     :        :     :                                               +- NativeSort (61)
-         :     :        :     :                                                  +- InputAdapter (60)
-         :     :        :     :                                                     +- AQEShuffleRead (59)
-         :     :        :     :                                                        +- ShuffleQueryStage (58), Statistics(X)
-         :     :        :     :                                                           +- NativeShuffleExchange (57)
-         :     :        :     :                                                              +- NativeFilter (56)
-         :     :        :     :                                                                 +- InputAdapter (55)
-         :     :        :     :                                                                    +- NativeParquetScan  (54)
-         :     :        :     +- NativeSort (120)
-         :     :        :        +- InputAdapter (119)
-         :     :        :           +- AQEShuffleRead (118)
-         :     :        :              +- ShuffleQueryStage (117), Statistics(X)
-         :     :        :                 +- NativeShuffleExchange (116)
-         :     :        :                    +- NativeFilter (115)
-         :     :        :                       +- NativeProject (114)
-         :     :        :                          +- NativeHashAggregate (113)
-         :     :        :                             +- InputAdapter (112)
-         :     :        :                                +- AQEShuffleRead (111)
-         :     :        :                                   +- ShuffleQueryStage (110), Statistics(X)
-         :     :        :                                      +- NativeShuffleExchange (109)
-         :     :        :                                         +- NativeHashAggregate (108)
-         :     :        :                                            +- NativeProject (107)
-         :     :        :                                               +- NativeProject (106)
-         :     :        :                                                  +- NativeSortMergeJoin Inner (105)
-         :     :        :                                                     :- NativeSort (98)
-         :     :        :                                                     :  +- InputAdapter (97)
-         :     :        :                                                     :     +- AQEShuffleRead (96)
-         :     :        :                                                     :        +- ShuffleQueryStage (95), Statistics(X)
-         :     :        :                                                     :           +- NativeShuffleExchange (94)
-         :     :        :                                                     :              +- NativeProject (93)
-         :     :        :                                                     :                 +- NativeSortMergeJoin Inner (92)
-         :     :        :                                                     :                    :- NativeSort (83)
-         :     :        :                                                     :                    :  +- InputAdapter (82)
-         :     :        :                                                     :                    :     +- InputAdapter (81)
-         :     :        :                                                     :                    :        +- AQEShuffleRead (80)
-         :     :        :                                                     :                    :           +- ShuffleQueryStage (79), Statistics(X)
-         :     :        :                                                     :                    :              +- ReusedExchange (78)
-         :     :        :                                                     :                    +- NativeSort (91)
-         :     :        :                                                     :                       +- InputAdapter (90)
-         :     :        :                                                     :                          +- AQEShuffleRead (89)
-         :     :        :                                                     :                             +- ShuffleQueryStage (88), Statistics(X)
-         :     :        :                                                     :                                +- NativeShuffleExchange (87)
-         :     :        :                                                     :                                   +- NativeFilter (86)
-         :     :        :                                                     :                                      +- InputAdapter (85)
-         :     :        :                                                     :                                         +- NativeParquetScan  (84)
-         :     :        :                                                     +- NativeSort (104)
-         :     :        :                                                        +- InputAdapter (103)
-         :     :        :                                                           +- InputAdapter (102)
-         :     :        :                                                              +- AQEShuffleRead (101)
-         :     :        :                                                                 +- ShuffleQueryStage (100), Statistics(X)
-         :     :        :                                                                    +- ReusedExchange (99)
-         :     :        +- NativeSort (149)
-         :     :           +- InputAdapter (148)
-         :     :              +- AQEShuffleRead (147)
-         :     :                 +- ShuffleQueryStage (146), Statistics(X)
-         :     :                    +- NativeShuffleExchange (145)
-         :     :                       +- NativeProject (144)
-         :     :                          +- NativeHashAggregate (143)
-         :     :                             +- InputAdapter (142)
-         :     :                                +- AQEShuffleRead (141)
-         :     :                                   +- ShuffleQueryStage (140), Statistics(X)
-         :     :                                      +- NativeShuffleExchange (139)
-         :     :                                         +- NativeHashAggregate (138)
-         :     :                                            +- NativeProject (137)
-         :     :                                               +- NativeProject (136)
-         :     :                                                  +- NativeSortMergeJoin Inner (135)
-         :     :                                                     :- NativeSort (128)
-         :     :                                                     :  +- InputAdapter (127)
-         :     :                                                     :     +- InputAdapter (126)
-         :     :                                                     :        +- AQEShuffleRead (125)
-         :     :                                                     :           +- ShuffleQueryStage (124), Statistics(X)
-         :     :                                                     :              +- ReusedExchange (123)
-         :     :                                                     +- NativeSort (134)
-         :     :                                                        +- InputAdapter (133)
-         :     :                                                           +- InputAdapter (132)
-         :     :                                                              +- AQEShuffleRead (131)
-         :     :                                                                 +- ShuffleQueryStage (130), Statistics(X)
-         :     :                                                                    +- ReusedExchange (129)
-         :     +- NativeSort (195)
-         :        +- InputAdapter (194)
-         :           +- AQEShuffleRead (193)
-         :              +- ShuffleQueryStage (192), Statistics(X)
-         :                 +- NativeShuffleExchange (191)
-         :                    +- NativeFilter (190)
-         :                       +- NativeProject (189)
-         :                          +- NativeHashAggregate (188)
-         :                             +- InputAdapter (187)
-         :                                +- AQEShuffleRead (186)
-         :                                   +- ShuffleQueryStage (185), Statistics(X)
-         :                                      +- NativeShuffleExchange (184)
-         :                                         +- NativeHashAggregate (183)
-         :                                            +- NativeProject (182)
-         :                                               +- NativeProject (181)
-         :                                                  +- NativeSortMergeJoin Inner (180)
-         :                                                     :- NativeSort (173)
-         :                                                     :  +- InputAdapter (172)
-         :                                                     :     +- AQEShuffleRead (171)
-         :                                                     :        +- ShuffleQueryStage (170), Statistics(X)
-         :                                                     :           +- NativeShuffleExchange (169)
-         :                                                     :              +- NativeProject (168)
-         :                                                     :                 +- NativeSortMergeJoin Inner (167)
-         :                                                     :                    :- NativeSort (158)
-         :                                                     :                    :  +- InputAdapter (157)
-         :                                                     :                    :     +- InputAdapter (156)
-         :                                                     :                    :        +- AQEShuffleRead (155)
-         :                                                     :                    :           +- ShuffleQueryStage (154), Statistics(X)
-         :                                                     :                    :              +- ReusedExchange (153)
-         :                                                     :                    +- NativeSort (166)
-         :                                                     :                       +- InputAdapter (165)
-         :                                                     :                          +- AQEShuffleRead (164)
-         :                                                     :                             +- ShuffleQueryStage (163), Statistics(X)
-         :                                                     :                                +- NativeShuffleExchange (162)
-         :                                                     :                                   +- NativeFilter (161)
-         :                                                     :                                      +- InputAdapter (160)
-         :                                                     :                                         +- NativeParquetScan  (159)
-         :                                                     +- NativeSort (179)
-         :                                                        +- InputAdapter (178)
-         :                                                           +- InputAdapter (177)
-         :                                                              +- AQEShuffleRead (176)
-         :                                                                 +- ShuffleQueryStage (175), Statistics(X)
-         :                                                                    +- ReusedExchange (174)
-         +- NativeSort (224)
-            +- InputAdapter (223)
-               +- AQEShuffleRead (222)
-                  +- ShuffleQueryStage (221), Statistics(X)
-                     +- NativeShuffleExchange (220)
-                        +- NativeProject (219)
-                           +- NativeHashAggregate (218)
-                              +- InputAdapter (217)
-                                 +- AQEShuffleRead (216)
-                                    +- ShuffleQueryStage (215), Statistics(X)
-                                       +- NativeShuffleExchange (214)
-                                          +- NativeHashAggregate (213)
-                                             +- NativeProject (212)
-                                                +- NativeProject (211)
-                                                   +- NativeSortMergeJoin Inner (210)
-                                                      :- NativeSort (203)
-                                                      :  +- InputAdapter (202)
-                                                      :     +- InputAdapter (201)
-                                                      :        +- AQEShuffleRead (200)
-                                                      :           +- ShuffleQueryStage (199), Statistics(X)
-                                                      :              +- ReusedExchange (198)
-                                                      +- NativeSort (209)
-                                                         +- InputAdapter (208)
-                                                            +- InputAdapter (207)
-                                                               +- AQEShuffleRead (206)
-                                                                  +- ShuffleQueryStage (205), Statistics(X)
-                                                                     +- ReusedExchange (204)
+   NativeTakeOrdered (226)
+   +- NativeProject (225)
+      +- NativeSortMergeJoin Inner (224)
+         :- NativeProject (196)
+         :  +- NativeSortMergeJoin Inner (195)
+         :     :- NativeProject (151)
+         :     :  +- NativeSortMergeJoin Inner (150)
+         :     :     :- NativeProject (122)
+         :     :     :  +- NativeSortMergeJoin Inner (121)
+         :     :     :     :- NativeSortMergeJoin Inner (77)
+         :     :     :     :  :- NativeSort (47)
+         :     :     :     :  :  +- InputAdapter (46)
+         :     :     :     :  :     +- AQEShuffleRead (45)
+         :     :     :     :  :        +- ShuffleQueryStage (44), Statistics(X)
+         :     :     :     :  :           +- NativeShuffleExchange (43)
+         :     :     :     :  :              +- NativeFilter (42)
+         :     :     :     :  :                 +- NativeProject (41)
+         :     :     :     :  :                    +- NativeHashAggregate (40)
+         :     :     :     :  :                       +- InputAdapter (39)
+         :     :     :     :  :                          +- AQEShuffleRead (38)
+         :     :     :     :  :                             +- ShuffleQueryStage (37), Statistics(X)
+         :     :     :     :  :                                +- NativeShuffleExchange (36)
+         :     :     :     :  :                                   +- NativeHashAggregate (35)
+         :     :     :     :  :                                      +- NativeProject (34)
+         :     :     :     :  :                                         +- NativeProject (33)
+         :     :     :     :  :                                            +- NativeSortMergeJoin Inner (32)
+         :     :     :     :  :                                               :- NativeSort (23)
+         :     :     :     :  :                                               :  +- InputAdapter (22)
+         :     :     :     :  :                                               :     +- AQEShuffleRead (21)
+         :     :     :     :  :                                               :        +- ShuffleQueryStage (20), Statistics(X)
+         :     :     :     :  :                                               :           +- NativeShuffleExchange (19)
+         :     :     :     :  :                                               :              +- NativeProject (18)
+         :     :     :     :  :                                               :                 +- NativeSortMergeJoin Inner (17)
+         :     :     :     :  :                                               :                    :- NativeSort (8)
+         :     :     :     :  :                                               :                    :  +- InputAdapter (7)
+         :     :     :     :  :                                               :                    :     +- AQEShuffleRead (6)
+         :     :     :     :  :                                               :                    :        +- ShuffleQueryStage (5), Statistics(X)
+         :     :     :     :  :                                               :                    :           +- NativeShuffleExchange (4)
+         :     :     :     :  :                                               :                    :              +- NativeFilter (3)
+         :     :     :     :  :                                               :                    :                 +- InputAdapter (2)
+         :     :     :     :  :                                               :                    :                    +- NativeParquetScan  (1)
+         :     :     :     :  :                                               :                    +- NativeSort (16)
+         :     :     :     :  :                                               :                       +- InputAdapter (15)
+         :     :     :     :  :                                               :                          +- AQEShuffleRead (14)
+         :     :     :     :  :                                               :                             +- ShuffleQueryStage (13), Statistics(X)
+         :     :     :     :  :                                               :                                +- NativeShuffleExchange (12)
+         :     :     :     :  :                                               :                                   +- NativeFilter (11)
+         :     :     :     :  :                                               :                                      +- InputAdapter (10)
+         :     :     :     :  :                                               :                                         +- NativeParquetScan  (9)
+         :     :     :     :  :                                               +- NativeSort (31)
+         :     :     :     :  :                                                  +- InputAdapter (30)
+         :     :     :     :  :                                                     +- AQEShuffleRead (29)
+         :     :     :     :  :                                                        +- ShuffleQueryStage (28), Statistics(X)
+         :     :     :     :  :                                                           +- NativeShuffleExchange (27)
+         :     :     :     :  :                                                              +- NativeFilter (26)
+         :     :     :     :  :                                                                 +- InputAdapter (25)
+         :     :     :     :  :                                                                    +- NativeParquetScan  (24)
+         :     :     :     :  +- NativeSort (76)
+         :     :     :     :     +- InputAdapter (75)
+         :     :     :     :        +- AQEShuffleRead (74)
+         :     :     :     :           +- ShuffleQueryStage (73), Statistics(X)
+         :     :     :     :              +- NativeShuffleExchange (72)
+         :     :     :     :                 +- NativeProject (71)
+         :     :     :     :                    +- NativeHashAggregate (70)
+         :     :     :     :                       +- InputAdapter (69)
+         :     :     :     :                          +- AQEShuffleRead (68)
+         :     :     :     :                             +- ShuffleQueryStage (67), Statistics(X)
+         :     :     :     :                                +- NativeShuffleExchange (66)
+         :     :     :     :                                   +- NativeHashAggregate (65)
+         :     :     :     :                                      +- NativeProject (64)
+         :     :     :     :                                         +- NativeProject (63)
+         :     :     :     :                                            +- NativeSortMergeJoin Inner (62)
+         :     :     :     :                                               :- NativeSort (53)
+         :     :     :     :                                               :  +- InputAdapter (52)
+         :     :     :     :                                               :     +- InputAdapter (51)
+         :     :     :     :                                               :        +- AQEShuffleRead (50)
+         :     :     :     :                                               :           +- ShuffleQueryStage (49), Statistics(X)
+         :     :     :     :                                               :              +- ReusedExchange (48)
+         :     :     :     :                                               +- NativeSort (61)
+         :     :     :     :                                                  +- InputAdapter (60)
+         :     :     :     :                                                     +- AQEShuffleRead (59)
+         :     :     :     :                                                        +- ShuffleQueryStage (58), Statistics(X)
+         :     :     :     :                                                           +- NativeShuffleExchange (57)
+         :     :     :     :                                                              +- NativeFilter (56)
+         :     :     :     :                                                                 +- InputAdapter (55)
+         :     :     :     :                                                                    +- NativeParquetScan  (54)
+         :     :     :     +- NativeSort (120)
+         :     :     :        +- InputAdapter (119)
+         :     :     :           +- AQEShuffleRead (118)
+         :     :     :              +- ShuffleQueryStage (117), Statistics(X)
+         :     :     :                 +- NativeShuffleExchange (116)
+         :     :     :                    +- NativeFilter (115)
+         :     :     :                       +- NativeProject (114)
+         :     :     :                          +- NativeHashAggregate (113)
+         :     :     :                             +- InputAdapter (112)
+         :     :     :                                +- AQEShuffleRead (111)
+         :     :     :                                   +- ShuffleQueryStage (110), Statistics(X)
+         :     :     :                                      +- NativeShuffleExchange (109)
+         :     :     :                                         +- NativeHashAggregate (108)
+         :     :     :                                            +- NativeProject (107)
+         :     :     :                                               +- NativeProject (106)
+         :     :     :                                                  +- NativeSortMergeJoin Inner (105)
+         :     :     :                                                     :- NativeSort (98)
+         :     :     :                                                     :  +- InputAdapter (97)
+         :     :     :                                                     :     +- AQEShuffleRead (96)
+         :     :     :                                                     :        +- ShuffleQueryStage (95), Statistics(X)
+         :     :     :                                                     :           +- NativeShuffleExchange (94)
+         :     :     :                                                     :              +- NativeProject (93)
+         :     :     :                                                     :                 +- NativeSortMergeJoin Inner (92)
+         :     :     :                                                     :                    :- NativeSort (83)
+         :     :     :                                                     :                    :  +- InputAdapter (82)
+         :     :     :                                                     :                    :     +- InputAdapter (81)
+         :     :     :                                                     :                    :        +- AQEShuffleRead (80)
+         :     :     :                                                     :                    :           +- ShuffleQueryStage (79), Statistics(X)
+         :     :     :                                                     :                    :              +- ReusedExchange (78)
+         :     :     :                                                     :                    +- NativeSort (91)
+         :     :     :                                                     :                       +- InputAdapter (90)
+         :     :     :                                                     :                          +- AQEShuffleRead (89)
+         :     :     :                                                     :                             +- ShuffleQueryStage (88), Statistics(X)
+         :     :     :                                                     :                                +- NativeShuffleExchange (87)
+         :     :     :                                                     :                                   +- NativeFilter (86)
+         :     :     :                                                     :                                      +- InputAdapter (85)
+         :     :     :                                                     :                                         +- NativeParquetScan  (84)
+         :     :     :                                                     +- NativeSort (104)
+         :     :     :                                                        +- InputAdapter (103)
+         :     :     :                                                           +- InputAdapter (102)
+         :     :     :                                                              +- AQEShuffleRead (101)
+         :     :     :                                                                 +- ShuffleQueryStage (100), Statistics(X)
+         :     :     :                                                                    +- ReusedExchange (99)
+         :     :     +- NativeSort (149)
+         :     :        +- InputAdapter (148)
+         :     :           +- AQEShuffleRead (147)
+         :     :              +- ShuffleQueryStage (146), Statistics(X)
+         :     :                 +- NativeShuffleExchange (145)
+         :     :                    +- NativeProject (144)
+         :     :                       +- NativeHashAggregate (143)
+         :     :                          +- InputAdapter (142)
+         :     :                             +- AQEShuffleRead (141)
+         :     :                                +- ShuffleQueryStage (140), Statistics(X)
+         :     :                                   +- NativeShuffleExchange (139)
+         :     :                                      +- NativeHashAggregate (138)
+         :     :                                         +- NativeProject (137)
+         :     :                                            +- NativeProject (136)
+         :     :                                               +- NativeSortMergeJoin Inner (135)
+         :     :                                                  :- NativeSort (128)
+         :     :                                                  :  +- InputAdapter (127)
+         :     :                                                  :     +- InputAdapter (126)
+         :     :                                                  :        +- AQEShuffleRead (125)
+         :     :                                                  :           +- ShuffleQueryStage (124), Statistics(X)
+         :     :                                                  :              +- ReusedExchange (123)
+         :     :                                                  +- NativeSort (134)
+         :     :                                                     +- InputAdapter (133)
+         :     :                                                        +- InputAdapter (132)
+         :     :                                                           +- AQEShuffleRead (131)
+         :     :                                                              +- ShuffleQueryStage (130), Statistics(X)
+         :     :                                                                 +- ReusedExchange (129)
+         :     +- NativeSort (194)
+         :        +- InputAdapter (193)
+         :           +- AQEShuffleRead (192)
+         :              +- ShuffleQueryStage (191), Statistics(X)
+         :                 +- NativeShuffleExchange (190)
+         :                    +- NativeFilter (189)
+         :                       +- NativeProject (188)
+         :                          +- NativeHashAggregate (187)
+         :                             +- InputAdapter (186)
+         :                                +- AQEShuffleRead (185)
+         :                                   +- ShuffleQueryStage (184), Statistics(X)
+         :                                      +- NativeShuffleExchange (183)
+         :                                         +- NativeHashAggregate (182)
+         :                                            +- NativeProject (181)
+         :                                               +- NativeProject (180)
+         :                                                  +- NativeSortMergeJoin Inner (179)
+         :                                                     :- NativeSort (172)
+         :                                                     :  +- InputAdapter (171)
+         :                                                     :     +- AQEShuffleRead (170)
+         :                                                     :        +- ShuffleQueryStage (169), Statistics(X)
+         :                                                     :           +- NativeShuffleExchange (168)
+         :                                                     :              +- NativeProject (167)
+         :                                                     :                 +- NativeSortMergeJoin Inner (166)
+         :                                                     :                    :- NativeSort (157)
+         :                                                     :                    :  +- InputAdapter (156)
+         :                                                     :                    :     +- InputAdapter (155)
+         :                                                     :                    :        +- AQEShuffleRead (154)
+         :                                                     :                    :           +- ShuffleQueryStage (153), Statistics(X)
+         :                                                     :                    :              +- ReusedExchange (152)
+         :                                                     :                    +- NativeSort (165)
+         :                                                     :                       +- InputAdapter (164)
+         :                                                     :                          +- AQEShuffleRead (163)
+         :                                                     :                             +- ShuffleQueryStage (162), Statistics(X)
+         :                                                     :                                +- NativeShuffleExchange (161)
+         :                                                     :                                   +- NativeFilter (160)
+         :                                                     :                                      +- InputAdapter (159)
+         :                                                     :                                         +- NativeParquetScan  (158)
+         :                                                     +- NativeSort (178)
+         :                                                        +- InputAdapter (177)
+         :                                                           +- InputAdapter (176)
+         :                                                              +- AQEShuffleRead (175)
+         :                                                                 +- ShuffleQueryStage (174), Statistics(X)
+         :                                                                    +- ReusedExchange (173)
+         +- NativeSort (223)
+            +- InputAdapter (222)
+               +- AQEShuffleRead (221)
+                  +- ShuffleQueryStage (220), Statistics(X)
+                     +- NativeShuffleExchange (219)
+                        +- NativeProject (218)
+                           +- NativeHashAggregate (217)
+                              +- InputAdapter (216)
+                                 +- AQEShuffleRead (215)
+                                    +- ShuffleQueryStage (214), Statistics(X)
+                                       +- NativeShuffleExchange (213)
+                                          +- NativeHashAggregate (212)
+                                             +- NativeProject (211)
+                                                +- NativeProject (210)
+                                                   +- NativeSortMergeJoin Inner (209)
+                                                      :- NativeSort (202)
+                                                      :  +- InputAdapter (201)
+                                                      :     +- InputAdapter (200)
+                                                      :        +- AQEShuffleRead (199)
+                                                      :           +- ShuffleQueryStage (198), Statistics(X)
+                                                      :              +- ReusedExchange (197)
+                                                      +- NativeSort (208)
+                                                         +- InputAdapter (207)
+                                                            +- InputAdapter (206)
+                                                               +- AQEShuffleRead (205)
+                                                                  +- ShuffleQueryStage (204), Statistics(X)
+                                                                     +- ReusedExchange (203)
 +- == Initial Plan ==
-   TakeOrderedAndProject (378)
-   +- Project (377)
-      +- SortMergeJoin Inner (376)
-         :- Project (352)
-         :  +- SortMergeJoin Inner (351)
-         :     :- Project (326)
-         :     :  +- SortMergeJoin Inner (325)
-         :     :     :- Project (301)
-         :     :     :  +- SortMergeJoin Inner (300)
-         :     :     :     :- SortMergeJoin Inner (275)
-         :     :     :     :  :- Sort (251)
-         :     :     :     :  :  +- Exchange (250)
-         :     :     :     :  :     +- Filter (249)
-         :     :     :     :  :        +- HashAggregate (248)
-         :     :     :     :  :           +- Exchange (247)
-         :     :     :     :  :              +- HashAggregate (246)
-         :     :     :     :  :                 +- Project (245)
-         :     :     :     :  :                    +- SortMergeJoin Inner (244)
-         :     :     :     :  :                       :- Sort (239)
-         :     :     :     :  :                       :  +- Exchange (238)
-         :     :     :     :  :                       :     +- Project (237)
-         :     :     :     :  :                       :        +- SortMergeJoin Inner (236)
-         :     :     :     :  :                       :           :- Sort (231)
-         :     :     :     :  :                       :           :  +- Exchange (230)
-         :     :     :     :  :                       :           :     +- Filter (229)
-         :     :     :     :  :                       :           :        +- Scan parquet (228)
-         :     :     :     :  :                       :           +- Sort (235)
-         :     :     :     :  :                       :              +- Exchange (234)
-         :     :     :     :  :                       :                 +- Filter (233)
-         :     :     :     :  :                       :                    +- Scan parquet (232)
-         :     :     :     :  :                       +- Sort (243)
-         :     :     :     :  :                          +- Exchange (242)
-         :     :     :     :  :                             +- Filter (241)
-         :     :     :     :  :                                +- Scan parquet (240)
-         :     :     :     :  +- Sort (274)
-         :     :     :     :     +- Exchange (273)
-         :     :     :     :        +- HashAggregate (272)
-         :     :     :     :           +- Exchange (271)
-         :     :     :     :              +- HashAggregate (270)
-         :     :     :     :                 +- Project (269)
-         :     :     :     :                    +- SortMergeJoin Inner (268)
-         :     :     :     :                       :- Sort (263)
-         :     :     :     :                       :  +- Exchange (262)
-         :     :     :     :                       :     +- Project (261)
-         :     :     :     :                       :        +- SortMergeJoin Inner (260)
-         :     :     :     :                       :           :- Sort (255)
-         :     :     :     :                       :           :  +- Exchange (254)
-         :     :     :     :                       :           :     +- Filter (253)
-         :     :     :     :                       :           :        +- Scan parquet (252)
-         :     :     :     :                       :           +- Sort (259)
-         :     :     :     :                       :              +- Exchange (258)
-         :     :     :     :                       :                 +- Filter (257)
-         :     :     :     :                       :                    +- Scan parquet (256)
-         :     :     :     :                       +- Sort (267)
-         :     :     :     :                          +- Exchange (266)
-         :     :     :     :                             +- Filter (265)
-         :     :     :     :                                +- Scan parquet (264)
-         :     :     :     +- Sort (299)
-         :     :     :        +- Exchange (298)
-         :     :     :           +- Filter (297)
-         :     :     :              +- HashAggregate (296)
-         :     :     :                 +- Exchange (295)
-         :     :     :                    +- HashAggregate (294)
-         :     :     :                       +- Project (293)
-         :     :     :                          +- SortMergeJoin Inner (292)
-         :     :     :                             :- Sort (287)
-         :     :     :                             :  +- Exchange (286)
-         :     :     :                             :     +- Project (285)
-         :     :     :                             :        +- SortMergeJoin Inner (284)
-         :     :     :                             :           :- Sort (279)
-         :     :     :                             :           :  +- Exchange (278)
-         :     :     :                             :           :     +- Filter (277)
-         :     :     :                             :           :        +- Scan parquet (276)
-         :     :     :                             :           +- Sort (283)
-         :     :     :                             :              +- Exchange (282)
-         :     :     :                             :                 +- Filter (281)
-         :     :     :                             :                    +- Scan parquet (280)
-         :     :     :                             +- Sort (291)
-         :     :     :                                +- Exchange (290)
-         :     :     :                                   +- Filter (289)
-         :     :     :                                      +- Scan parquet (288)
-         :     :     +- Sort (324)
-         :     :        +- Exchange (323)
-         :     :           +- HashAggregate (322)
-         :     :              +- Exchange (321)
-         :     :                 +- HashAggregate (320)
-         :     :                    +- Project (319)
-         :     :                       +- SortMergeJoin Inner (318)
-         :     :                          :- Sort (313)
-         :     :                          :  +- Exchange (312)
-         :     :                          :     +- Project (311)
-         :     :                          :        +- SortMergeJoin Inner (310)
-         :     :                          :           :- Sort (305)
-         :     :                          :           :  +- Exchange (304)
-         :     :                          :           :     +- Filter (303)
-         :     :                          :           :        +- Scan parquet (302)
-         :     :                          :           +- Sort (309)
-         :     :                          :              +- Exchange (308)
-         :     :                          :                 +- Filter (307)
-         :     :                          :                    +- Scan parquet (306)
-         :     :                          +- Sort (317)
-         :     :                             +- Exchange (316)
-         :     :                                +- Filter (315)
-         :     :                                   +- Scan parquet (314)
-         :     +- Sort (350)
-         :        +- Exchange (349)
-         :           +- Filter (348)
-         :              +- HashAggregate (347)
-         :                 +- Exchange (346)
-         :                    +- HashAggregate (345)
-         :                       +- Project (344)
-         :                          +- SortMergeJoin Inner (343)
-         :                             :- Sort (338)
-         :                             :  +- Exchange (337)
-         :                             :     +- Project (336)
-         :                             :        +- SortMergeJoin Inner (335)
-         :                             :           :- Sort (330)
-         :                             :           :  +- Exchange (329)
-         :                             :           :     +- Filter (328)
-         :                             :           :        +- Scan parquet (327)
-         :                             :           +- Sort (334)
-         :                             :              +- Exchange (333)
-         :                             :                 +- Filter (332)
-         :                             :                    +- Scan parquet (331)
-         :                             +- Sort (342)
-         :                                +- Exchange (341)
-         :                                   +- Filter (340)
-         :                                      +- Scan parquet (339)
-         +- Sort (375)
-            +- Exchange (374)
-               +- HashAggregate (373)
-                  +- Exchange (372)
-                     +- HashAggregate (371)
-                        +- Project (370)
-                           +- SortMergeJoin Inner (369)
-                              :- Sort (364)
-                              :  +- Exchange (363)
-                              :     +- Project (362)
-                              :        +- SortMergeJoin Inner (361)
-                              :           :- Sort (356)
-                              :           :  +- Exchange (355)
-                              :           :     +- Filter (354)
-                              :           :        +- Scan parquet (353)
-                              :           +- Sort (360)
-                              :              +- Exchange (359)
-                              :                 +- Filter (358)
-                              :                    +- Scan parquet (357)
-                              +- Sort (368)
-                                 +- Exchange (367)
-                                    +- Filter (366)
-                                       +- Scan parquet (365)
+   TakeOrderedAndProject (377)
+   +- Project (376)
+      +- SortMergeJoin Inner (375)
+         :- Project (351)
+         :  +- SortMergeJoin Inner (350)
+         :     :- Project (325)
+         :     :  +- SortMergeJoin Inner (324)
+         :     :     :- Project (300)
+         :     :     :  +- SortMergeJoin Inner (299)
+         :     :     :     :- SortMergeJoin Inner (274)
+         :     :     :     :  :- Sort (250)
+         :     :     :     :  :  +- Exchange (249)
+         :     :     :     :  :     +- Filter (248)
+         :     :     :     :  :        +- HashAggregate (247)
+         :     :     :     :  :           +- Exchange (246)
+         :     :     :     :  :              +- HashAggregate (245)
+         :     :     :     :  :                 +- Project (244)
+         :     :     :     :  :                    +- SortMergeJoin Inner (243)
+         :     :     :     :  :                       :- Sort (238)
+         :     :     :     :  :                       :  +- Exchange (237)
+         :     :     :     :  :                       :     +- Project (236)
+         :     :     :     :  :                       :        +- SortMergeJoin Inner (235)
+         :     :     :     :  :                       :           :- Sort (230)
+         :     :     :     :  :                       :           :  +- Exchange (229)
+         :     :     :     :  :                       :           :     +- Filter (228)
+         :     :     :     :  :                       :           :        +- Scan parquet (227)
+         :     :     :     :  :                       :           +- Sort (234)
+         :     :     :     :  :                       :              +- Exchange (233)
+         :     :     :     :  :                       :                 +- Filter (232)
+         :     :     :     :  :                       :                    +- Scan parquet (231)
+         :     :     :     :  :                       +- Sort (242)
+         :     :     :     :  :                          +- Exchange (241)
+         :     :     :     :  :                             +- Filter (240)
+         :     :     :     :  :                                +- Scan parquet (239)
+         :     :     :     :  +- Sort (273)
+         :     :     :     :     +- Exchange (272)
+         :     :     :     :        +- HashAggregate (271)
+         :     :     :     :           +- Exchange (270)
+         :     :     :     :              +- HashAggregate (269)
+         :     :     :     :                 +- Project (268)
+         :     :     :     :                    +- SortMergeJoin Inner (267)
+         :     :     :     :                       :- Sort (262)
+         :     :     :     :                       :  +- Exchange (261)
+         :     :     :     :                       :     +- Project (260)
+         :     :     :     :                       :        +- SortMergeJoin Inner (259)
+         :     :     :     :                       :           :- Sort (254)
+         :     :     :     :                       :           :  +- Exchange (253)
+         :     :     :     :                       :           :     +- Filter (252)
+         :     :     :     :                       :           :        +- Scan parquet (251)
+         :     :     :     :                       :           +- Sort (258)
+         :     :     :     :                       :              +- Exchange (257)
+         :     :     :     :                       :                 +- Filter (256)
+         :     :     :     :                       :                    +- Scan parquet (255)
+         :     :     :     :                       +- Sort (266)
+         :     :     :     :                          +- Exchange (265)
+         :     :     :     :                             +- Filter (264)
+         :     :     :     :                                +- Scan parquet (263)
+         :     :     :     +- Sort (298)
+         :     :     :        +- Exchange (297)
+         :     :     :           +- Filter (296)
+         :     :     :              +- HashAggregate (295)
+         :     :     :                 +- Exchange (294)
+         :     :     :                    +- HashAggregate (293)
+         :     :     :                       +- Project (292)
+         :     :     :                          +- SortMergeJoin Inner (291)
+         :     :     :                             :- Sort (286)
+         :     :     :                             :  +- Exchange (285)
+         :     :     :                             :     +- Project (284)
+         :     :     :                             :        +- SortMergeJoin Inner (283)
+         :     :     :                             :           :- Sort (278)
+         :     :     :                             :           :  +- Exchange (277)
+         :     :     :                             :           :     +- Filter (276)
+         :     :     :                             :           :        +- Scan parquet (275)
+         :     :     :                             :           +- Sort (282)
+         :     :     :                             :              +- Exchange (281)
+         :     :     :                             :                 +- Filter (280)
+         :     :     :                             :                    +- Scan parquet (279)
+         :     :     :                             +- Sort (290)
+         :     :     :                                +- Exchange (289)
+         :     :     :                                   +- Filter (288)
+         :     :     :                                      +- Scan parquet (287)
+         :     :     +- Sort (323)
+         :     :        +- Exchange (322)
+         :     :           +- HashAggregate (321)
+         :     :              +- Exchange (320)
+         :     :                 +- HashAggregate (319)
+         :     :                    +- Project (318)
+         :     :                       +- SortMergeJoin Inner (317)
+         :     :                          :- Sort (312)
+         :     :                          :  +- Exchange (311)
+         :     :                          :     +- Project (310)
+         :     :                          :        +- SortMergeJoin Inner (309)
+         :     :                          :           :- Sort (304)
+         :     :                          :           :  +- Exchange (303)
+         :     :                          :           :     +- Filter (302)
+         :     :                          :           :        +- Scan parquet (301)
+         :     :                          :           +- Sort (308)
+         :     :                          :              +- Exchange (307)
+         :     :                          :                 +- Filter (306)
+         :     :                          :                    +- Scan parquet (305)
+         :     :                          +- Sort (316)
+         :     :                             +- Exchange (315)
+         :     :                                +- Filter (314)
+         :     :                                   +- Scan parquet (313)
+         :     +- Sort (349)
+         :        +- Exchange (348)
+         :           +- Filter (347)
+         :              +- HashAggregate (346)
+         :                 +- Exchange (345)
+         :                    +- HashAggregate (344)
+         :                       +- Project (343)
+         :                          +- SortMergeJoin Inner (342)
+         :                             :- Sort (337)
+         :                             :  +- Exchange (336)
+         :                             :     +- Project (335)
+         :                             :        +- SortMergeJoin Inner (334)
+         :                             :           :- Sort (329)
+         :                             :           :  +- Exchange (328)
+         :                             :           :     +- Filter (327)
+         :                             :           :        +- Scan parquet (326)
+         :                             :           +- Sort (333)
+         :                             :              +- Exchange (332)
+         :                             :                 +- Filter (331)
+         :                             :                    +- Scan parquet (330)
+         :                             +- Sort (341)
+         :                                +- Exchange (340)
+         :                                   +- Filter (339)
+         :                                      +- Scan parquet (338)
+         +- Sort (374)
+            +- Exchange (373)
+               +- HashAggregate (372)
+                  +- Exchange (371)
+                     +- HashAggregate (370)
+                        +- Project (369)
+                           +- SortMergeJoin Inner (368)
+                              :- Sort (363)
+                              :  +- Exchange (362)
+                              :     +- Project (361)
+                              :        +- SortMergeJoin Inner (360)
+                              :           :- Sort (355)
+                              :           :  +- Exchange (354)
+                              :           :     +- Filter (353)
+                              :           :        +- Scan parquet (352)
+                              :           +- Sort (359)
+                              :              +- Exchange (358)
+                              :                 +- Filter (357)
+                              :                    +- Scan parquet (356)
+                              +- Sort (367)
+                                 +- Exchange (366)
+                                    +- Filter (365)
+                                       +- Scan parquet (364)
 
 
-(228) Scan parquet
+(227) Scan parquet
 Output [8]: [c_customer_sk#1, c_customer_id#2, c_first_name#3, c_last_name#4, c_preferred_cust_flag#5, c_birth_country#6, c_login#7, c_email_address#8]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
@@ -416,7 +415,7 @@ Input [8]: [#1#1, #2#2, #3#3, #4#4, #5#5, #6#6, #7#7, #8#8]
 Input [8]: [#1#1, #2#2, #3#3, #4#4, #5#5, #6#6, #7#7, #8#8]
 Arguments: [c_customer_sk#1 ASC NULLS FIRST], false
 
-(232) Scan parquet
+(231) Scan parquet
 Output [6]: [ss_sold_date_sk#9, ss_customer_sk#10, ss_ext_discount_amt#11, ss_ext_sales_price#12, ss_ext_wholesale_cost#13, ss_ext_list_price#14]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
@@ -479,7 +478,7 @@ Input [12]: [c_customer_id#2, c_first_name#3, c_last_name#4, c_preferred_cust_fl
 Input [12]: [c_customer_id#2, c_first_name#3, c_last_name#4, c_preferred_cust_flag#5, c_birth_country#6, c_login#7, c_email_address#8, ss_sold_date_sk#9, ss_ext_discount_amt#11, ss_ext_sales_price#12, ss_ext_wholesale_cost#13, ss_ext_list_price#14]
 Arguments: [ss_sold_date_sk#9 ASC NULLS FIRST], false
 
-(240) Scan parquet
+(239) Scan parquet
 Output [2]: [d_date_sk#15, d_year#16]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
@@ -605,7 +604,7 @@ Input [12]: [#24#24, #25#25, #26#26, #27#27, #28#28, #29#29, #30#30, #31#31, #32
 Input [12]: [#24#24, #25#25, #26#26, #27#27, #28#28, #29#29, #30#30, #31#31, #32#32, #33#33, #34#34, #35#35]
 Arguments: [ss_sold_date_sk#31 ASC NULLS FIRST], false
 
-(264) Scan parquet
+(263) Scan parquet
 Output [2]: [d_date_sk#36, d_year#37]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
@@ -733,7 +732,7 @@ Input [8]: [#49#49, #50#50, #51#51, #52#52, #53#53, #54#54, #55#55, #56#56]
 Input [8]: [#49#49, #50#50, #51#51, #52#52, #53#53, #54#54, #55#55, #56#56]
 Arguments: [c_customer_sk#49 ASC NULLS FIRST], false
 
-(280) Scan parquet
+(279) Scan parquet
 Output [6]: [cs_sold_date_sk#57, cs_bill_customer_sk#58, cs_ext_discount_amt#59, cs_ext_sales_price#60, cs_ext_wholesale_cost#61, cs_ext_list_price#62]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
@@ -1008,1059 +1007,1056 @@ Input [2]: [customer_id#88, year_total#89]
 Input [2]: [customer_id#88, year_total#89]
 Arguments: [customer_id#88 ASC NULLS FIRST], false
 
-(150) SortMergeJoin [codegen id : X]
+(150) NativeSortMergeJoin
 Left keys [1]: [customer_id#22]
 Right keys [1]: [customer_id#88]
 Join type: Inner
 Join condition: (CASE WHEN (year_total#70 > 0.000000) THEN (year_total#89 / year_total#70) END > CASE WHEN (year_total#23 > 0.000000) THEN (year_total#48 / year_total#23) END)
 
-(151) Project [codegen id : X]
+(151) NativeProject
 Output [10]: [customer_id#22, customer_id#41, customer_first_name#42, customer_last_name#43, customer_preferred_cust_flag#44, customer_birth_country#45, customer_login#46, customer_email_address#47, year_total#70, year_total#89]
 Input [13]: [customer_id#22, year_total#23, customer_id#41, customer_first_name#42, customer_last_name#43, customer_preferred_cust_flag#44, customer_birth_country#45, customer_login#46, customer_email_address#47, year_total#48, year_total#70, customer_id#88, year_total#89]
 
-(152) ConvertToNative
-Input [10]: [customer_id#22, customer_id#41, customer_first_name#42, customer_last_name#43, customer_preferred_cust_flag#44, customer_birth_country#45, customer_login#46, customer_email_address#47, year_total#70, year_total#89]
-
-(153) ReusedExchange [Reuses operator id: 4]
+(152) ReusedExchange [Reuses operator id: 4]
 Output [8]: [c_customer_sk#90, c_customer_id#91, c_first_name#92, c_last_name#93, c_preferred_cust_flag#94, c_birth_country#95, c_login#96, c_email_address#97]
 
-(154) ShuffleQueryStage
+(153) ShuffleQueryStage
 Output [8]: [c_customer_sk#90, c_customer_id#91, c_first_name#92, c_last_name#93, c_preferred_cust_flag#94, c_birth_country#95, c_login#96, c_email_address#97]
 Arguments: X
 
-(155) AQEShuffleRead
+(154) AQEShuffleRead
 Input [8]: [c_customer_sk#90, c_customer_id#91, c_first_name#92, c_last_name#93, c_preferred_cust_flag#94, c_birth_country#95, c_login#96, c_email_address#97]
 Arguments: coalesced
 
-(156) InputAdapter
+(155) InputAdapter
 Input [8]: [c_customer_sk#90, c_customer_id#91, c_first_name#92, c_last_name#93, c_preferred_cust_flag#94, c_birth_country#95, c_login#96, c_email_address#97]
 Arguments: [#90, #91, #92, #93, #94, #95, #96, #97]
 
-(157) InputAdapter
+(156) InputAdapter
 Input [8]: [#90#90, #91#91, #92#92, #93#93, #94#94, #95#95, #96#96, #97#97]
 
-(158) NativeSort
+(157) NativeSort
 Input [8]: [#90#90, #91#91, #92#92, #93#93, #94#94, #95#95, #96#96, #97#97]
 Arguments: [c_customer_sk#90 ASC NULLS FIRST], false
 
-(331) Scan parquet
+(330) Scan parquet
 Output [6]: [ws_sold_date_sk#98, ws_bill_customer_sk#99, ws_ext_discount_amt#100, ws_ext_sales_price#101, ws_ext_wholesale_cost#102, ws_ext_list_price#103]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(ws_bill_customer_sk), IsNotNull(ws_sold_date_sk)]
 ReadSchema: struct<ws_sold_date_sk:int,ws_bill_customer_sk:int,ws_ext_discount_amt:decimal(7,2),ws_ext_sales_price:decimal(7,2),ws_ext_wholesale_cost:decimal(7,2),ws_ext_list_price:decimal(7,2)>
 
-(160) InputAdapter
+(159) InputAdapter
 Input [6]: [ws_sold_date_sk#98, ws_bill_customer_sk#99, ws_ext_discount_amt#100, ws_ext_sales_price#101, ws_ext_wholesale_cost#102, ws_ext_list_price#103]
 Arguments: [#98, #99, #100, #101, #102, #103]
 
-(161) NativeFilter
+(160) NativeFilter
 Input [6]: [#98#98, #99#99, #100#100, #101#101, #102#102, #103#103]
 Condition : (isnotnull(ws_bill_customer_sk#99) AND isnotnull(ws_sold_date_sk#98))
 
-(162) NativeShuffleExchange
+(161) NativeShuffleExchange
 Input [6]: [#98#98, #99#99, #100#100, #101#101, #102#102, #103#103]
 Arguments: hashpartitioning(ws_bill_customer_sk#99, 100), ENSURE_REQUIREMENTS, [plan_id=16]
 
-(163) ShuffleQueryStage
+(162) ShuffleQueryStage
 Output [6]: [#98#98, #99#99, #100#100, #101#101, #102#102, #103#103]
 Arguments: X
 
-(164) AQEShuffleRead
+(163) AQEShuffleRead
 Input [6]: [#98#98, #99#99, #100#100, #101#101, #102#102, #103#103]
 Arguments: coalesced
 
-(165) InputAdapter
+(164) InputAdapter
 Input [6]: [#98#98, #99#99, #100#100, #101#101, #102#102, #103#103]
 
-(166) NativeSort
+(165) NativeSort
 Input [6]: [#98#98, #99#99, #100#100, #101#101, #102#102, #103#103]
 Arguments: [ws_bill_customer_sk#99 ASC NULLS FIRST], false
 
-(167) NativeSortMergeJoin
+(166) NativeSortMergeJoin
 Left keys [1]: [c_customer_sk#90]
 Right keys [1]: [ws_bill_customer_sk#99]
 Join type: Inner
 Join condition: None
 
-(168) NativeProject
+(167) NativeProject
 Output [12]: [c_customer_id#91, c_first_name#92, c_last_name#93, c_preferred_cust_flag#94, c_birth_country#95, c_login#96, c_email_address#97, ws_sold_date_sk#98, ws_ext_discount_amt#100, ws_ext_sales_price#101, ws_ext_wholesale_cost#102, ws_ext_list_price#103]
 Input [14]: [#90#90, #91#91, #92#92, #93#93, #94#94, #95#95, #96#96, #97#97, #98#98, #99#99, #100#100, #101#101, #102#102, #103#103]
 
-(169) NativeShuffleExchange
+(168) NativeShuffleExchange
 Input [12]: [c_customer_id#91, c_first_name#92, c_last_name#93, c_preferred_cust_flag#94, c_birth_country#95, c_login#96, c_email_address#97, ws_sold_date_sk#98, ws_ext_discount_amt#100, ws_ext_sales_price#101, ws_ext_wholesale_cost#102, ws_ext_list_price#103]
 Arguments: hashpartitioning(ws_sold_date_sk#98, 100), ENSURE_REQUIREMENTS, [plan_id=17]
 
-(170) ShuffleQueryStage
+(169) ShuffleQueryStage
 Output [12]: [c_customer_id#91, c_first_name#92, c_last_name#93, c_preferred_cust_flag#94, c_birth_country#95, c_login#96, c_email_address#97, ws_sold_date_sk#98, ws_ext_discount_amt#100, ws_ext_sales_price#101, ws_ext_wholesale_cost#102, ws_ext_list_price#103]
 Arguments: X
 
-(171) AQEShuffleRead
+(170) AQEShuffleRead
 Input [12]: [c_customer_id#91, c_first_name#92, c_last_name#93, c_preferred_cust_flag#94, c_birth_country#95, c_login#96, c_email_address#97, ws_sold_date_sk#98, ws_ext_discount_amt#100, ws_ext_sales_price#101, ws_ext_wholesale_cost#102, ws_ext_list_price#103]
 Arguments: coalesced
 
-(172) InputAdapter
+(171) InputAdapter
 Input [12]: [c_customer_id#91, c_first_name#92, c_last_name#93, c_preferred_cust_flag#94, c_birth_country#95, c_login#96, c_email_address#97, ws_sold_date_sk#98, ws_ext_discount_amt#100, ws_ext_sales_price#101, ws_ext_wholesale_cost#102, ws_ext_list_price#103]
 
-(173) NativeSort
+(172) NativeSort
 Input [12]: [c_customer_id#91, c_first_name#92, c_last_name#93, c_preferred_cust_flag#94, c_birth_country#95, c_login#96, c_email_address#97, ws_sold_date_sk#98, ws_ext_discount_amt#100, ws_ext_sales_price#101, ws_ext_wholesale_cost#102, ws_ext_list_price#103]
 Arguments: [ws_sold_date_sk#98 ASC NULLS FIRST], false
 
-(174) ReusedExchange [Reuses operator id: 27]
+(173) ReusedExchange [Reuses operator id: 27]
 Output [2]: [d_date_sk#104, d_year#105]
 
-(175) ShuffleQueryStage
+(174) ShuffleQueryStage
 Output [2]: [d_date_sk#104, d_year#105]
 Arguments: X
 
-(176) AQEShuffleRead
+(175) AQEShuffleRead
 Input [2]: [d_date_sk#104, d_year#105]
 Arguments: coalesced
 
-(177) InputAdapter
+(176) InputAdapter
 Input [2]: [d_date_sk#104, d_year#105]
 Arguments: [#104, #105]
 
-(178) InputAdapter
+(177) InputAdapter
 Input [2]: [#104#104, #105#105]
 
-(179) NativeSort
+(178) NativeSort
 Input [2]: [#104#104, #105#105]
 Arguments: [d_date_sk#104 ASC NULLS FIRST], false
 
-(180) NativeSortMergeJoin
+(179) NativeSortMergeJoin
 Left keys [1]: [ws_sold_date_sk#98]
 Right keys [1]: [d_date_sk#104]
 Join type: Inner
 Join condition: None
 
-(181) NativeProject
+(180) NativeProject
 Output [12]: [c_customer_id#91, c_first_name#92, c_last_name#93, c_preferred_cust_flag#94, c_birth_country#95, c_login#96, c_email_address#97, ws_ext_discount_amt#100, ws_ext_sales_price#101, ws_ext_wholesale_cost#102, ws_ext_list_price#103, d_year#105]
 Input [14]: [c_customer_id#91, c_first_name#92, c_last_name#93, c_preferred_cust_flag#94, c_birth_country#95, c_login#96, c_email_address#97, ws_sold_date_sk#98, ws_ext_discount_amt#100, ws_ext_sales_price#101, ws_ext_wholesale_cost#102, ws_ext_list_price#103, #104#104, #105#105]
 
-(182) NativeProject
+(181) NativeProject
 Output [9]: [c_customer_id#91 AS c_customer_id#91, c_first_name#92 AS c_first_name#92, c_last_name#93 AS c_last_name#93, c_preferred_cust_flag#94 AS c_preferred_cust_flag#94, c_birth_country#95 AS c_birth_country#95, c_login#96 AS c_login#96, c_email_address#97 AS c_email_address#97, d_year#105 AS d_year#105, ((((ws_ext_list_price#103 - ws_ext_wholesale_cost#102) - ws_ext_discount_amt#100) + ws_ext_sales_price#101) / 2) AS _c8#106]
 Input [12]: [c_customer_id#91, c_first_name#92, c_last_name#93, c_preferred_cust_flag#94, c_birth_country#95, c_login#96, c_email_address#97, ws_ext_discount_amt#100, ws_ext_sales_price#101, ws_ext_wholesale_cost#102, ws_ext_list_price#103, d_year#105]
 
-(183) NativeHashAggregate
+(182) NativeHashAggregate
 Input [9]: [c_customer_id#91, c_first_name#92, c_last_name#93, c_preferred_cust_flag#94, c_birth_country#95, c_login#96, c_email_address#97, d_year#105, _c8#106]
 Keys [8]: [c_customer_id#91, c_first_name#92, c_last_name#93, c_preferred_cust_flag#94, c_birth_country#95, c_login#96, c_email_address#97, d_year#105]
 Functions [1]: [partial_sum(_c8#106)]
 Aggregate Attributes [2]: [sum#107, isEmpty#108]
 Results [9]: [c_customer_id#91, c_first_name#92, c_last_name#93, c_preferred_cust_flag#94, c_birth_country#95, c_login#96, c_email_address#97, d_year#105, #20]
 
-(184) NativeShuffleExchange
+(183) NativeShuffleExchange
 Input [9]: [c_customer_id#91, c_first_name#92, c_last_name#93, c_preferred_cust_flag#94, c_birth_country#95, c_login#96, c_email_address#97, d_year#105, #20]
 Arguments: hashpartitioning(c_customer_id#91, c_first_name#92, c_last_name#93, c_preferred_cust_flag#94, c_birth_country#95, c_login#96, c_email_address#97, d_year#105, 100), ENSURE_REQUIREMENTS, [plan_id=18]
 
-(185) ShuffleQueryStage
+(184) ShuffleQueryStage
 Output [9]: [c_customer_id#91, c_first_name#92, c_last_name#93, c_preferred_cust_flag#94, c_birth_country#95, c_login#96, c_email_address#97, d_year#105, #20]
 Arguments: X
 
-(186) AQEShuffleRead
+(185) AQEShuffleRead
 Input [9]: [c_customer_id#91, c_first_name#92, c_last_name#93, c_preferred_cust_flag#94, c_birth_country#95, c_login#96, c_email_address#97, d_year#105, #20]
 Arguments: coalesced
 
-(187) InputAdapter
+(186) InputAdapter
 Input [9]: [c_customer_id#91, c_first_name#92, c_last_name#93, c_preferred_cust_flag#94, c_birth_country#95, c_login#96, c_email_address#97, d_year#105, #20]
 
-(188) NativeHashAggregate
+(187) NativeHashAggregate
 Input [9]: [c_customer_id#91, c_first_name#92, c_last_name#93, c_preferred_cust_flag#94, c_birth_country#95, c_login#96, c_email_address#97, d_year#105, #20]
 Keys [8]: [c_customer_id#91, c_first_name#92, c_last_name#93, c_preferred_cust_flag#94, c_birth_country#95, c_login#96, c_email_address#97, d_year#105]
 Functions [1]: [sum(((((ws_ext_list_price#103 - ws_ext_wholesale_cost#102) - ws_ext_discount_amt#100) + ws_ext_sales_price#101) / 2))]
 Aggregate Attributes [1]: [sum(((((ws_ext_list_price#103 - ws_ext_wholesale_cost#102) - ws_ext_discount_amt#100) + ws_ext_sales_price#101) / 2))#109]
 Results [9]: [c_customer_id#91, c_first_name#92, c_last_name#93, c_preferred_cust_flag#94, c_birth_country#95, c_login#96, c_email_address#97, d_year#105, sum(((((ws_ext_list_price#103 - ws_ext_wholesale_cost#102) - ws_ext_discount_amt#100) + ws_ext_sales_price#101) / 2))#109]
 
-(189) NativeProject
+(188) NativeProject
 Output [2]: [c_customer_id#91 AS customer_id#110, sum(((((ws_ext_list_price#103 - ws_ext_wholesale_cost#102) - ws_ext_discount_amt#100) + ws_ext_sales_price#101) / 2))#109 AS year_total#111]
 Input [9]: [c_customer_id#91, c_first_name#92, c_last_name#93, c_preferred_cust_flag#94, c_birth_country#95, c_login#96, c_email_address#97, d_year#105, sum(((((ws_ext_list_price#103 - ws_ext_wholesale_cost#102) - ws_ext_discount_amt#100) + ws_ext_sales_price#101) / 2))#109]
 
-(190) NativeFilter
+(189) NativeFilter
 Input [2]: [customer_id#110, year_total#111]
 Condition : (isnotnull(year_total#111) AND (year_total#111 > 0.000000))
 
-(191) NativeShuffleExchange
+(190) NativeShuffleExchange
 Input [2]: [customer_id#110, year_total#111]
 Arguments: hashpartitioning(customer_id#110, 100), ENSURE_REQUIREMENTS, [plan_id=19]
 
-(192) ShuffleQueryStage
+(191) ShuffleQueryStage
 Output [2]: [customer_id#110, year_total#111]
 Arguments: X
 
-(193) AQEShuffleRead
+(192) AQEShuffleRead
 Input [2]: [customer_id#110, year_total#111]
 Arguments: coalesced
 
-(194) InputAdapter
+(193) InputAdapter
 Input [2]: [customer_id#110, year_total#111]
 
-(195) NativeSort
+(194) NativeSort
 Input [2]: [customer_id#110, year_total#111]
 Arguments: [customer_id#110 ASC NULLS FIRST], false
 
-(196) NativeSortMergeJoin
+(195) NativeSortMergeJoin
 Left keys [1]: [customer_id#22]
 Right keys [1]: [customer_id#110]
 Join type: Inner
 Join condition: None
 
-(197) NativeProject
+(196) NativeProject
 Output [11]: [customer_id#22, customer_id#41, customer_first_name#42, customer_last_name#43, customer_preferred_cust_flag#44, customer_birth_country#45, customer_login#46, customer_email_address#47, year_total#70, year_total#89, year_total#111]
 Input [12]: [customer_id#22, customer_id#41, customer_first_name#42, customer_last_name#43, customer_preferred_cust_flag#44, customer_birth_country#45, customer_login#46, customer_email_address#47, year_total#70, year_total#89, customer_id#110, year_total#111]
 
-(198) ReusedExchange [Reuses operator id: 169]
+(197) ReusedExchange [Reuses operator id: 168]
 Output [12]: [c_customer_id#112, c_first_name#113, c_last_name#114, c_preferred_cust_flag#115, c_birth_country#116, c_login#117, c_email_address#118, ws_sold_date_sk#119, ws_ext_discount_amt#120, ws_ext_sales_price#121, ws_ext_wholesale_cost#122, ws_ext_list_price#123]
 
-(199) ShuffleQueryStage
+(198) ShuffleQueryStage
 Output [12]: [c_customer_id#112, c_first_name#113, c_last_name#114, c_preferred_cust_flag#115, c_birth_country#116, c_login#117, c_email_address#118, ws_sold_date_sk#119, ws_ext_discount_amt#120, ws_ext_sales_price#121, ws_ext_wholesale_cost#122, ws_ext_list_price#123]
 Arguments: X
 
-(200) AQEShuffleRead
+(199) AQEShuffleRead
 Input [12]: [c_customer_id#112, c_first_name#113, c_last_name#114, c_preferred_cust_flag#115, c_birth_country#116, c_login#117, c_email_address#118, ws_sold_date_sk#119, ws_ext_discount_amt#120, ws_ext_sales_price#121, ws_ext_wholesale_cost#122, ws_ext_list_price#123]
 Arguments: coalesced
 
-(201) InputAdapter
+(200) InputAdapter
 Input [12]: [c_customer_id#112, c_first_name#113, c_last_name#114, c_preferred_cust_flag#115, c_birth_country#116, c_login#117, c_email_address#118, ws_sold_date_sk#119, ws_ext_discount_amt#120, ws_ext_sales_price#121, ws_ext_wholesale_cost#122, ws_ext_list_price#123]
 Arguments: [#112, #113, #114, #115, #116, #117, #118, #119, #120, #121, #122, #123]
 
-(202) InputAdapter
+(201) InputAdapter
 Input [12]: [#112#112, #113#113, #114#114, #115#115, #116#116, #117#117, #118#118, #119#119, #120#120, #121#121, #122#122, #123#123]
 
-(203) NativeSort
+(202) NativeSort
 Input [12]: [#112#112, #113#113, #114#114, #115#115, #116#116, #117#117, #118#118, #119#119, #120#120, #121#121, #122#122, #123#123]
 Arguments: [ws_sold_date_sk#119 ASC NULLS FIRST], false
 
-(204) ReusedExchange [Reuses operator id: 57]
+(203) ReusedExchange [Reuses operator id: 57]
 Output [2]: [d_date_sk#124, d_year#125]
 
-(205) ShuffleQueryStage
+(204) ShuffleQueryStage
 Output [2]: [d_date_sk#124, d_year#125]
 Arguments: X
 
-(206) AQEShuffleRead
+(205) AQEShuffleRead
 Input [2]: [d_date_sk#124, d_year#125]
 Arguments: coalesced
 
-(207) InputAdapter
+(206) InputAdapter
 Input [2]: [d_date_sk#124, d_year#125]
 Arguments: [#124, #125]
 
-(208) InputAdapter
+(207) InputAdapter
 Input [2]: [#124#124, #125#125]
 
-(209) NativeSort
+(208) NativeSort
 Input [2]: [#124#124, #125#125]
 Arguments: [d_date_sk#124 ASC NULLS FIRST], false
 
-(210) NativeSortMergeJoin
+(209) NativeSortMergeJoin
 Left keys [1]: [ws_sold_date_sk#119]
 Right keys [1]: [d_date_sk#124]
 Join type: Inner
 Join condition: None
 
-(211) NativeProject
+(210) NativeProject
 Output [12]: [c_customer_id#112, c_first_name#113, c_last_name#114, c_preferred_cust_flag#115, c_birth_country#116, c_login#117, c_email_address#118, ws_ext_discount_amt#120, ws_ext_sales_price#121, ws_ext_wholesale_cost#122, ws_ext_list_price#123, d_year#125]
 Input [14]: [#112#112, #113#113, #114#114, #115#115, #116#116, #117#117, #118#118, #119#119, #120#120, #121#121, #122#122, #123#123, #124#124, #125#125]
 
-(212) NativeProject
+(211) NativeProject
 Output [9]: [c_customer_id#112 AS c_customer_id#112, c_first_name#113 AS c_first_name#113, c_last_name#114 AS c_last_name#114, c_preferred_cust_flag#115 AS c_preferred_cust_flag#115, c_birth_country#116 AS c_birth_country#116, c_login#117 AS c_login#117, c_email_address#118 AS c_email_address#118, d_year#125 AS d_year#125, ((((ws_ext_list_price#123 - ws_ext_wholesale_cost#122) - ws_ext_discount_amt#120) + ws_ext_sales_price#121) / 2) AS _c8#126]
 Input [12]: [c_customer_id#112, c_first_name#113, c_last_name#114, c_preferred_cust_flag#115, c_birth_country#116, c_login#117, c_email_address#118, ws_ext_discount_amt#120, ws_ext_sales_price#121, ws_ext_wholesale_cost#122, ws_ext_list_price#123, d_year#125]
 
-(213) NativeHashAggregate
+(212) NativeHashAggregate
 Input [9]: [c_customer_id#112, c_first_name#113, c_last_name#114, c_preferred_cust_flag#115, c_birth_country#116, c_login#117, c_email_address#118, d_year#125, _c8#126]
 Keys [8]: [c_customer_id#112, c_first_name#113, c_last_name#114, c_preferred_cust_flag#115, c_birth_country#116, c_login#117, c_email_address#118, d_year#125]
 Functions [1]: [partial_sum(_c8#126)]
 Aggregate Attributes [2]: [sum#127, isEmpty#128]
 Results [9]: [c_customer_id#112, c_first_name#113, c_last_name#114, c_preferred_cust_flag#115, c_birth_country#116, c_login#117, c_email_address#118, d_year#125, #20]
 
-(214) NativeShuffleExchange
+(213) NativeShuffleExchange
 Input [9]: [c_customer_id#112, c_first_name#113, c_last_name#114, c_preferred_cust_flag#115, c_birth_country#116, c_login#117, c_email_address#118, d_year#125, #20]
 Arguments: hashpartitioning(c_customer_id#112, c_first_name#113, c_last_name#114, c_preferred_cust_flag#115, c_birth_country#116, c_login#117, c_email_address#118, d_year#125, 100), ENSURE_REQUIREMENTS, [plan_id=20]
 
-(215) ShuffleQueryStage
+(214) ShuffleQueryStage
 Output [9]: [c_customer_id#112, c_first_name#113, c_last_name#114, c_preferred_cust_flag#115, c_birth_country#116, c_login#117, c_email_address#118, d_year#125, #20]
 Arguments: X
 
-(216) AQEShuffleRead
+(215) AQEShuffleRead
 Input [9]: [c_customer_id#112, c_first_name#113, c_last_name#114, c_preferred_cust_flag#115, c_birth_country#116, c_login#117, c_email_address#118, d_year#125, #20]
 Arguments: coalesced
 
-(217) InputAdapter
+(216) InputAdapter
 Input [9]: [c_customer_id#112, c_first_name#113, c_last_name#114, c_preferred_cust_flag#115, c_birth_country#116, c_login#117, c_email_address#118, d_year#125, #20]
 
-(218) NativeHashAggregate
+(217) NativeHashAggregate
 Input [9]: [c_customer_id#112, c_first_name#113, c_last_name#114, c_preferred_cust_flag#115, c_birth_country#116, c_login#117, c_email_address#118, d_year#125, #20]
 Keys [8]: [c_customer_id#112, c_first_name#113, c_last_name#114, c_preferred_cust_flag#115, c_birth_country#116, c_login#117, c_email_address#118, d_year#125]
 Functions [1]: [sum(((((ws_ext_list_price#123 - ws_ext_wholesale_cost#122) - ws_ext_discount_amt#120) + ws_ext_sales_price#121) / 2))]
 Aggregate Attributes [1]: [sum(((((ws_ext_list_price#123 - ws_ext_wholesale_cost#122) - ws_ext_discount_amt#120) + ws_ext_sales_price#121) / 2))#109]
 Results [9]: [c_customer_id#112, c_first_name#113, c_last_name#114, c_preferred_cust_flag#115, c_birth_country#116, c_login#117, c_email_address#118, d_year#125, sum(((((ws_ext_list_price#123 - ws_ext_wholesale_cost#122) - ws_ext_discount_amt#120) + ws_ext_sales_price#121) / 2))#109]
 
-(219) NativeProject
+(218) NativeProject
 Output [2]: [c_customer_id#112 AS customer_id#129, sum(((((ws_ext_list_price#123 - ws_ext_wholesale_cost#122) - ws_ext_discount_amt#120) + ws_ext_sales_price#121) / 2))#109 AS year_total#130]
 Input [9]: [c_customer_id#112, c_first_name#113, c_last_name#114, c_preferred_cust_flag#115, c_birth_country#116, c_login#117, c_email_address#118, d_year#125, sum(((((ws_ext_list_price#123 - ws_ext_wholesale_cost#122) - ws_ext_discount_amt#120) + ws_ext_sales_price#121) / 2))#109]
 
-(220) NativeShuffleExchange
+(219) NativeShuffleExchange
 Input [2]: [customer_id#129, year_total#130]
 Arguments: hashpartitioning(customer_id#129, 100), ENSURE_REQUIREMENTS, [plan_id=21]
 
-(221) ShuffleQueryStage
+(220) ShuffleQueryStage
 Output [2]: [customer_id#129, year_total#130]
 Arguments: X
 
-(222) AQEShuffleRead
+(221) AQEShuffleRead
 Input [2]: [customer_id#129, year_total#130]
 Arguments: coalesced
 
-(223) InputAdapter
+(222) InputAdapter
 Input [2]: [customer_id#129, year_total#130]
 
-(224) NativeSort
+(223) NativeSort
 Input [2]: [customer_id#129, year_total#130]
 Arguments: [customer_id#129 ASC NULLS FIRST], false
 
-(225) SortMergeJoin [codegen id : X]
+(224) NativeSortMergeJoin
 Left keys [1]: [customer_id#22]
 Right keys [1]: [customer_id#129]
 Join type: Inner
 Join condition: (CASE WHEN (year_total#70 > 0.000000) THEN (year_total#89 / year_total#70) END > CASE WHEN (year_total#111 > 0.000000) THEN (year_total#130 / year_total#111) END)
 
-(226) Project [codegen id : X]
+(225) NativeProject
 Output [7]: [customer_id#41, customer_first_name#42, customer_last_name#43, customer_preferred_cust_flag#44, customer_birth_country#45, customer_login#46, customer_email_address#47]
 Input [13]: [customer_id#22, customer_id#41, customer_first_name#42, customer_last_name#43, customer_preferred_cust_flag#44, customer_birth_country#45, customer_login#46, customer_email_address#47, year_total#70, year_total#89, year_total#111, customer_id#129, year_total#130]
 
-(227) TakeOrderedAndProject
+(226) NativeTakeOrdered
 Input [7]: [customer_id#41, customer_first_name#42, customer_last_name#43, customer_preferred_cust_flag#44, customer_birth_country#45, customer_login#46, customer_email_address#47]
-Arguments: X, [customer_id#41 ASC NULLS FIRST, customer_first_name#42 ASC NULLS FIRST, customer_last_name#43 ASC NULLS FIRST, customer_preferred_cust_flag#44 ASC NULLS FIRST, customer_birth_country#45 ASC NULLS FIRST, customer_login#46 ASC NULLS FIRST, customer_email_address#47 ASC NULLS FIRST], [customer_id#41, customer_first_name#42, customer_last_name#43, customer_preferred_cust_flag#44, customer_birth_country#45, customer_login#46, customer_email_address#47]
+Arguments: X, X, [customer_id#41 ASC NULLS FIRST, customer_first_name#42 ASC NULLS FIRST, customer_last_name#43 ASC NULLS FIRST, customer_preferred_cust_flag#44 ASC NULLS FIRST, customer_birth_country#45 ASC NULLS FIRST, customer_login#46 ASC NULLS FIRST, customer_email_address#47 ASC NULLS FIRST]
 
-(228) Scan parquet
+(227) Scan parquet
 Output [8]: [c_customer_sk#1, c_customer_id#2, c_first_name#3, c_last_name#4, c_preferred_cust_flag#5, c_birth_country#6, c_login#7, c_email_address#8]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_customer_id)]
 ReadSchema: struct<c_customer_sk:int,c_customer_id:string,c_first_name:string,c_last_name:string,c_preferred_cust_flag:string,c_birth_country:string,c_login:string,c_email_address:string>
 
-(229) Filter
+(228) Filter
 Input [8]: [c_customer_sk#1, c_customer_id#2, c_first_name#3, c_last_name#4, c_preferred_cust_flag#5, c_birth_country#6, c_login#7, c_email_address#8]
 Condition : (isnotnull(c_customer_sk#1) AND isnotnull(c_customer_id#2))
 
-(230) Exchange
+(229) Exchange
 Input [8]: [c_customer_sk#1, c_customer_id#2, c_first_name#3, c_last_name#4, c_preferred_cust_flag#5, c_birth_country#6, c_login#7, c_email_address#8]
 Arguments: hashpartitioning(c_customer_sk#1, 100), ENSURE_REQUIREMENTS, [plan_id=22]
 
-(231) Sort
+(230) Sort
 Input [8]: [c_customer_sk#1, c_customer_id#2, c_first_name#3, c_last_name#4, c_preferred_cust_flag#5, c_birth_country#6, c_login#7, c_email_address#8]
 Arguments: [c_customer_sk#1 ASC NULLS FIRST], false, 0
 
-(232) Scan parquet
+(231) Scan parquet
 Output [6]: [ss_sold_date_sk#9, ss_customer_sk#10, ss_ext_discount_amt#11, ss_ext_sales_price#12, ss_ext_wholesale_cost#13, ss_ext_list_price#14]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(ss_customer_sk), IsNotNull(ss_sold_date_sk)]
 ReadSchema: struct<ss_sold_date_sk:int,ss_customer_sk:int,ss_ext_discount_amt:decimal(7,2),ss_ext_sales_price:decimal(7,2),ss_ext_wholesale_cost:decimal(7,2),ss_ext_list_price:decimal(7,2)>
 
-(233) Filter
+(232) Filter
 Input [6]: [ss_sold_date_sk#9, ss_customer_sk#10, ss_ext_discount_amt#11, ss_ext_sales_price#12, ss_ext_wholesale_cost#13, ss_ext_list_price#14]
 Condition : (isnotnull(ss_customer_sk#10) AND isnotnull(ss_sold_date_sk#9))
 
-(234) Exchange
+(233) Exchange
 Input [6]: [ss_sold_date_sk#9, ss_customer_sk#10, ss_ext_discount_amt#11, ss_ext_sales_price#12, ss_ext_wholesale_cost#13, ss_ext_list_price#14]
 Arguments: hashpartitioning(ss_customer_sk#10, 100), ENSURE_REQUIREMENTS, [plan_id=23]
 
-(235) Sort
+(234) Sort
 Input [6]: [ss_sold_date_sk#9, ss_customer_sk#10, ss_ext_discount_amt#11, ss_ext_sales_price#12, ss_ext_wholesale_cost#13, ss_ext_list_price#14]
 Arguments: [ss_customer_sk#10 ASC NULLS FIRST], false, 0
 
-(236) SortMergeJoin
+(235) SortMergeJoin
 Left keys [1]: [c_customer_sk#1]
 Right keys [1]: [ss_customer_sk#10]
 Join type: Inner
 Join condition: None
 
-(237) Project
+(236) Project
 Output [12]: [c_customer_id#2, c_first_name#3, c_last_name#4, c_preferred_cust_flag#5, c_birth_country#6, c_login#7, c_email_address#8, ss_sold_date_sk#9, ss_ext_discount_amt#11, ss_ext_sales_price#12, ss_ext_wholesale_cost#13, ss_ext_list_price#14]
 Input [14]: [c_customer_sk#1, c_customer_id#2, c_first_name#3, c_last_name#4, c_preferred_cust_flag#5, c_birth_country#6, c_login#7, c_email_address#8, ss_sold_date_sk#9, ss_customer_sk#10, ss_ext_discount_amt#11, ss_ext_sales_price#12, ss_ext_wholesale_cost#13, ss_ext_list_price#14]
 
-(238) Exchange
+(237) Exchange
 Input [12]: [c_customer_id#2, c_first_name#3, c_last_name#4, c_preferred_cust_flag#5, c_birth_country#6, c_login#7, c_email_address#8, ss_sold_date_sk#9, ss_ext_discount_amt#11, ss_ext_sales_price#12, ss_ext_wholesale_cost#13, ss_ext_list_price#14]
 Arguments: hashpartitioning(ss_sold_date_sk#9, 100), ENSURE_REQUIREMENTS, [plan_id=24]
 
-(239) Sort
+(238) Sort
 Input [12]: [c_customer_id#2, c_first_name#3, c_last_name#4, c_preferred_cust_flag#5, c_birth_country#6, c_login#7, c_email_address#8, ss_sold_date_sk#9, ss_ext_discount_amt#11, ss_ext_sales_price#12, ss_ext_wholesale_cost#13, ss_ext_list_price#14]
 Arguments: [ss_sold_date_sk#9 ASC NULLS FIRST], false, 0
 
-(240) Scan parquet
+(239) Scan parquet
 Output [2]: [d_date_sk#15, d_year#16]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2001), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
-(241) Filter
+(240) Filter
 Input [2]: [d_date_sk#15, d_year#16]
 Condition : ((isnotnull(d_year#16) AND (d_year#16 = 2001)) AND isnotnull(d_date_sk#15))
 
-(242) Exchange
+(241) Exchange
 Input [2]: [d_date_sk#15, d_year#16]
 Arguments: hashpartitioning(d_date_sk#15, 100), ENSURE_REQUIREMENTS, [plan_id=25]
 
-(243) Sort
+(242) Sort
 Input [2]: [d_date_sk#15, d_year#16]
 Arguments: [d_date_sk#15 ASC NULLS FIRST], false, 0
 
-(244) SortMergeJoin
+(243) SortMergeJoin
 Left keys [1]: [ss_sold_date_sk#9]
 Right keys [1]: [d_date_sk#15]
 Join type: Inner
 Join condition: None
 
-(245) Project
+(244) Project
 Output [12]: [c_customer_id#2, c_first_name#3, c_last_name#4, c_preferred_cust_flag#5, c_birth_country#6, c_login#7, c_email_address#8, ss_ext_discount_amt#11, ss_ext_sales_price#12, ss_ext_wholesale_cost#13, ss_ext_list_price#14, d_year#16]
 Input [14]: [c_customer_id#2, c_first_name#3, c_last_name#4, c_preferred_cust_flag#5, c_birth_country#6, c_login#7, c_email_address#8, ss_sold_date_sk#9, ss_ext_discount_amt#11, ss_ext_sales_price#12, ss_ext_wholesale_cost#13, ss_ext_list_price#14, d_date_sk#15, d_year#16]
 
-(246) HashAggregate
+(245) HashAggregate
 Input [12]: [c_customer_id#2, c_first_name#3, c_last_name#4, c_preferred_cust_flag#5, c_birth_country#6, c_login#7, c_email_address#8, ss_ext_discount_amt#11, ss_ext_sales_price#12, ss_ext_wholesale_cost#13, ss_ext_list_price#14, d_year#16]
 Keys [8]: [c_customer_id#2, c_first_name#3, c_last_name#4, c_preferred_cust_flag#5, c_birth_country#6, c_login#7, c_email_address#8, d_year#16]
 Functions [1]: [partial_sum(((((ss_ext_list_price#14 - ss_ext_wholesale_cost#13) - ss_ext_discount_amt#11) + ss_ext_sales_price#12) / 2))]
 Aggregate Attributes [2]: [sum#18, isEmpty#19]
 Results [10]: [c_customer_id#2, c_first_name#3, c_last_name#4, c_preferred_cust_flag#5, c_birth_country#6, c_login#7, c_email_address#8, d_year#16, sum#131, isEmpty#132]
 
-(247) Exchange
+(246) Exchange
 Input [10]: [c_customer_id#2, c_first_name#3, c_last_name#4, c_preferred_cust_flag#5, c_birth_country#6, c_login#7, c_email_address#8, d_year#16, sum#131, isEmpty#132]
 Arguments: hashpartitioning(c_customer_id#2, c_first_name#3, c_last_name#4, c_preferred_cust_flag#5, c_birth_country#6, c_login#7, c_email_address#8, d_year#16, 100), ENSURE_REQUIREMENTS, [plan_id=26]
 
-(248) HashAggregate
+(247) HashAggregate
 Input [10]: [c_customer_id#2, c_first_name#3, c_last_name#4, c_preferred_cust_flag#5, c_birth_country#6, c_login#7, c_email_address#8, d_year#16, sum#131, isEmpty#132]
 Keys [8]: [c_customer_id#2, c_first_name#3, c_last_name#4, c_preferred_cust_flag#5, c_birth_country#6, c_login#7, c_email_address#8, d_year#16]
 Functions [1]: [sum(((((ss_ext_list_price#14 - ss_ext_wholesale_cost#13) - ss_ext_discount_amt#11) + ss_ext_sales_price#12) / 2))]
 Aggregate Attributes [1]: [sum(((((ss_ext_list_price#14 - ss_ext_wholesale_cost#13) - ss_ext_discount_amt#11) + ss_ext_sales_price#12) / 2))#21]
 Results [2]: [c_customer_id#2 AS customer_id#22, sum(((((ss_ext_list_price#14 - ss_ext_wholesale_cost#13) - ss_ext_discount_amt#11) + ss_ext_sales_price#12) / 2))#21 AS year_total#23]
 
-(249) Filter
+(248) Filter
 Input [2]: [customer_id#22, year_total#23]
 Condition : (isnotnull(year_total#23) AND (year_total#23 > 0.000000))
 
-(250) Exchange
+(249) Exchange
 Input [2]: [customer_id#22, year_total#23]
 Arguments: hashpartitioning(customer_id#22, 100), ENSURE_REQUIREMENTS, [plan_id=27]
 
-(251) Sort
+(250) Sort
 Input [2]: [customer_id#22, year_total#23]
 Arguments: [customer_id#22 ASC NULLS FIRST], false, 0
 
-(252) Scan parquet
+(251) Scan parquet
 Output [8]: [c_customer_sk#133, c_customer_id#24, c_first_name#25, c_last_name#26, c_preferred_cust_flag#27, c_birth_country#28, c_login#29, c_email_address#30]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_customer_id)]
 ReadSchema: struct<c_customer_sk:int,c_customer_id:string,c_first_name:string,c_last_name:string,c_preferred_cust_flag:string,c_birth_country:string,c_login:string,c_email_address:string>
 
-(253) Filter
+(252) Filter
 Input [8]: [c_customer_sk#133, c_customer_id#24, c_first_name#25, c_last_name#26, c_preferred_cust_flag#27, c_birth_country#28, c_login#29, c_email_address#30]
 Condition : (isnotnull(c_customer_sk#133) AND isnotnull(c_customer_id#24))
 
-(254) Exchange
+(253) Exchange
 Input [8]: [c_customer_sk#133, c_customer_id#24, c_first_name#25, c_last_name#26, c_preferred_cust_flag#27, c_birth_country#28, c_login#29, c_email_address#30]
 Arguments: hashpartitioning(c_customer_sk#133, 100), ENSURE_REQUIREMENTS, [plan_id=28]
 
-(255) Sort
+(254) Sort
 Input [8]: [c_customer_sk#133, c_customer_id#24, c_first_name#25, c_last_name#26, c_preferred_cust_flag#27, c_birth_country#28, c_login#29, c_email_address#30]
 Arguments: [c_customer_sk#133 ASC NULLS FIRST], false, 0
 
-(256) Scan parquet
+(255) Scan parquet
 Output [6]: [ss_sold_date_sk#31, ss_customer_sk#134, ss_ext_discount_amt#32, ss_ext_sales_price#33, ss_ext_wholesale_cost#34, ss_ext_list_price#35]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(ss_customer_sk), IsNotNull(ss_sold_date_sk)]
 ReadSchema: struct<ss_sold_date_sk:int,ss_customer_sk:int,ss_ext_discount_amt:decimal(7,2),ss_ext_sales_price:decimal(7,2),ss_ext_wholesale_cost:decimal(7,2),ss_ext_list_price:decimal(7,2)>
 
-(257) Filter
+(256) Filter
 Input [6]: [ss_sold_date_sk#31, ss_customer_sk#134, ss_ext_discount_amt#32, ss_ext_sales_price#33, ss_ext_wholesale_cost#34, ss_ext_list_price#35]
 Condition : (isnotnull(ss_customer_sk#134) AND isnotnull(ss_sold_date_sk#31))
 
-(258) Exchange
+(257) Exchange
 Input [6]: [ss_sold_date_sk#31, ss_customer_sk#134, ss_ext_discount_amt#32, ss_ext_sales_price#33, ss_ext_wholesale_cost#34, ss_ext_list_price#35]
 Arguments: hashpartitioning(ss_customer_sk#134, 100), ENSURE_REQUIREMENTS, [plan_id=29]
 
-(259) Sort
+(258) Sort
 Input [6]: [ss_sold_date_sk#31, ss_customer_sk#134, ss_ext_discount_amt#32, ss_ext_sales_price#33, ss_ext_wholesale_cost#34, ss_ext_list_price#35]
 Arguments: [ss_customer_sk#134 ASC NULLS FIRST], false, 0
 
-(260) SortMergeJoin
+(259) SortMergeJoin
 Left keys [1]: [c_customer_sk#133]
 Right keys [1]: [ss_customer_sk#134]
 Join type: Inner
 Join condition: None
 
-(261) Project
+(260) Project
 Output [12]: [c_customer_id#24, c_first_name#25, c_last_name#26, c_preferred_cust_flag#27, c_birth_country#28, c_login#29, c_email_address#30, ss_sold_date_sk#31, ss_ext_discount_amt#32, ss_ext_sales_price#33, ss_ext_wholesale_cost#34, ss_ext_list_price#35]
 Input [14]: [c_customer_sk#133, c_customer_id#24, c_first_name#25, c_last_name#26, c_preferred_cust_flag#27, c_birth_country#28, c_login#29, c_email_address#30, ss_sold_date_sk#31, ss_customer_sk#134, ss_ext_discount_amt#32, ss_ext_sales_price#33, ss_ext_wholesale_cost#34, ss_ext_list_price#35]
 
-(262) Exchange
+(261) Exchange
 Input [12]: [c_customer_id#24, c_first_name#25, c_last_name#26, c_preferred_cust_flag#27, c_birth_country#28, c_login#29, c_email_address#30, ss_sold_date_sk#31, ss_ext_discount_amt#32, ss_ext_sales_price#33, ss_ext_wholesale_cost#34, ss_ext_list_price#35]
 Arguments: hashpartitioning(ss_sold_date_sk#31, 100), ENSURE_REQUIREMENTS, [plan_id=30]
 
-(263) Sort
+(262) Sort
 Input [12]: [c_customer_id#24, c_first_name#25, c_last_name#26, c_preferred_cust_flag#27, c_birth_country#28, c_login#29, c_email_address#30, ss_sold_date_sk#31, ss_ext_discount_amt#32, ss_ext_sales_price#33, ss_ext_wholesale_cost#34, ss_ext_list_price#35]
 Arguments: [ss_sold_date_sk#31 ASC NULLS FIRST], false, 0
 
-(264) Scan parquet
+(263) Scan parquet
 Output [2]: [d_date_sk#36, d_year#37]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2002), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
-(265) Filter
+(264) Filter
 Input [2]: [d_date_sk#36, d_year#37]
 Condition : ((isnotnull(d_year#37) AND (d_year#37 = 2002)) AND isnotnull(d_date_sk#36))
 
-(266) Exchange
+(265) Exchange
 Input [2]: [d_date_sk#36, d_year#37]
 Arguments: hashpartitioning(d_date_sk#36, 100), ENSURE_REQUIREMENTS, [plan_id=31]
 
-(267) Sort
+(266) Sort
 Input [2]: [d_date_sk#36, d_year#37]
 Arguments: [d_date_sk#36 ASC NULLS FIRST], false, 0
 
-(268) SortMergeJoin
+(267) SortMergeJoin
 Left keys [1]: [ss_sold_date_sk#31]
 Right keys [1]: [d_date_sk#36]
 Join type: Inner
 Join condition: None
 
-(269) Project
+(268) Project
 Output [12]: [c_customer_id#24, c_first_name#25, c_last_name#26, c_preferred_cust_flag#27, c_birth_country#28, c_login#29, c_email_address#30, ss_ext_discount_amt#32, ss_ext_sales_price#33, ss_ext_wholesale_cost#34, ss_ext_list_price#35, d_year#37]
 Input [14]: [c_customer_id#24, c_first_name#25, c_last_name#26, c_preferred_cust_flag#27, c_birth_country#28, c_login#29, c_email_address#30, ss_sold_date_sk#31, ss_ext_discount_amt#32, ss_ext_sales_price#33, ss_ext_wholesale_cost#34, ss_ext_list_price#35, d_date_sk#36, d_year#37]
 
-(270) HashAggregate
+(269) HashAggregate
 Input [12]: [c_customer_id#24, c_first_name#25, c_last_name#26, c_preferred_cust_flag#27, c_birth_country#28, c_login#29, c_email_address#30, ss_ext_discount_amt#32, ss_ext_sales_price#33, ss_ext_wholesale_cost#34, ss_ext_list_price#35, d_year#37]
 Keys [8]: [c_customer_id#24, c_first_name#25, c_last_name#26, c_preferred_cust_flag#27, c_birth_country#28, c_login#29, c_email_address#30, d_year#37]
 Functions [1]: [partial_sum(((((ss_ext_list_price#35 - ss_ext_wholesale_cost#34) - ss_ext_discount_amt#32) + ss_ext_sales_price#33) / 2))]
 Aggregate Attributes [2]: [sum#39, isEmpty#40]
 Results [10]: [c_customer_id#24, c_first_name#25, c_last_name#26, c_preferred_cust_flag#27, c_birth_country#28, c_login#29, c_email_address#30, d_year#37, sum#135, isEmpty#136]
 
-(271) Exchange
+(270) Exchange
 Input [10]: [c_customer_id#24, c_first_name#25, c_last_name#26, c_preferred_cust_flag#27, c_birth_country#28, c_login#29, c_email_address#30, d_year#37, sum#135, isEmpty#136]
 Arguments: hashpartitioning(c_customer_id#24, c_first_name#25, c_last_name#26, c_preferred_cust_flag#27, c_birth_country#28, c_login#29, c_email_address#30, d_year#37, 100), ENSURE_REQUIREMENTS, [plan_id=32]
 
-(272) HashAggregate
+(271) HashAggregate
 Input [10]: [c_customer_id#24, c_first_name#25, c_last_name#26, c_preferred_cust_flag#27, c_birth_country#28, c_login#29, c_email_address#30, d_year#37, sum#135, isEmpty#136]
 Keys [8]: [c_customer_id#24, c_first_name#25, c_last_name#26, c_preferred_cust_flag#27, c_birth_country#28, c_login#29, c_email_address#30, d_year#37]
 Functions [1]: [sum(((((ss_ext_list_price#35 - ss_ext_wholesale_cost#34) - ss_ext_discount_amt#32) + ss_ext_sales_price#33) / 2))]
 Aggregate Attributes [1]: [sum(((((ss_ext_list_price#35 - ss_ext_wholesale_cost#34) - ss_ext_discount_amt#32) + ss_ext_sales_price#33) / 2))#21]
 Results [8]: [c_customer_id#24 AS customer_id#41, c_first_name#25 AS customer_first_name#42, c_last_name#26 AS customer_last_name#43, c_preferred_cust_flag#27 AS customer_preferred_cust_flag#44, c_birth_country#28 AS customer_birth_country#45, c_login#29 AS customer_login#46, c_email_address#30 AS customer_email_address#47, sum(((((ss_ext_list_price#35 - ss_ext_wholesale_cost#34) - ss_ext_discount_amt#32) + ss_ext_sales_price#33) / 2))#21 AS year_total#48]
 
-(273) Exchange
+(272) Exchange
 Input [8]: [customer_id#41, customer_first_name#42, customer_last_name#43, customer_preferred_cust_flag#44, customer_birth_country#45, customer_login#46, customer_email_address#47, year_total#48]
 Arguments: hashpartitioning(customer_id#41, 100), ENSURE_REQUIREMENTS, [plan_id=33]
 
-(274) Sort
+(273) Sort
 Input [8]: [customer_id#41, customer_first_name#42, customer_last_name#43, customer_preferred_cust_flag#44, customer_birth_country#45, customer_login#46, customer_email_address#47, year_total#48]
 Arguments: [customer_id#41 ASC NULLS FIRST], false, 0
 
-(275) SortMergeJoin
+(274) SortMergeJoin
 Left keys [1]: [customer_id#22]
 Right keys [1]: [customer_id#41]
 Join type: Inner
 Join condition: None
 
-(276) Scan parquet
+(275) Scan parquet
 Output [8]: [c_customer_sk#49, c_customer_id#50, c_first_name#51, c_last_name#52, c_preferred_cust_flag#53, c_birth_country#54, c_login#55, c_email_address#56]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_customer_id)]
 ReadSchema: struct<c_customer_sk:int,c_customer_id:string,c_first_name:string,c_last_name:string,c_preferred_cust_flag:string,c_birth_country:string,c_login:string,c_email_address:string>
 
-(277) Filter
+(276) Filter
 Input [8]: [c_customer_sk#49, c_customer_id#50, c_first_name#51, c_last_name#52, c_preferred_cust_flag#53, c_birth_country#54, c_login#55, c_email_address#56]
 Condition : (isnotnull(c_customer_sk#49) AND isnotnull(c_customer_id#50))
 
-(278) Exchange
+(277) Exchange
 Input [8]: [c_customer_sk#49, c_customer_id#50, c_first_name#51, c_last_name#52, c_preferred_cust_flag#53, c_birth_country#54, c_login#55, c_email_address#56]
 Arguments: hashpartitioning(c_customer_sk#49, 100), ENSURE_REQUIREMENTS, [plan_id=34]
 
-(279) Sort
+(278) Sort
 Input [8]: [c_customer_sk#49, c_customer_id#50, c_first_name#51, c_last_name#52, c_preferred_cust_flag#53, c_birth_country#54, c_login#55, c_email_address#56]
 Arguments: [c_customer_sk#49 ASC NULLS FIRST], false, 0
 
-(280) Scan parquet
+(279) Scan parquet
 Output [6]: [cs_sold_date_sk#57, cs_bill_customer_sk#58, cs_ext_discount_amt#59, cs_ext_sales_price#60, cs_ext_wholesale_cost#61, cs_ext_list_price#62]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(cs_bill_customer_sk), IsNotNull(cs_sold_date_sk)]
 ReadSchema: struct<cs_sold_date_sk:int,cs_bill_customer_sk:int,cs_ext_discount_amt:decimal(7,2),cs_ext_sales_price:decimal(7,2),cs_ext_wholesale_cost:decimal(7,2),cs_ext_list_price:decimal(7,2)>
 
-(281) Filter
+(280) Filter
 Input [6]: [cs_sold_date_sk#57, cs_bill_customer_sk#58, cs_ext_discount_amt#59, cs_ext_sales_price#60, cs_ext_wholesale_cost#61, cs_ext_list_price#62]
 Condition : (isnotnull(cs_bill_customer_sk#58) AND isnotnull(cs_sold_date_sk#57))
 
-(282) Exchange
+(281) Exchange
 Input [6]: [cs_sold_date_sk#57, cs_bill_customer_sk#58, cs_ext_discount_amt#59, cs_ext_sales_price#60, cs_ext_wholesale_cost#61, cs_ext_list_price#62]
 Arguments: hashpartitioning(cs_bill_customer_sk#58, 100), ENSURE_REQUIREMENTS, [plan_id=35]
 
-(283) Sort
+(282) Sort
 Input [6]: [cs_sold_date_sk#57, cs_bill_customer_sk#58, cs_ext_discount_amt#59, cs_ext_sales_price#60, cs_ext_wholesale_cost#61, cs_ext_list_price#62]
 Arguments: [cs_bill_customer_sk#58 ASC NULLS FIRST], false, 0
 
-(284) SortMergeJoin
+(283) SortMergeJoin
 Left keys [1]: [c_customer_sk#49]
 Right keys [1]: [cs_bill_customer_sk#58]
 Join type: Inner
 Join condition: None
 
-(285) Project
+(284) Project
 Output [12]: [c_customer_id#50, c_first_name#51, c_last_name#52, c_preferred_cust_flag#53, c_birth_country#54, c_login#55, c_email_address#56, cs_sold_date_sk#57, cs_ext_discount_amt#59, cs_ext_sales_price#60, cs_ext_wholesale_cost#61, cs_ext_list_price#62]
 Input [14]: [c_customer_sk#49, c_customer_id#50, c_first_name#51, c_last_name#52, c_preferred_cust_flag#53, c_birth_country#54, c_login#55, c_email_address#56, cs_sold_date_sk#57, cs_bill_customer_sk#58, cs_ext_discount_amt#59, cs_ext_sales_price#60, cs_ext_wholesale_cost#61, cs_ext_list_price#62]
 
-(286) Exchange
+(285) Exchange
 Input [12]: [c_customer_id#50, c_first_name#51, c_last_name#52, c_preferred_cust_flag#53, c_birth_country#54, c_login#55, c_email_address#56, cs_sold_date_sk#57, cs_ext_discount_amt#59, cs_ext_sales_price#60, cs_ext_wholesale_cost#61, cs_ext_list_price#62]
 Arguments: hashpartitioning(cs_sold_date_sk#57, 100), ENSURE_REQUIREMENTS, [plan_id=36]
 
-(287) Sort
+(286) Sort
 Input [12]: [c_customer_id#50, c_first_name#51, c_last_name#52, c_preferred_cust_flag#53, c_birth_country#54, c_login#55, c_email_address#56, cs_sold_date_sk#57, cs_ext_discount_amt#59, cs_ext_sales_price#60, cs_ext_wholesale_cost#61, cs_ext_list_price#62]
 Arguments: [cs_sold_date_sk#57 ASC NULLS FIRST], false, 0
 
-(288) Scan parquet
+(287) Scan parquet
 Output [2]: [d_date_sk#63, d_year#64]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2001), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
-(289) Filter
+(288) Filter
 Input [2]: [d_date_sk#63, d_year#64]
 Condition : ((isnotnull(d_year#64) AND (d_year#64 = 2001)) AND isnotnull(d_date_sk#63))
 
-(290) Exchange
+(289) Exchange
 Input [2]: [d_date_sk#63, d_year#64]
 Arguments: hashpartitioning(d_date_sk#63, 100), ENSURE_REQUIREMENTS, [plan_id=37]
 
-(291) Sort
+(290) Sort
 Input [2]: [d_date_sk#63, d_year#64]
 Arguments: [d_date_sk#63 ASC NULLS FIRST], false, 0
 
-(292) SortMergeJoin
+(291) SortMergeJoin
 Left keys [1]: [cs_sold_date_sk#57]
 Right keys [1]: [d_date_sk#63]
 Join type: Inner
 Join condition: None
 
-(293) Project
+(292) Project
 Output [12]: [c_customer_id#50, c_first_name#51, c_last_name#52, c_preferred_cust_flag#53, c_birth_country#54, c_login#55, c_email_address#56, cs_ext_discount_amt#59, cs_ext_sales_price#60, cs_ext_wholesale_cost#61, cs_ext_list_price#62, d_year#64]
 Input [14]: [c_customer_id#50, c_first_name#51, c_last_name#52, c_preferred_cust_flag#53, c_birth_country#54, c_login#55, c_email_address#56, cs_sold_date_sk#57, cs_ext_discount_amt#59, cs_ext_sales_price#60, cs_ext_wholesale_cost#61, cs_ext_list_price#62, d_date_sk#63, d_year#64]
 
-(294) HashAggregate
+(293) HashAggregate
 Input [12]: [c_customer_id#50, c_first_name#51, c_last_name#52, c_preferred_cust_flag#53, c_birth_country#54, c_login#55, c_email_address#56, cs_ext_discount_amt#59, cs_ext_sales_price#60, cs_ext_wholesale_cost#61, cs_ext_list_price#62, d_year#64]
 Keys [8]: [c_customer_id#50, c_first_name#51, c_last_name#52, c_preferred_cust_flag#53, c_birth_country#54, c_login#55, c_email_address#56, d_year#64]
 Functions [1]: [partial_sum(((((cs_ext_list_price#62 - cs_ext_wholesale_cost#61) - cs_ext_discount_amt#59) + cs_ext_sales_price#60) / 2))]
 Aggregate Attributes [2]: [sum#66, isEmpty#67]
 Results [10]: [c_customer_id#50, c_first_name#51, c_last_name#52, c_preferred_cust_flag#53, c_birth_country#54, c_login#55, c_email_address#56, d_year#64, sum#137, isEmpty#138]
 
-(295) Exchange
+(294) Exchange
 Input [10]: [c_customer_id#50, c_first_name#51, c_last_name#52, c_preferred_cust_flag#53, c_birth_country#54, c_login#55, c_email_address#56, d_year#64, sum#137, isEmpty#138]
 Arguments: hashpartitioning(c_customer_id#50, c_first_name#51, c_last_name#52, c_preferred_cust_flag#53, c_birth_country#54, c_login#55, c_email_address#56, d_year#64, 100), ENSURE_REQUIREMENTS, [plan_id=38]
 
-(296) HashAggregate
+(295) HashAggregate
 Input [10]: [c_customer_id#50, c_first_name#51, c_last_name#52, c_preferred_cust_flag#53, c_birth_country#54, c_login#55, c_email_address#56, d_year#64, sum#137, isEmpty#138]
 Keys [8]: [c_customer_id#50, c_first_name#51, c_last_name#52, c_preferred_cust_flag#53, c_birth_country#54, c_login#55, c_email_address#56, d_year#64]
 Functions [1]: [sum(((((cs_ext_list_price#62 - cs_ext_wholesale_cost#61) - cs_ext_discount_amt#59) + cs_ext_sales_price#60) / 2))]
 Aggregate Attributes [1]: [sum(((((cs_ext_list_price#62 - cs_ext_wholesale_cost#61) - cs_ext_discount_amt#59) + cs_ext_sales_price#60) / 2))#68]
 Results [2]: [c_customer_id#50 AS customer_id#69, sum(((((cs_ext_list_price#62 - cs_ext_wholesale_cost#61) - cs_ext_discount_amt#59) + cs_ext_sales_price#60) / 2))#68 AS year_total#70]
 
-(297) Filter
+(296) Filter
 Input [2]: [customer_id#69, year_total#70]
 Condition : (isnotnull(year_total#70) AND (year_total#70 > 0.000000))
 
-(298) Exchange
+(297) Exchange
 Input [2]: [customer_id#69, year_total#70]
 Arguments: hashpartitioning(customer_id#69, 100), ENSURE_REQUIREMENTS, [plan_id=39]
 
-(299) Sort
+(298) Sort
 Input [2]: [customer_id#69, year_total#70]
 Arguments: [customer_id#69 ASC NULLS FIRST], false, 0
 
-(300) SortMergeJoin
+(299) SortMergeJoin
 Left keys [1]: [customer_id#22]
 Right keys [1]: [customer_id#69]
 Join type: Inner
 Join condition: None
 
-(301) Project
+(300) Project
 Output [11]: [customer_id#22, year_total#23, customer_id#41, customer_first_name#42, customer_last_name#43, customer_preferred_cust_flag#44, customer_birth_country#45, customer_login#46, customer_email_address#47, year_total#48, year_total#70]
 Input [12]: [customer_id#22, year_total#23, customer_id#41, customer_first_name#42, customer_last_name#43, customer_preferred_cust_flag#44, customer_birth_country#45, customer_login#46, customer_email_address#47, year_total#48, customer_id#69, year_total#70]
 
-(302) Scan parquet
+(301) Scan parquet
 Output [8]: [c_customer_sk#139, c_customer_id#71, c_first_name#72, c_last_name#73, c_preferred_cust_flag#74, c_birth_country#75, c_login#76, c_email_address#77]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_customer_id)]
 ReadSchema: struct<c_customer_sk:int,c_customer_id:string,c_first_name:string,c_last_name:string,c_preferred_cust_flag:string,c_birth_country:string,c_login:string,c_email_address:string>
 
-(303) Filter
+(302) Filter
 Input [8]: [c_customer_sk#139, c_customer_id#71, c_first_name#72, c_last_name#73, c_preferred_cust_flag#74, c_birth_country#75, c_login#76, c_email_address#77]
 Condition : (isnotnull(c_customer_sk#139) AND isnotnull(c_customer_id#71))
 
-(304) Exchange
+(303) Exchange
 Input [8]: [c_customer_sk#139, c_customer_id#71, c_first_name#72, c_last_name#73, c_preferred_cust_flag#74, c_birth_country#75, c_login#76, c_email_address#77]
 Arguments: hashpartitioning(c_customer_sk#139, 100), ENSURE_REQUIREMENTS, [plan_id=40]
 
-(305) Sort
+(304) Sort
 Input [8]: [c_customer_sk#139, c_customer_id#71, c_first_name#72, c_last_name#73, c_preferred_cust_flag#74, c_birth_country#75, c_login#76, c_email_address#77]
 Arguments: [c_customer_sk#139 ASC NULLS FIRST], false, 0
 
-(306) Scan parquet
+(305) Scan parquet
 Output [6]: [cs_sold_date_sk#78, cs_bill_customer_sk#140, cs_ext_discount_amt#79, cs_ext_sales_price#80, cs_ext_wholesale_cost#81, cs_ext_list_price#82]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(cs_bill_customer_sk), IsNotNull(cs_sold_date_sk)]
 ReadSchema: struct<cs_sold_date_sk:int,cs_bill_customer_sk:int,cs_ext_discount_amt:decimal(7,2),cs_ext_sales_price:decimal(7,2),cs_ext_wholesale_cost:decimal(7,2),cs_ext_list_price:decimal(7,2)>
 
-(307) Filter
+(306) Filter
 Input [6]: [cs_sold_date_sk#78, cs_bill_customer_sk#140, cs_ext_discount_amt#79, cs_ext_sales_price#80, cs_ext_wholesale_cost#81, cs_ext_list_price#82]
 Condition : (isnotnull(cs_bill_customer_sk#140) AND isnotnull(cs_sold_date_sk#78))
 
-(308) Exchange
+(307) Exchange
 Input [6]: [cs_sold_date_sk#78, cs_bill_customer_sk#140, cs_ext_discount_amt#79, cs_ext_sales_price#80, cs_ext_wholesale_cost#81, cs_ext_list_price#82]
 Arguments: hashpartitioning(cs_bill_customer_sk#140, 100), ENSURE_REQUIREMENTS, [plan_id=41]
 
-(309) Sort
+(308) Sort
 Input [6]: [cs_sold_date_sk#78, cs_bill_customer_sk#140, cs_ext_discount_amt#79, cs_ext_sales_price#80, cs_ext_wholesale_cost#81, cs_ext_list_price#82]
 Arguments: [cs_bill_customer_sk#140 ASC NULLS FIRST], false, 0
 
-(310) SortMergeJoin
+(309) SortMergeJoin
 Left keys [1]: [c_customer_sk#139]
 Right keys [1]: [cs_bill_customer_sk#140]
 Join type: Inner
 Join condition: None
 
-(311) Project
+(310) Project
 Output [12]: [c_customer_id#71, c_first_name#72, c_last_name#73, c_preferred_cust_flag#74, c_birth_country#75, c_login#76, c_email_address#77, cs_sold_date_sk#78, cs_ext_discount_amt#79, cs_ext_sales_price#80, cs_ext_wholesale_cost#81, cs_ext_list_price#82]
 Input [14]: [c_customer_sk#139, c_customer_id#71, c_first_name#72, c_last_name#73, c_preferred_cust_flag#74, c_birth_country#75, c_login#76, c_email_address#77, cs_sold_date_sk#78, cs_bill_customer_sk#140, cs_ext_discount_amt#79, cs_ext_sales_price#80, cs_ext_wholesale_cost#81, cs_ext_list_price#82]
 
-(312) Exchange
+(311) Exchange
 Input [12]: [c_customer_id#71, c_first_name#72, c_last_name#73, c_preferred_cust_flag#74, c_birth_country#75, c_login#76, c_email_address#77, cs_sold_date_sk#78, cs_ext_discount_amt#79, cs_ext_sales_price#80, cs_ext_wholesale_cost#81, cs_ext_list_price#82]
 Arguments: hashpartitioning(cs_sold_date_sk#78, 100), ENSURE_REQUIREMENTS, [plan_id=42]
 
-(313) Sort
+(312) Sort
 Input [12]: [c_customer_id#71, c_first_name#72, c_last_name#73, c_preferred_cust_flag#74, c_birth_country#75, c_login#76, c_email_address#77, cs_sold_date_sk#78, cs_ext_discount_amt#79, cs_ext_sales_price#80, cs_ext_wholesale_cost#81, cs_ext_list_price#82]
 Arguments: [cs_sold_date_sk#78 ASC NULLS FIRST], false, 0
 
-(314) Scan parquet
+(313) Scan parquet
 Output [2]: [d_date_sk#83, d_year#84]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2002), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
-(315) Filter
+(314) Filter
 Input [2]: [d_date_sk#83, d_year#84]
 Condition : ((isnotnull(d_year#84) AND (d_year#84 = 2002)) AND isnotnull(d_date_sk#83))
 
-(316) Exchange
+(315) Exchange
 Input [2]: [d_date_sk#83, d_year#84]
 Arguments: hashpartitioning(d_date_sk#83, 100), ENSURE_REQUIREMENTS, [plan_id=43]
 
-(317) Sort
+(316) Sort
 Input [2]: [d_date_sk#83, d_year#84]
 Arguments: [d_date_sk#83 ASC NULLS FIRST], false, 0
 
-(318) SortMergeJoin
+(317) SortMergeJoin
 Left keys [1]: [cs_sold_date_sk#78]
 Right keys [1]: [d_date_sk#83]
 Join type: Inner
 Join condition: None
 
-(319) Project
+(318) Project
 Output [12]: [c_customer_id#71, c_first_name#72, c_last_name#73, c_preferred_cust_flag#74, c_birth_country#75, c_login#76, c_email_address#77, cs_ext_discount_amt#79, cs_ext_sales_price#80, cs_ext_wholesale_cost#81, cs_ext_list_price#82, d_year#84]
 Input [14]: [c_customer_id#71, c_first_name#72, c_last_name#73, c_preferred_cust_flag#74, c_birth_country#75, c_login#76, c_email_address#77, cs_sold_date_sk#78, cs_ext_discount_amt#79, cs_ext_sales_price#80, cs_ext_wholesale_cost#81, cs_ext_list_price#82, d_date_sk#83, d_year#84]
 
-(320) HashAggregate
+(319) HashAggregate
 Input [12]: [c_customer_id#71, c_first_name#72, c_last_name#73, c_preferred_cust_flag#74, c_birth_country#75, c_login#76, c_email_address#77, cs_ext_discount_amt#79, cs_ext_sales_price#80, cs_ext_wholesale_cost#81, cs_ext_list_price#82, d_year#84]
 Keys [8]: [c_customer_id#71, c_first_name#72, c_last_name#73, c_preferred_cust_flag#74, c_birth_country#75, c_login#76, c_email_address#77, d_year#84]
 Functions [1]: [partial_sum(((((cs_ext_list_price#82 - cs_ext_wholesale_cost#81) - cs_ext_discount_amt#79) + cs_ext_sales_price#80) / 2))]
 Aggregate Attributes [2]: [sum#86, isEmpty#87]
 Results [10]: [c_customer_id#71, c_first_name#72, c_last_name#73, c_preferred_cust_flag#74, c_birth_country#75, c_login#76, c_email_address#77, d_year#84, sum#141, isEmpty#142]
 
-(321) Exchange
+(320) Exchange
 Input [10]: [c_customer_id#71, c_first_name#72, c_last_name#73, c_preferred_cust_flag#74, c_birth_country#75, c_login#76, c_email_address#77, d_year#84, sum#141, isEmpty#142]
 Arguments: hashpartitioning(c_customer_id#71, c_first_name#72, c_last_name#73, c_preferred_cust_flag#74, c_birth_country#75, c_login#76, c_email_address#77, d_year#84, 100), ENSURE_REQUIREMENTS, [plan_id=44]
 
-(322) HashAggregate
+(321) HashAggregate
 Input [10]: [c_customer_id#71, c_first_name#72, c_last_name#73, c_preferred_cust_flag#74, c_birth_country#75, c_login#76, c_email_address#77, d_year#84, sum#141, isEmpty#142]
 Keys [8]: [c_customer_id#71, c_first_name#72, c_last_name#73, c_preferred_cust_flag#74, c_birth_country#75, c_login#76, c_email_address#77, d_year#84]
 Functions [1]: [sum(((((cs_ext_list_price#82 - cs_ext_wholesale_cost#81) - cs_ext_discount_amt#79) + cs_ext_sales_price#80) / 2))]
 Aggregate Attributes [1]: [sum(((((cs_ext_list_price#82 - cs_ext_wholesale_cost#81) - cs_ext_discount_amt#79) + cs_ext_sales_price#80) / 2))#68]
 Results [2]: [c_customer_id#71 AS customer_id#88, sum(((((cs_ext_list_price#82 - cs_ext_wholesale_cost#81) - cs_ext_discount_amt#79) + cs_ext_sales_price#80) / 2))#68 AS year_total#89]
 
-(323) Exchange
+(322) Exchange
 Input [2]: [customer_id#88, year_total#89]
 Arguments: hashpartitioning(customer_id#88, 100), ENSURE_REQUIREMENTS, [plan_id=45]
 
-(324) Sort
+(323) Sort
 Input [2]: [customer_id#88, year_total#89]
 Arguments: [customer_id#88 ASC NULLS FIRST], false, 0
 
-(325) SortMergeJoin
+(324) SortMergeJoin
 Left keys [1]: [customer_id#22]
 Right keys [1]: [customer_id#88]
 Join type: Inner
 Join condition: (CASE WHEN (year_total#70 > 0.000000) THEN (year_total#89 / year_total#70) END > CASE WHEN (year_total#23 > 0.000000) THEN (year_total#48 / year_total#23) END)
 
-(326) Project
+(325) Project
 Output [10]: [customer_id#22, customer_id#41, customer_first_name#42, customer_last_name#43, customer_preferred_cust_flag#44, customer_birth_country#45, customer_login#46, customer_email_address#47, year_total#70, year_total#89]
 Input [13]: [customer_id#22, year_total#23, customer_id#41, customer_first_name#42, customer_last_name#43, customer_preferred_cust_flag#44, customer_birth_country#45, customer_login#46, customer_email_address#47, year_total#48, year_total#70, customer_id#88, year_total#89]
 
-(327) Scan parquet
+(326) Scan parquet
 Output [8]: [c_customer_sk#90, c_customer_id#91, c_first_name#92, c_last_name#93, c_preferred_cust_flag#94, c_birth_country#95, c_login#96, c_email_address#97]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_customer_id)]
 ReadSchema: struct<c_customer_sk:int,c_customer_id:string,c_first_name:string,c_last_name:string,c_preferred_cust_flag:string,c_birth_country:string,c_login:string,c_email_address:string>
 
-(328) Filter
+(327) Filter
 Input [8]: [c_customer_sk#90, c_customer_id#91, c_first_name#92, c_last_name#93, c_preferred_cust_flag#94, c_birth_country#95, c_login#96, c_email_address#97]
 Condition : (isnotnull(c_customer_sk#90) AND isnotnull(c_customer_id#91))
 
-(329) Exchange
+(328) Exchange
 Input [8]: [c_customer_sk#90, c_customer_id#91, c_first_name#92, c_last_name#93, c_preferred_cust_flag#94, c_birth_country#95, c_login#96, c_email_address#97]
 Arguments: hashpartitioning(c_customer_sk#90, 100), ENSURE_REQUIREMENTS, [plan_id=46]
 
-(330) Sort
+(329) Sort
 Input [8]: [c_customer_sk#90, c_customer_id#91, c_first_name#92, c_last_name#93, c_preferred_cust_flag#94, c_birth_country#95, c_login#96, c_email_address#97]
 Arguments: [c_customer_sk#90 ASC NULLS FIRST], false, 0
 
-(331) Scan parquet
+(330) Scan parquet
 Output [6]: [ws_sold_date_sk#98, ws_bill_customer_sk#99, ws_ext_discount_amt#100, ws_ext_sales_price#101, ws_ext_wholesale_cost#102, ws_ext_list_price#103]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(ws_bill_customer_sk), IsNotNull(ws_sold_date_sk)]
 ReadSchema: struct<ws_sold_date_sk:int,ws_bill_customer_sk:int,ws_ext_discount_amt:decimal(7,2),ws_ext_sales_price:decimal(7,2),ws_ext_wholesale_cost:decimal(7,2),ws_ext_list_price:decimal(7,2)>
 
-(332) Filter
+(331) Filter
 Input [6]: [ws_sold_date_sk#98, ws_bill_customer_sk#99, ws_ext_discount_amt#100, ws_ext_sales_price#101, ws_ext_wholesale_cost#102, ws_ext_list_price#103]
 Condition : (isnotnull(ws_bill_customer_sk#99) AND isnotnull(ws_sold_date_sk#98))
 
-(333) Exchange
+(332) Exchange
 Input [6]: [ws_sold_date_sk#98, ws_bill_customer_sk#99, ws_ext_discount_amt#100, ws_ext_sales_price#101, ws_ext_wholesale_cost#102, ws_ext_list_price#103]
 Arguments: hashpartitioning(ws_bill_customer_sk#99, 100), ENSURE_REQUIREMENTS, [plan_id=47]
 
-(334) Sort
+(333) Sort
 Input [6]: [ws_sold_date_sk#98, ws_bill_customer_sk#99, ws_ext_discount_amt#100, ws_ext_sales_price#101, ws_ext_wholesale_cost#102, ws_ext_list_price#103]
 Arguments: [ws_bill_customer_sk#99 ASC NULLS FIRST], false, 0
 
-(335) SortMergeJoin
+(334) SortMergeJoin
 Left keys [1]: [c_customer_sk#90]
 Right keys [1]: [ws_bill_customer_sk#99]
 Join type: Inner
 Join condition: None
 
-(336) Project
+(335) Project
 Output [12]: [c_customer_id#91, c_first_name#92, c_last_name#93, c_preferred_cust_flag#94, c_birth_country#95, c_login#96, c_email_address#97, ws_sold_date_sk#98, ws_ext_discount_amt#100, ws_ext_sales_price#101, ws_ext_wholesale_cost#102, ws_ext_list_price#103]
 Input [14]: [c_customer_sk#90, c_customer_id#91, c_first_name#92, c_last_name#93, c_preferred_cust_flag#94, c_birth_country#95, c_login#96, c_email_address#97, ws_sold_date_sk#98, ws_bill_customer_sk#99, ws_ext_discount_amt#100, ws_ext_sales_price#101, ws_ext_wholesale_cost#102, ws_ext_list_price#103]
 
-(337) Exchange
+(336) Exchange
 Input [12]: [c_customer_id#91, c_first_name#92, c_last_name#93, c_preferred_cust_flag#94, c_birth_country#95, c_login#96, c_email_address#97, ws_sold_date_sk#98, ws_ext_discount_amt#100, ws_ext_sales_price#101, ws_ext_wholesale_cost#102, ws_ext_list_price#103]
 Arguments: hashpartitioning(ws_sold_date_sk#98, 100), ENSURE_REQUIREMENTS, [plan_id=48]
 
-(338) Sort
+(337) Sort
 Input [12]: [c_customer_id#91, c_first_name#92, c_last_name#93, c_preferred_cust_flag#94, c_birth_country#95, c_login#96, c_email_address#97, ws_sold_date_sk#98, ws_ext_discount_amt#100, ws_ext_sales_price#101, ws_ext_wholesale_cost#102, ws_ext_list_price#103]
 Arguments: [ws_sold_date_sk#98 ASC NULLS FIRST], false, 0
 
-(339) Scan parquet
+(338) Scan parquet
 Output [2]: [d_date_sk#104, d_year#105]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2001), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
-(340) Filter
+(339) Filter
 Input [2]: [d_date_sk#104, d_year#105]
 Condition : ((isnotnull(d_year#105) AND (d_year#105 = 2001)) AND isnotnull(d_date_sk#104))
 
-(341) Exchange
+(340) Exchange
 Input [2]: [d_date_sk#104, d_year#105]
 Arguments: hashpartitioning(d_date_sk#104, 100), ENSURE_REQUIREMENTS, [plan_id=49]
 
-(342) Sort
+(341) Sort
 Input [2]: [d_date_sk#104, d_year#105]
 Arguments: [d_date_sk#104 ASC NULLS FIRST], false, 0
 
-(343) SortMergeJoin
+(342) SortMergeJoin
 Left keys [1]: [ws_sold_date_sk#98]
 Right keys [1]: [d_date_sk#104]
 Join type: Inner
 Join condition: None
 
-(344) Project
+(343) Project
 Output [12]: [c_customer_id#91, c_first_name#92, c_last_name#93, c_preferred_cust_flag#94, c_birth_country#95, c_login#96, c_email_address#97, ws_ext_discount_amt#100, ws_ext_sales_price#101, ws_ext_wholesale_cost#102, ws_ext_list_price#103, d_year#105]
 Input [14]: [c_customer_id#91, c_first_name#92, c_last_name#93, c_preferred_cust_flag#94, c_birth_country#95, c_login#96, c_email_address#97, ws_sold_date_sk#98, ws_ext_discount_amt#100, ws_ext_sales_price#101, ws_ext_wholesale_cost#102, ws_ext_list_price#103, d_date_sk#104, d_year#105]
 
-(345) HashAggregate
+(344) HashAggregate
 Input [12]: [c_customer_id#91, c_first_name#92, c_last_name#93, c_preferred_cust_flag#94, c_birth_country#95, c_login#96, c_email_address#97, ws_ext_discount_amt#100, ws_ext_sales_price#101, ws_ext_wholesale_cost#102, ws_ext_list_price#103, d_year#105]
 Keys [8]: [c_customer_id#91, c_first_name#92, c_last_name#93, c_preferred_cust_flag#94, c_birth_country#95, c_login#96, c_email_address#97, d_year#105]
 Functions [1]: [partial_sum(((((ws_ext_list_price#103 - ws_ext_wholesale_cost#102) - ws_ext_discount_amt#100) + ws_ext_sales_price#101) / 2))]
 Aggregate Attributes [2]: [sum#107, isEmpty#108]
 Results [10]: [c_customer_id#91, c_first_name#92, c_last_name#93, c_preferred_cust_flag#94, c_birth_country#95, c_login#96, c_email_address#97, d_year#105, sum#143, isEmpty#144]
 
-(346) Exchange
+(345) Exchange
 Input [10]: [c_customer_id#91, c_first_name#92, c_last_name#93, c_preferred_cust_flag#94, c_birth_country#95, c_login#96, c_email_address#97, d_year#105, sum#143, isEmpty#144]
 Arguments: hashpartitioning(c_customer_id#91, c_first_name#92, c_last_name#93, c_preferred_cust_flag#94, c_birth_country#95, c_login#96, c_email_address#97, d_year#105, 100), ENSURE_REQUIREMENTS, [plan_id=50]
 
-(347) HashAggregate
+(346) HashAggregate
 Input [10]: [c_customer_id#91, c_first_name#92, c_last_name#93, c_preferred_cust_flag#94, c_birth_country#95, c_login#96, c_email_address#97, d_year#105, sum#143, isEmpty#144]
 Keys [8]: [c_customer_id#91, c_first_name#92, c_last_name#93, c_preferred_cust_flag#94, c_birth_country#95, c_login#96, c_email_address#97, d_year#105]
 Functions [1]: [sum(((((ws_ext_list_price#103 - ws_ext_wholesale_cost#102) - ws_ext_discount_amt#100) + ws_ext_sales_price#101) / 2))]
 Aggregate Attributes [1]: [sum(((((ws_ext_list_price#103 - ws_ext_wholesale_cost#102) - ws_ext_discount_amt#100) + ws_ext_sales_price#101) / 2))#109]
 Results [2]: [c_customer_id#91 AS customer_id#110, sum(((((ws_ext_list_price#103 - ws_ext_wholesale_cost#102) - ws_ext_discount_amt#100) + ws_ext_sales_price#101) / 2))#109 AS year_total#111]
 
-(348) Filter
+(347) Filter
 Input [2]: [customer_id#110, year_total#111]
 Condition : (isnotnull(year_total#111) AND (year_total#111 > 0.000000))
 
-(349) Exchange
+(348) Exchange
 Input [2]: [customer_id#110, year_total#111]
 Arguments: hashpartitioning(customer_id#110, 100), ENSURE_REQUIREMENTS, [plan_id=51]
 
-(350) Sort
+(349) Sort
 Input [2]: [customer_id#110, year_total#111]
 Arguments: [customer_id#110 ASC NULLS FIRST], false, 0
 
-(351) SortMergeJoin
+(350) SortMergeJoin
 Left keys [1]: [customer_id#22]
 Right keys [1]: [customer_id#110]
 Join type: Inner
 Join condition: None
 
-(352) Project
+(351) Project
 Output [11]: [customer_id#22, customer_id#41, customer_first_name#42, customer_last_name#43, customer_preferred_cust_flag#44, customer_birth_country#45, customer_login#46, customer_email_address#47, year_total#70, year_total#89, year_total#111]
 Input [12]: [customer_id#22, customer_id#41, customer_first_name#42, customer_last_name#43, customer_preferred_cust_flag#44, customer_birth_country#45, customer_login#46, customer_email_address#47, year_total#70, year_total#89, customer_id#110, year_total#111]
 
-(353) Scan parquet
+(352) Scan parquet
 Output [8]: [c_customer_sk#145, c_customer_id#112, c_first_name#113, c_last_name#114, c_preferred_cust_flag#115, c_birth_country#116, c_login#117, c_email_address#118]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_customer_id)]
 ReadSchema: struct<c_customer_sk:int,c_customer_id:string,c_first_name:string,c_last_name:string,c_preferred_cust_flag:string,c_birth_country:string,c_login:string,c_email_address:string>
 
-(354) Filter
+(353) Filter
 Input [8]: [c_customer_sk#145, c_customer_id#112, c_first_name#113, c_last_name#114, c_preferred_cust_flag#115, c_birth_country#116, c_login#117, c_email_address#118]
 Condition : (isnotnull(c_customer_sk#145) AND isnotnull(c_customer_id#112))
 
-(355) Exchange
+(354) Exchange
 Input [8]: [c_customer_sk#145, c_customer_id#112, c_first_name#113, c_last_name#114, c_preferred_cust_flag#115, c_birth_country#116, c_login#117, c_email_address#118]
 Arguments: hashpartitioning(c_customer_sk#145, 100), ENSURE_REQUIREMENTS, [plan_id=52]
 
-(356) Sort
+(355) Sort
 Input [8]: [c_customer_sk#145, c_customer_id#112, c_first_name#113, c_last_name#114, c_preferred_cust_flag#115, c_birth_country#116, c_login#117, c_email_address#118]
 Arguments: [c_customer_sk#145 ASC NULLS FIRST], false, 0
 
-(357) Scan parquet
+(356) Scan parquet
 Output [6]: [ws_sold_date_sk#119, ws_bill_customer_sk#146, ws_ext_discount_amt#120, ws_ext_sales_price#121, ws_ext_wholesale_cost#122, ws_ext_list_price#123]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(ws_bill_customer_sk), IsNotNull(ws_sold_date_sk)]
 ReadSchema: struct<ws_sold_date_sk:int,ws_bill_customer_sk:int,ws_ext_discount_amt:decimal(7,2),ws_ext_sales_price:decimal(7,2),ws_ext_wholesale_cost:decimal(7,2),ws_ext_list_price:decimal(7,2)>
 
-(358) Filter
+(357) Filter
 Input [6]: [ws_sold_date_sk#119, ws_bill_customer_sk#146, ws_ext_discount_amt#120, ws_ext_sales_price#121, ws_ext_wholesale_cost#122, ws_ext_list_price#123]
 Condition : (isnotnull(ws_bill_customer_sk#146) AND isnotnull(ws_sold_date_sk#119))
 
-(359) Exchange
+(358) Exchange
 Input [6]: [ws_sold_date_sk#119, ws_bill_customer_sk#146, ws_ext_discount_amt#120, ws_ext_sales_price#121, ws_ext_wholesale_cost#122, ws_ext_list_price#123]
 Arguments: hashpartitioning(ws_bill_customer_sk#146, 100), ENSURE_REQUIREMENTS, [plan_id=53]
 
-(360) Sort
+(359) Sort
 Input [6]: [ws_sold_date_sk#119, ws_bill_customer_sk#146, ws_ext_discount_amt#120, ws_ext_sales_price#121, ws_ext_wholesale_cost#122, ws_ext_list_price#123]
 Arguments: [ws_bill_customer_sk#146 ASC NULLS FIRST], false, 0
 
-(361) SortMergeJoin
+(360) SortMergeJoin
 Left keys [1]: [c_customer_sk#145]
 Right keys [1]: [ws_bill_customer_sk#146]
 Join type: Inner
 Join condition: None
 
-(362) Project
+(361) Project
 Output [12]: [c_customer_id#112, c_first_name#113, c_last_name#114, c_preferred_cust_flag#115, c_birth_country#116, c_login#117, c_email_address#118, ws_sold_date_sk#119, ws_ext_discount_amt#120, ws_ext_sales_price#121, ws_ext_wholesale_cost#122, ws_ext_list_price#123]
 Input [14]: [c_customer_sk#145, c_customer_id#112, c_first_name#113, c_last_name#114, c_preferred_cust_flag#115, c_birth_country#116, c_login#117, c_email_address#118, ws_sold_date_sk#119, ws_bill_customer_sk#146, ws_ext_discount_amt#120, ws_ext_sales_price#121, ws_ext_wholesale_cost#122, ws_ext_list_price#123]
 
-(363) Exchange
+(362) Exchange
 Input [12]: [c_customer_id#112, c_first_name#113, c_last_name#114, c_preferred_cust_flag#115, c_birth_country#116, c_login#117, c_email_address#118, ws_sold_date_sk#119, ws_ext_discount_amt#120, ws_ext_sales_price#121, ws_ext_wholesale_cost#122, ws_ext_list_price#123]
 Arguments: hashpartitioning(ws_sold_date_sk#119, 100), ENSURE_REQUIREMENTS, [plan_id=54]
 
-(364) Sort
+(363) Sort
 Input [12]: [c_customer_id#112, c_first_name#113, c_last_name#114, c_preferred_cust_flag#115, c_birth_country#116, c_login#117, c_email_address#118, ws_sold_date_sk#119, ws_ext_discount_amt#120, ws_ext_sales_price#121, ws_ext_wholesale_cost#122, ws_ext_list_price#123]
 Arguments: [ws_sold_date_sk#119 ASC NULLS FIRST], false, 0
 
-(365) Scan parquet
+(364) Scan parquet
 Output [2]: [d_date_sk#124, d_year#125]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2002), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
-(366) Filter
+(365) Filter
 Input [2]: [d_date_sk#124, d_year#125]
 Condition : ((isnotnull(d_year#125) AND (d_year#125 = 2002)) AND isnotnull(d_date_sk#124))
 
-(367) Exchange
+(366) Exchange
 Input [2]: [d_date_sk#124, d_year#125]
 Arguments: hashpartitioning(d_date_sk#124, 100), ENSURE_REQUIREMENTS, [plan_id=55]
 
-(368) Sort
+(367) Sort
 Input [2]: [d_date_sk#124, d_year#125]
 Arguments: [d_date_sk#124 ASC NULLS FIRST], false, 0
 
-(369) SortMergeJoin
+(368) SortMergeJoin
 Left keys [1]: [ws_sold_date_sk#119]
 Right keys [1]: [d_date_sk#124]
 Join type: Inner
 Join condition: None
 
-(370) Project
+(369) Project
 Output [12]: [c_customer_id#112, c_first_name#113, c_last_name#114, c_preferred_cust_flag#115, c_birth_country#116, c_login#117, c_email_address#118, ws_ext_discount_amt#120, ws_ext_sales_price#121, ws_ext_wholesale_cost#122, ws_ext_list_price#123, d_year#125]
 Input [14]: [c_customer_id#112, c_first_name#113, c_last_name#114, c_preferred_cust_flag#115, c_birth_country#116, c_login#117, c_email_address#118, ws_sold_date_sk#119, ws_ext_discount_amt#120, ws_ext_sales_price#121, ws_ext_wholesale_cost#122, ws_ext_list_price#123, d_date_sk#124, d_year#125]
 
-(371) HashAggregate
+(370) HashAggregate
 Input [12]: [c_customer_id#112, c_first_name#113, c_last_name#114, c_preferred_cust_flag#115, c_birth_country#116, c_login#117, c_email_address#118, ws_ext_discount_amt#120, ws_ext_sales_price#121, ws_ext_wholesale_cost#122, ws_ext_list_price#123, d_year#125]
 Keys [8]: [c_customer_id#112, c_first_name#113, c_last_name#114, c_preferred_cust_flag#115, c_birth_country#116, c_login#117, c_email_address#118, d_year#125]
 Functions [1]: [partial_sum(((((ws_ext_list_price#123 - ws_ext_wholesale_cost#122) - ws_ext_discount_amt#120) + ws_ext_sales_price#121) / 2))]
 Aggregate Attributes [2]: [sum#127, isEmpty#128]
 Results [10]: [c_customer_id#112, c_first_name#113, c_last_name#114, c_preferred_cust_flag#115, c_birth_country#116, c_login#117, c_email_address#118, d_year#125, sum#147, isEmpty#148]
 
-(372) Exchange
+(371) Exchange
 Input [10]: [c_customer_id#112, c_first_name#113, c_last_name#114, c_preferred_cust_flag#115, c_birth_country#116, c_login#117, c_email_address#118, d_year#125, sum#147, isEmpty#148]
 Arguments: hashpartitioning(c_customer_id#112, c_first_name#113, c_last_name#114, c_preferred_cust_flag#115, c_birth_country#116, c_login#117, c_email_address#118, d_year#125, 100), ENSURE_REQUIREMENTS, [plan_id=56]
 
-(373) HashAggregate
+(372) HashAggregate
 Input [10]: [c_customer_id#112, c_first_name#113, c_last_name#114, c_preferred_cust_flag#115, c_birth_country#116, c_login#117, c_email_address#118, d_year#125, sum#147, isEmpty#148]
 Keys [8]: [c_customer_id#112, c_first_name#113, c_last_name#114, c_preferred_cust_flag#115, c_birth_country#116, c_login#117, c_email_address#118, d_year#125]
 Functions [1]: [sum(((((ws_ext_list_price#123 - ws_ext_wholesale_cost#122) - ws_ext_discount_amt#120) + ws_ext_sales_price#121) / 2))]
 Aggregate Attributes [1]: [sum(((((ws_ext_list_price#123 - ws_ext_wholesale_cost#122) - ws_ext_discount_amt#120) + ws_ext_sales_price#121) / 2))#109]
 Results [2]: [c_customer_id#112 AS customer_id#129, sum(((((ws_ext_list_price#123 - ws_ext_wholesale_cost#122) - ws_ext_discount_amt#120) + ws_ext_sales_price#121) / 2))#109 AS year_total#130]
 
-(374) Exchange
+(373) Exchange
 Input [2]: [customer_id#129, year_total#130]
 Arguments: hashpartitioning(customer_id#129, 100), ENSURE_REQUIREMENTS, [plan_id=57]
 
-(375) Sort
+(374) Sort
 Input [2]: [customer_id#129, year_total#130]
 Arguments: [customer_id#129 ASC NULLS FIRST], false, 0
 
-(376) SortMergeJoin
+(375) SortMergeJoin
 Left keys [1]: [customer_id#22]
 Right keys [1]: [customer_id#129]
 Join type: Inner
 Join condition: (CASE WHEN (year_total#70 > 0.000000) THEN (year_total#89 / year_total#70) END > CASE WHEN (year_total#111 > 0.000000) THEN (year_total#130 / year_total#111) END)
 
-(377) Project
+(376) Project
 Output [7]: [customer_id#41, customer_first_name#42, customer_last_name#43, customer_preferred_cust_flag#44, customer_birth_country#45, customer_login#46, customer_email_address#47]
 Input [13]: [customer_id#22, customer_id#41, customer_first_name#42, customer_last_name#43, customer_preferred_cust_flag#44, customer_birth_country#45, customer_login#46, customer_email_address#47, year_total#70, year_total#89, year_total#111, customer_id#129, year_total#130]
 
-(378) TakeOrderedAndProject
+(377) TakeOrderedAndProject
 Input [7]: [customer_id#41, customer_first_name#42, customer_last_name#43, customer_preferred_cust_flag#44, customer_birth_country#45, customer_login#46, customer_email_address#47]
 Arguments: X, [customer_id#41 ASC NULLS FIRST, customer_first_name#42 ASC NULLS FIRST, customer_last_name#43 ASC NULLS FIRST, customer_preferred_cust_flag#44 ASC NULLS FIRST, customer_birth_country#45 ASC NULLS FIRST, customer_login#46 ASC NULLS FIRST, customer_email_address#47 ASC NULLS FIRST], [customer_id#41, customer_first_name#42, customer_last_name#43, customer_preferred_cust_flag#44, customer_birth_country#45, customer_login#46, customer_email_address#47]
 
-(379) AdaptiveSparkPlan
+(378) AdaptiveSparkPlan
 Output [7]: [customer_id#41, customer_first_name#42, customer_last_name#43, customer_preferred_cust_flag#44, customer_birth_country#45, customer_login#46, customer_email_address#47]
 Arguments: isFinalPlan=true
 

--- a/dev/auron-it/src/main/resources/tpcds-plan-stability/spark-3.5/q46.txt
+++ b/dev/auron-it/src/main/resources/tpcds-plan-stability/spark-3.5/q46.txt
@@ -1,9 +1,9 @@
 == Physical Plan ==
 AdaptiveSparkPlan (156)
 +- == Final Plan ==
-   TakeOrderedAndProject (99)
-   +- * Project (98)
-      +- * SortMergeJoin Inner (97)
+   NativeTakeOrdered (99)
+   +- NativeProject (98)
+      +- NativeSortMergeJoin Inner (97)
          :- NativeSort (90)
          :  +- InputAdapter (89)
          :     +- AQEShuffleRead (88)
@@ -564,19 +564,19 @@ Input [2]: [#33#33, #34#34]
 Input [2]: [#33#33, #34#34]
 Arguments: [ca_address_sk#33 ASC NULLS FIRST], false
 
-(97) SortMergeJoin [codegen id : X]
+(97) NativeSortMergeJoin
 Left keys [1]: [c_current_addr_sk#30]
 Right keys [1]: [ca_address_sk#33]
 Join type: Inner
 Join condition: NOT (ca_city#34 = bought_city#26)
 
-(98) Project [codegen id : X]
+(98) NativeProject
 Output [7]: [c_last_name#32, c_first_name#31, ca_city#34, bought_city#26, ss_ticket_number#6, amt#27, profit#28]
 Input [9]: [ss_ticket_number#6, bought_city#26, amt#27, profit#28, c_current_addr_sk#30, c_first_name#31, c_last_name#32, #33#33, #34#34]
 
-(99) TakeOrderedAndProject
+(99) NativeTakeOrdered
 Input [7]: [c_last_name#32, c_first_name#31, ca_city#34, bought_city#26, ss_ticket_number#6, amt#27, profit#28]
-Arguments: X, [c_last_name#32 ASC NULLS FIRST, c_first_name#31 ASC NULLS FIRST, ca_city#34 ASC NULLS FIRST, bought_city#26 ASC NULLS FIRST, ss_ticket_number#6 ASC NULLS FIRST], [c_last_name#32, c_first_name#31, ca_city#34, bought_city#26, ss_ticket_number#6, amt#27, profit#28]
+Arguments: X, X, [c_last_name#32 ASC NULLS FIRST, c_first_name#31 ASC NULLS FIRST, ca_city#34 ASC NULLS FIRST, bought_city#26 ASC NULLS FIRST, ss_ticket_number#6 ASC NULLS FIRST]
 
 (100) Scan parquet
 Output [8]: [ss_sold_date_sk#1, ss_customer_sk#2, ss_hdemo_sk#3, ss_addr_sk#4, ss_store_sk#5, ss_ticket_number#6, ss_coupon_amt#7, ss_net_profit#8]

--- a/dev/auron-it/src/main/resources/tpcds-plan-stability/spark-3.5/q48.txt
+++ b/dev/auron-it/src/main/resources/tpcds-plan-stability/spark-3.5/q48.txt
@@ -1,121 +1,119 @@
 == Physical Plan ==
-AdaptiveSparkPlan (112)
+AdaptiveSparkPlan (110)
 +- == Final Plan ==
-   NativeProject (72)
-   +- NativeHashAggregate (71)
-      +- ShuffleQueryStage (70), Statistics(X)
-         +- NativeShuffleExchange (69)
-            +- NativeHashAggregate (68)
-               +- NativeProject (67)
-                  +- NativeSortMergeJoin Inner (66)
-                     :- NativeSort (56)
-                     :  +- InputAdapter (55)
-                     :     +- AQEShuffleRead (54)
-                     :        +- ShuffleQueryStage (53), Statistics(X)
-                     :           +- NativeShuffleExchange (52)
-                     :              +- ConvertToNative (51)
-                     :                 +- * Project (50)
-                     :                    +- * SortMergeJoin Inner (49)
-                     :                       :- NativeSort (39)
-                     :                       :  +- InputAdapter (38)
-                     :                       :     +- AQEShuffleRead (37)
-                     :                       :        +- ShuffleQueryStage (36), Statistics(X)
-                     :                       :           +- NativeShuffleExchange (35)
-                     :                       :              +- ConvertToNative (34)
-                     :                       :                 +- * Project (33)
-                     :                       :                    +- * SortMergeJoin Inner (32)
-                     :                       :                       :- NativeSort (23)
-                     :                       :                       :  +- InputAdapter (22)
-                     :                       :                       :     +- AQEShuffleRead (21)
-                     :                       :                       :        +- ShuffleQueryStage (20), Statistics(X)
-                     :                       :                       :           +- NativeShuffleExchange (19)
-                     :                       :                       :              +- NativeProject (18)
-                     :                       :                       :                 +- NativeSortMergeJoin Inner (17)
-                     :                       :                       :                    :- NativeSort (8)
-                     :                       :                       :                    :  +- InputAdapter (7)
-                     :                       :                       :                    :     +- AQEShuffleRead (6)
-                     :                       :                       :                    :        +- ShuffleQueryStage (5), Statistics(X)
-                     :                       :                       :                    :           +- NativeShuffleExchange (4)
-                     :                       :                       :                    :              +- NativeFilter (3)
-                     :                       :                       :                    :                 +- InputAdapter (2)
-                     :                       :                       :                    :                    +- NativeParquetScan  (1)
-                     :                       :                       :                    +- NativeSort (16)
-                     :                       :                       :                       +- InputAdapter (15)
-                     :                       :                       :                          +- AQEShuffleRead (14)
-                     :                       :                       :                             +- ShuffleQueryStage (13), Statistics(X)
-                     :                       :                       :                                +- NativeShuffleExchange (12)
-                     :                       :                       :                                   +- NativeFilter (11)
-                     :                       :                       :                                      +- InputAdapter (10)
-                     :                       :                       :                                         +- NativeParquetScan  (9)
-                     :                       :                       +- NativeSort (31)
-                     :                       :                          +- InputAdapter (30)
-                     :                       :                             +- AQEShuffleRead (29)
-                     :                       :                                +- ShuffleQueryStage (28), Statistics(X)
-                     :                       :                                   +- NativeShuffleExchange (27)
-                     :                       :                                      +- NativeFilter (26)
-                     :                       :                                         +- InputAdapter (25)
-                     :                       :                                            +- NativeParquetScan  (24)
-                     :                       +- NativeSort (48)
-                     :                          +- InputAdapter (47)
-                     :                             +- AQEShuffleRead (46)
-                     :                                +- ShuffleQueryStage (45), Statistics(X)
-                     :                                   +- NativeShuffleExchange (44)
-                     :                                      +- NativeProject (43)
-                     :                                         +- NativeFilter (42)
-                     :                                            +- InputAdapter (41)
-                     :                                               +- NativeParquetScan  (40)
-                     +- NativeSort (65)
-                        +- InputAdapter (64)
-                           +- AQEShuffleRead (63)
-                              +- ShuffleQueryStage (62), Statistics(X)
-                                 +- NativeShuffleExchange (61)
-                                    +- NativeProject (60)
-                                       +- NativeFilter (59)
-                                          +- InputAdapter (58)
-                                             +- NativeParquetScan  (57)
+   NativeProject (70)
+   +- NativeHashAggregate (69)
+      +- ShuffleQueryStage (68), Statistics(X)
+         +- NativeShuffleExchange (67)
+            +- NativeHashAggregate (66)
+               +- NativeProject (65)
+                  +- NativeSortMergeJoin Inner (64)
+                     :- NativeSort (54)
+                     :  +- InputAdapter (53)
+                     :     +- AQEShuffleRead (52)
+                     :        +- ShuffleQueryStage (51), Statistics(X)
+                     :           +- NativeShuffleExchange (50)
+                     :              +- NativeProject (49)
+                     :                 +- NativeSortMergeJoin Inner (48)
+                     :                    :- NativeSort (38)
+                     :                    :  +- InputAdapter (37)
+                     :                    :     +- AQEShuffleRead (36)
+                     :                    :        +- ShuffleQueryStage (35), Statistics(X)
+                     :                    :           +- NativeShuffleExchange (34)
+                     :                    :              +- NativeProject (33)
+                     :                    :                 +- NativeSortMergeJoin Inner (32)
+                     :                    :                    :- NativeSort (23)
+                     :                    :                    :  +- InputAdapter (22)
+                     :                    :                    :     +- AQEShuffleRead (21)
+                     :                    :                    :        +- ShuffleQueryStage (20), Statistics(X)
+                     :                    :                    :           +- NativeShuffleExchange (19)
+                     :                    :                    :              +- NativeProject (18)
+                     :                    :                    :                 +- NativeSortMergeJoin Inner (17)
+                     :                    :                    :                    :- NativeSort (8)
+                     :                    :                    :                    :  +- InputAdapter (7)
+                     :                    :                    :                    :     +- AQEShuffleRead (6)
+                     :                    :                    :                    :        +- ShuffleQueryStage (5), Statistics(X)
+                     :                    :                    :                    :           +- NativeShuffleExchange (4)
+                     :                    :                    :                    :              +- NativeFilter (3)
+                     :                    :                    :                    :                 +- InputAdapter (2)
+                     :                    :                    :                    :                    +- NativeParquetScan  (1)
+                     :                    :                    :                    +- NativeSort (16)
+                     :                    :                    :                       +- InputAdapter (15)
+                     :                    :                    :                          +- AQEShuffleRead (14)
+                     :                    :                    :                             +- ShuffleQueryStage (13), Statistics(X)
+                     :                    :                    :                                +- NativeShuffleExchange (12)
+                     :                    :                    :                                   +- NativeFilter (11)
+                     :                    :                    :                                      +- InputAdapter (10)
+                     :                    :                    :                                         +- NativeParquetScan  (9)
+                     :                    :                    +- NativeSort (31)
+                     :                    :                       +- InputAdapter (30)
+                     :                    :                          +- AQEShuffleRead (29)
+                     :                    :                             +- ShuffleQueryStage (28), Statistics(X)
+                     :                    :                                +- NativeShuffleExchange (27)
+                     :                    :                                   +- NativeFilter (26)
+                     :                    :                                      +- InputAdapter (25)
+                     :                    :                                         +- NativeParquetScan  (24)
+                     :                    +- NativeSort (47)
+                     :                       +- InputAdapter (46)
+                     :                          +- AQEShuffleRead (45)
+                     :                             +- ShuffleQueryStage (44), Statistics(X)
+                     :                                +- NativeShuffleExchange (43)
+                     :                                   +- NativeProject (42)
+                     :                                      +- NativeFilter (41)
+                     :                                         +- InputAdapter (40)
+                     :                                            +- NativeParquetScan  (39)
+                     +- NativeSort (63)
+                        +- InputAdapter (62)
+                           +- AQEShuffleRead (61)
+                              +- ShuffleQueryStage (60), Statistics(X)
+                                 +- NativeShuffleExchange (59)
+                                    +- NativeProject (58)
+                                       +- NativeFilter (57)
+                                          +- InputAdapter (56)
+                                             +- NativeParquetScan  (55)
 +- == Initial Plan ==
-   HashAggregate (111)
-   +- Exchange (110)
-      +- HashAggregate (109)
-         +- Project (108)
-            +- SortMergeJoin Inner (107)
-               :- Sort (101)
-               :  +- Exchange (100)
-               :     +- Project (99)
-               :        +- SortMergeJoin Inner (98)
-               :           :- Sort (92)
-               :           :  +- Exchange (91)
-               :           :     +- Project (90)
-               :           :        +- SortMergeJoin Inner (89)
-               :           :           :- Sort (84)
-               :           :           :  +- Exchange (83)
-               :           :           :     +- Project (82)
-               :           :           :        +- SortMergeJoin Inner (81)
-               :           :           :           :- Sort (76)
-               :           :           :           :  +- Exchange (75)
-               :           :           :           :     +- Filter (74)
-               :           :           :           :        +- Scan parquet (73)
-               :           :           :           +- Sort (80)
-               :           :           :              +- Exchange (79)
-               :           :           :                 +- Filter (78)
-               :           :           :                    +- Scan parquet (77)
-               :           :           +- Sort (88)
-               :           :              +- Exchange (87)
-               :           :                 +- Filter (86)
-               :           :                    +- Scan parquet (85)
-               :           +- Sort (97)
-               :              +- Exchange (96)
-               :                 +- Project (95)
-               :                    +- Filter (94)
-               :                       +- Scan parquet (93)
-               +- Sort (106)
-                  +- Exchange (105)
-                     +- Project (104)
-                        +- Filter (103)
-                           +- Scan parquet (102)
+   HashAggregate (109)
+   +- Exchange (108)
+      +- HashAggregate (107)
+         +- Project (106)
+            +- SortMergeJoin Inner (105)
+               :- Sort (99)
+               :  +- Exchange (98)
+               :     +- Project (97)
+               :        +- SortMergeJoin Inner (96)
+               :           :- Sort (90)
+               :           :  +- Exchange (89)
+               :           :     +- Project (88)
+               :           :        +- SortMergeJoin Inner (87)
+               :           :           :- Sort (82)
+               :           :           :  +- Exchange (81)
+               :           :           :     +- Project (80)
+               :           :           :        +- SortMergeJoin Inner (79)
+               :           :           :           :- Sort (74)
+               :           :           :           :  +- Exchange (73)
+               :           :           :           :     +- Filter (72)
+               :           :           :           :        +- Scan parquet (71)
+               :           :           :           +- Sort (78)
+               :           :           :              +- Exchange (77)
+               :           :           :                 +- Filter (76)
+               :           :           :                    +- Scan parquet (75)
+               :           :           +- Sort (86)
+               :           :              +- Exchange (85)
+               :           :                 +- Filter (84)
+               :           :                    +- Scan parquet (83)
+               :           +- Sort (95)
+               :              +- Exchange (94)
+               :                 +- Project (93)
+               :                    +- Filter (92)
+               :                       +- Scan parquet (91)
+               +- Sort (104)
+                  +- Exchange (103)
+                     +- Project (102)
+                        +- Filter (101)
+                           +- Scan parquet (100)
 
 
-(73) Scan parquet
+(71) Scan parquet
 Output [7]: [ss_sold_date_sk#1, ss_cdemo_sk#2, ss_addr_sk#3, ss_store_sk#4, ss_quantity#5, ss_sales_price#6, ss_net_profit#7]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
@@ -149,7 +147,7 @@ Input [7]: [#1#1, #2#2, #3#3, #4#4, #5#5, #6#6, #7#7]
 Input [7]: [#1#1, #2#2, #3#3, #4#4, #5#5, #6#6, #7#7]
 Arguments: [ss_store_sk#4 ASC NULLS FIRST], false
 
-(77) Scan parquet
+(75) Scan parquet
 Output [1]: [s_store_sk#8]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
@@ -212,7 +210,7 @@ Input [6]: [ss_sold_date_sk#1, ss_cdemo_sk#2, ss_addr_sk#3, ss_quantity#5, ss_sa
 Input [6]: [ss_sold_date_sk#1, ss_cdemo_sk#2, ss_addr_sk#3, ss_quantity#5, ss_sales_price#6, ss_net_profit#7]
 Arguments: [ss_cdemo_sk#2 ASC NULLS FIRST], false
 
-(85) Scan parquet
+(83) Scan parquet
 Output [3]: [cd_demo_sk#9, cd_marital_status#10, cd_education_status#11]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
@@ -246,368 +244,362 @@ Input [3]: [#9#9, #10#10, #11#11]
 Input [3]: [#9#9, #10#10, #11#11]
 Arguments: [cd_demo_sk#9 ASC NULLS FIRST], false
 
-(32) SortMergeJoin [codegen id : X]
+(32) NativeSortMergeJoin
 Left keys [1]: [ss_cdemo_sk#2]
 Right keys [1]: [cd_demo_sk#9]
 Join type: Inner
 Join condition: ((((((cd_marital_status#10 = M) AND (cd_education_status#11 = 4 yr Degree)) AND (ss_sales_price#6 >= 100.00)) AND (ss_sales_price#6 <= 150.00)) OR ((((cd_marital_status#10 = D) AND (cd_education_status#11 = 2 yr Degree)) AND (ss_sales_price#6 >= 50.00)) AND (ss_sales_price#6 <= 100.00))) OR ((((cd_marital_status#10 = S) AND (cd_education_status#11 = College)) AND (ss_sales_price#6 >= 150.00)) AND (ss_sales_price#6 <= 200.00)))
 
-(33) Project [codegen id : X]
+(33) NativeProject
 Output [4]: [ss_sold_date_sk#1, ss_addr_sk#3, ss_quantity#5, ss_net_profit#7]
 Input [9]: [ss_sold_date_sk#1, ss_cdemo_sk#2, ss_addr_sk#3, ss_quantity#5, ss_sales_price#6, ss_net_profit#7, #9#9, #10#10, #11#11]
 
-(34) ConvertToNative
-Input [4]: [ss_sold_date_sk#1, ss_addr_sk#3, ss_quantity#5, ss_net_profit#7]
-
-(35) NativeShuffleExchange
+(34) NativeShuffleExchange
 Input [4]: [ss_sold_date_sk#1, ss_addr_sk#3, ss_quantity#5, ss_net_profit#7]
 Arguments: hashpartitioning(ss_addr_sk#3, 100), ENSURE_REQUIREMENTS, [plan_id=5]
 
-(36) ShuffleQueryStage
+(35) ShuffleQueryStage
 Output [4]: [ss_sold_date_sk#1, ss_addr_sk#3, ss_quantity#5, ss_net_profit#7]
 Arguments: X
 
-(37) AQEShuffleRead
+(36) AQEShuffleRead
 Input [4]: [ss_sold_date_sk#1, ss_addr_sk#3, ss_quantity#5, ss_net_profit#7]
 Arguments: coalesced
 
-(38) InputAdapter
+(37) InputAdapter
 Input [4]: [ss_sold_date_sk#1, ss_addr_sk#3, ss_quantity#5, ss_net_profit#7]
 
-(39) NativeSort
+(38) NativeSort
 Input [4]: [ss_sold_date_sk#1, ss_addr_sk#3, ss_quantity#5, ss_net_profit#7]
 Arguments: [ss_addr_sk#3 ASC NULLS FIRST], false
 
-(93) Scan parquet
+(91) Scan parquet
 Output [3]: [ca_address_sk#12, ca_state#13, ca_country#14]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(ca_country), EqualTo(ca_country,United States), IsNotNull(ca_address_sk), Or(Or(In(ca_state, [CO,OH,TX]),In(ca_state, [KY,MN,OR])),In(ca_state, [CA,MS,VA]))]
 ReadSchema: struct<ca_address_sk:int,ca_state:string,ca_country:string>
 
-(41) InputAdapter
+(40) InputAdapter
 Input [3]: [ca_address_sk#12, ca_state#13, ca_country#14]
 Arguments: [#12, #13, #14]
 
-(42) NativeFilter
+(41) NativeFilter
 Input [3]: [#12#12, #13#13, #14#14]
 Condition : (((isnotnull(ca_country#14) AND (ca_country#14 = United States)) AND isnotnull(ca_address_sk#12)) AND ((ca_state#13 IN (CO,OH,TX) OR ca_state#13 IN (OR,MN,KY)) OR ca_state#13 IN (VA,CA,MS)))
 
-(43) NativeProject
+(42) NativeProject
 Output [2]: [ca_address_sk#12, ca_state#13]
 Input [3]: [#12#12, #13#13, #14#14]
 
-(44) NativeShuffleExchange
+(43) NativeShuffleExchange
 Input [2]: [ca_address_sk#12, ca_state#13]
 Arguments: hashpartitioning(ca_address_sk#12, 100), ENSURE_REQUIREMENTS, [plan_id=6]
 
-(45) ShuffleQueryStage
+(44) ShuffleQueryStage
 Output [2]: [ca_address_sk#12, ca_state#13]
 Arguments: X
 
-(46) AQEShuffleRead
+(45) AQEShuffleRead
 Input [2]: [ca_address_sk#12, ca_state#13]
 Arguments: coalesced
 
-(47) InputAdapter
+(46) InputAdapter
 Input [2]: [ca_address_sk#12, ca_state#13]
 
-(48) NativeSort
+(47) NativeSort
 Input [2]: [ca_address_sk#12, ca_state#13]
 Arguments: [ca_address_sk#12 ASC NULLS FIRST], false
 
-(49) SortMergeJoin [codegen id : X]
+(48) NativeSortMergeJoin
 Left keys [1]: [ss_addr_sk#3]
 Right keys [1]: [ca_address_sk#12]
 Join type: Inner
 Join condition: ((((ca_state#13 IN (CO,OH,TX) AND (ss_net_profit#7 >= 0.00)) AND (ss_net_profit#7 <= 2000.00)) OR ((ca_state#13 IN (OR,MN,KY) AND (ss_net_profit#7 >= 150.00)) AND (ss_net_profit#7 <= 3000.00))) OR ((ca_state#13 IN (VA,CA,MS) AND (ss_net_profit#7 >= 50.00)) AND (ss_net_profit#7 <= 25000.00)))
 
-(50) Project [codegen id : X]
+(49) NativeProject
 Output [2]: [ss_sold_date_sk#1, ss_quantity#5]
 Input [6]: [ss_sold_date_sk#1, ss_addr_sk#3, ss_quantity#5, ss_net_profit#7, ca_address_sk#12, ca_state#13]
 
-(51) ConvertToNative
-Input [2]: [ss_sold_date_sk#1, ss_quantity#5]
-
-(52) NativeShuffleExchange
+(50) NativeShuffleExchange
 Input [2]: [ss_sold_date_sk#1, ss_quantity#5]
 Arguments: hashpartitioning(ss_sold_date_sk#1, 100), ENSURE_REQUIREMENTS, [plan_id=7]
 
-(53) ShuffleQueryStage
+(51) ShuffleQueryStage
 Output [2]: [ss_sold_date_sk#1, ss_quantity#5]
 Arguments: X
 
-(54) AQEShuffleRead
+(52) AQEShuffleRead
 Input [2]: [ss_sold_date_sk#1, ss_quantity#5]
 Arguments: coalesced
 
-(55) InputAdapter
+(53) InputAdapter
 Input [2]: [ss_sold_date_sk#1, ss_quantity#5]
 
-(56) NativeSort
+(54) NativeSort
 Input [2]: [ss_sold_date_sk#1, ss_quantity#5]
 Arguments: [ss_sold_date_sk#1 ASC NULLS FIRST], false
 
-(102) Scan parquet
+(100) Scan parquet
 Output [2]: [d_date_sk#15, d_year#16]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2001), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
-(58) InputAdapter
+(56) InputAdapter
 Input [2]: [d_date_sk#15, d_year#16]
 Arguments: [#15, #16]
 
-(59) NativeFilter
+(57) NativeFilter
 Input [2]: [#15#15, #16#16]
 Condition : ((isnotnull(d_year#16) AND (d_year#16 = 2001)) AND isnotnull(d_date_sk#15))
 
-(60) NativeProject
+(58) NativeProject
 Output [1]: [d_date_sk#15]
 Input [2]: [#15#15, #16#16]
 
-(61) NativeShuffleExchange
+(59) NativeShuffleExchange
 Input [1]: [d_date_sk#15]
 Arguments: hashpartitioning(d_date_sk#15, 100), ENSURE_REQUIREMENTS, [plan_id=8]
 
-(62) ShuffleQueryStage
+(60) ShuffleQueryStage
 Output [1]: [d_date_sk#15]
 Arguments: X
 
-(63) AQEShuffleRead
+(61) AQEShuffleRead
 Input [1]: [d_date_sk#15]
 Arguments: coalesced
 
-(64) InputAdapter
+(62) InputAdapter
 Input [1]: [d_date_sk#15]
 
-(65) NativeSort
+(63) NativeSort
 Input [1]: [d_date_sk#15]
 Arguments: [d_date_sk#15 ASC NULLS FIRST], false
 
-(66) NativeSortMergeJoin
+(64) NativeSortMergeJoin
 Left keys [1]: [ss_sold_date_sk#1]
 Right keys [1]: [d_date_sk#15]
 Join type: Inner
 Join condition: None
 
-(67) NativeProject
+(65) NativeProject
 Output [1]: [ss_quantity#5]
 Input [3]: [ss_sold_date_sk#1, ss_quantity#5, d_date_sk#15]
 
-(68) NativeHashAggregate
+(66) NativeHashAggregate
 Input [1]: [ss_quantity#5]
 Keys: []
 Functions [1]: [partial_sum(ss_quantity#5)]
 Aggregate Attributes [1]: [sum#17]
 Results [1]: [#18]
 
-(69) NativeShuffleExchange
+(67) NativeShuffleExchange
 Input [1]: [#18]
 Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=9]
 
-(70) ShuffleQueryStage
+(68) ShuffleQueryStage
 Output [1]: [#18]
 Arguments: X
 
-(71) NativeHashAggregate
+(69) NativeHashAggregate
 Input [1]: [#18]
 Keys: []
 Functions [1]: [sum(ss_quantity#5)]
 Aggregate Attributes [1]: [sum(ss_quantity#5)#19]
 Results [1]: [sum(ss_quantity#5)#19]
 
-(72) NativeProject
+(70) NativeProject
 Output [1]: [sum(ss_quantity#5)#19 AS sum(ss_quantity)#20]
 Input [1]: [sum(ss_quantity#5)#19]
 
-(73) Scan parquet
+(71) Scan parquet
 Output [7]: [ss_sold_date_sk#1, ss_cdemo_sk#2, ss_addr_sk#3, ss_store_sk#4, ss_quantity#5, ss_sales_price#6, ss_net_profit#7]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(ss_store_sk), IsNotNull(ss_cdemo_sk), IsNotNull(ss_addr_sk), IsNotNull(ss_sold_date_sk), Or(Or(And(GreaterThanOrEqual(ss_sales_price,100.00),LessThanOrEqual(ss_sales_price,150.00)),And(GreaterThanOrEqual(ss_sales_price,50.00),LessThanOrEqual(ss_sales_price,100.00))),And(GreaterThanOrEqual(ss_sales_price,150.00),LessThanOrEqual(ss_sales_price,200.00))), Or(Or(And(GreaterThanOrEqual(ss_net_profit,0.00),LessThanOrEqual(ss_net_profit,2000.00)),And(GreaterThanOrEqual(ss_net_profit,150.00),LessThanOrEqual(ss_net_profit,3000.00))),And(GreaterThanOrEqual(ss_net_profit,50.00),LessThanOrEqual(ss_net_profit,25000.00)))]
 ReadSchema: struct<ss_sold_date_sk:int,ss_cdemo_sk:int,ss_addr_sk:int,ss_store_sk:int,ss_quantity:int,ss_sales_price:decimal(7,2),ss_net_profit:decimal(7,2)>
 
-(74) Filter
+(72) Filter
 Input [7]: [ss_sold_date_sk#1, ss_cdemo_sk#2, ss_addr_sk#3, ss_store_sk#4, ss_quantity#5, ss_sales_price#6, ss_net_profit#7]
 Condition : (((((isnotnull(ss_store_sk#4) AND isnotnull(ss_cdemo_sk#2)) AND isnotnull(ss_addr_sk#3)) AND isnotnull(ss_sold_date_sk#1)) AND ((((ss_sales_price#6 >= 100.00) AND (ss_sales_price#6 <= 150.00)) OR ((ss_sales_price#6 >= 50.00) AND (ss_sales_price#6 <= 100.00))) OR ((ss_sales_price#6 >= 150.00) AND (ss_sales_price#6 <= 200.00)))) AND ((((ss_net_profit#7 >= 0.00) AND (ss_net_profit#7 <= 2000.00)) OR ((ss_net_profit#7 >= 150.00) AND (ss_net_profit#7 <= 3000.00))) OR ((ss_net_profit#7 >= 50.00) AND (ss_net_profit#7 <= 25000.00))))
 
-(75) Exchange
+(73) Exchange
 Input [7]: [ss_sold_date_sk#1, ss_cdemo_sk#2, ss_addr_sk#3, ss_store_sk#4, ss_quantity#5, ss_sales_price#6, ss_net_profit#7]
 Arguments: hashpartitioning(ss_store_sk#4, 100), ENSURE_REQUIREMENTS, [plan_id=10]
 
-(76) Sort
+(74) Sort
 Input [7]: [ss_sold_date_sk#1, ss_cdemo_sk#2, ss_addr_sk#3, ss_store_sk#4, ss_quantity#5, ss_sales_price#6, ss_net_profit#7]
 Arguments: [ss_store_sk#4 ASC NULLS FIRST], false, 0
 
-(77) Scan parquet
+(75) Scan parquet
 Output [1]: [s_store_sk#8]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(s_store_sk)]
 ReadSchema: struct<s_store_sk:int>
 
-(78) Filter
+(76) Filter
 Input [1]: [s_store_sk#8]
 Condition : isnotnull(s_store_sk#8)
 
-(79) Exchange
+(77) Exchange
 Input [1]: [s_store_sk#8]
 Arguments: hashpartitioning(s_store_sk#8, 100), ENSURE_REQUIREMENTS, [plan_id=11]
 
-(80) Sort
+(78) Sort
 Input [1]: [s_store_sk#8]
 Arguments: [s_store_sk#8 ASC NULLS FIRST], false, 0
 
-(81) SortMergeJoin
+(79) SortMergeJoin
 Left keys [1]: [ss_store_sk#4]
 Right keys [1]: [s_store_sk#8]
 Join type: Inner
 Join condition: None
 
-(82) Project
+(80) Project
 Output [6]: [ss_sold_date_sk#1, ss_cdemo_sk#2, ss_addr_sk#3, ss_quantity#5, ss_sales_price#6, ss_net_profit#7]
 Input [8]: [ss_sold_date_sk#1, ss_cdemo_sk#2, ss_addr_sk#3, ss_store_sk#4, ss_quantity#5, ss_sales_price#6, ss_net_profit#7, s_store_sk#8]
 
-(83) Exchange
+(81) Exchange
 Input [6]: [ss_sold_date_sk#1, ss_cdemo_sk#2, ss_addr_sk#3, ss_quantity#5, ss_sales_price#6, ss_net_profit#7]
 Arguments: hashpartitioning(ss_cdemo_sk#2, 100), ENSURE_REQUIREMENTS, [plan_id=12]
 
-(84) Sort
+(82) Sort
 Input [6]: [ss_sold_date_sk#1, ss_cdemo_sk#2, ss_addr_sk#3, ss_quantity#5, ss_sales_price#6, ss_net_profit#7]
 Arguments: [ss_cdemo_sk#2 ASC NULLS FIRST], false, 0
 
-(85) Scan parquet
+(83) Scan parquet
 Output [3]: [cd_demo_sk#9, cd_marital_status#10, cd_education_status#11]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(cd_demo_sk), Or(Or(And(EqualTo(cd_marital_status,M),EqualTo(cd_education_status,4 yr Degree)),And(EqualTo(cd_marital_status,D),EqualTo(cd_education_status,2 yr Degree))),And(EqualTo(cd_marital_status,S),EqualTo(cd_education_status,College)))]
 ReadSchema: struct<cd_demo_sk:int,cd_marital_status:string,cd_education_status:string>
 
-(86) Filter
+(84) Filter
 Input [3]: [cd_demo_sk#9, cd_marital_status#10, cd_education_status#11]
 Condition : (isnotnull(cd_demo_sk#9) AND ((((cd_marital_status#10 = M) AND (cd_education_status#11 = 4 yr Degree)) OR ((cd_marital_status#10 = D) AND (cd_education_status#11 = 2 yr Degree))) OR ((cd_marital_status#10 = S) AND (cd_education_status#11 = College))))
 
-(87) Exchange
+(85) Exchange
 Input [3]: [cd_demo_sk#9, cd_marital_status#10, cd_education_status#11]
 Arguments: hashpartitioning(cd_demo_sk#9, 100), ENSURE_REQUIREMENTS, [plan_id=13]
 
-(88) Sort
+(86) Sort
 Input [3]: [cd_demo_sk#9, cd_marital_status#10, cd_education_status#11]
 Arguments: [cd_demo_sk#9 ASC NULLS FIRST], false, 0
 
-(89) SortMergeJoin
+(87) SortMergeJoin
 Left keys [1]: [ss_cdemo_sk#2]
 Right keys [1]: [cd_demo_sk#9]
 Join type: Inner
 Join condition: ((((((cd_marital_status#10 = M) AND (cd_education_status#11 = 4 yr Degree)) AND (ss_sales_price#6 >= 100.00)) AND (ss_sales_price#6 <= 150.00)) OR ((((cd_marital_status#10 = D) AND (cd_education_status#11 = 2 yr Degree)) AND (ss_sales_price#6 >= 50.00)) AND (ss_sales_price#6 <= 100.00))) OR ((((cd_marital_status#10 = S) AND (cd_education_status#11 = College)) AND (ss_sales_price#6 >= 150.00)) AND (ss_sales_price#6 <= 200.00)))
 
-(90) Project
+(88) Project
 Output [4]: [ss_sold_date_sk#1, ss_addr_sk#3, ss_quantity#5, ss_net_profit#7]
 Input [9]: [ss_sold_date_sk#1, ss_cdemo_sk#2, ss_addr_sk#3, ss_quantity#5, ss_sales_price#6, ss_net_profit#7, cd_demo_sk#9, cd_marital_status#10, cd_education_status#11]
 
-(91) Exchange
+(89) Exchange
 Input [4]: [ss_sold_date_sk#1, ss_addr_sk#3, ss_quantity#5, ss_net_profit#7]
 Arguments: hashpartitioning(ss_addr_sk#3, 100), ENSURE_REQUIREMENTS, [plan_id=14]
 
-(92) Sort
+(90) Sort
 Input [4]: [ss_sold_date_sk#1, ss_addr_sk#3, ss_quantity#5, ss_net_profit#7]
 Arguments: [ss_addr_sk#3 ASC NULLS FIRST], false, 0
 
-(93) Scan parquet
+(91) Scan parquet
 Output [3]: [ca_address_sk#12, ca_state#13, ca_country#14]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(ca_country), EqualTo(ca_country,United States), IsNotNull(ca_address_sk), Or(Or(In(ca_state, [CO,OH,TX]),In(ca_state, [KY,MN,OR])),In(ca_state, [CA,MS,VA]))]
 ReadSchema: struct<ca_address_sk:int,ca_state:string,ca_country:string>
 
-(94) Filter
+(92) Filter
 Input [3]: [ca_address_sk#12, ca_state#13, ca_country#14]
 Condition : (((isnotnull(ca_country#14) AND (ca_country#14 = United States)) AND isnotnull(ca_address_sk#12)) AND ((ca_state#13 IN (CO,OH,TX) OR ca_state#13 IN (OR,MN,KY)) OR ca_state#13 IN (VA,CA,MS)))
 
-(95) Project
+(93) Project
 Output [2]: [ca_address_sk#12, ca_state#13]
 Input [3]: [ca_address_sk#12, ca_state#13, ca_country#14]
 
-(96) Exchange
+(94) Exchange
 Input [2]: [ca_address_sk#12, ca_state#13]
 Arguments: hashpartitioning(ca_address_sk#12, 100), ENSURE_REQUIREMENTS, [plan_id=15]
 
-(97) Sort
+(95) Sort
 Input [2]: [ca_address_sk#12, ca_state#13]
 Arguments: [ca_address_sk#12 ASC NULLS FIRST], false, 0
 
-(98) SortMergeJoin
+(96) SortMergeJoin
 Left keys [1]: [ss_addr_sk#3]
 Right keys [1]: [ca_address_sk#12]
 Join type: Inner
 Join condition: ((((ca_state#13 IN (CO,OH,TX) AND (ss_net_profit#7 >= 0.00)) AND (ss_net_profit#7 <= 2000.00)) OR ((ca_state#13 IN (OR,MN,KY) AND (ss_net_profit#7 >= 150.00)) AND (ss_net_profit#7 <= 3000.00))) OR ((ca_state#13 IN (VA,CA,MS) AND (ss_net_profit#7 >= 50.00)) AND (ss_net_profit#7 <= 25000.00)))
 
-(99) Project
+(97) Project
 Output [2]: [ss_sold_date_sk#1, ss_quantity#5]
 Input [6]: [ss_sold_date_sk#1, ss_addr_sk#3, ss_quantity#5, ss_net_profit#7, ca_address_sk#12, ca_state#13]
 
-(100) Exchange
+(98) Exchange
 Input [2]: [ss_sold_date_sk#1, ss_quantity#5]
 Arguments: hashpartitioning(ss_sold_date_sk#1, 100), ENSURE_REQUIREMENTS, [plan_id=16]
 
-(101) Sort
+(99) Sort
 Input [2]: [ss_sold_date_sk#1, ss_quantity#5]
 Arguments: [ss_sold_date_sk#1 ASC NULLS FIRST], false, 0
 
-(102) Scan parquet
+(100) Scan parquet
 Output [2]: [d_date_sk#15, d_year#16]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2001), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
-(103) Filter
+(101) Filter
 Input [2]: [d_date_sk#15, d_year#16]
 Condition : ((isnotnull(d_year#16) AND (d_year#16 = 2001)) AND isnotnull(d_date_sk#15))
 
-(104) Project
+(102) Project
 Output [1]: [d_date_sk#15]
 Input [2]: [d_date_sk#15, d_year#16]
 
-(105) Exchange
+(103) Exchange
 Input [1]: [d_date_sk#15]
 Arguments: hashpartitioning(d_date_sk#15, 100), ENSURE_REQUIREMENTS, [plan_id=17]
 
-(106) Sort
+(104) Sort
 Input [1]: [d_date_sk#15]
 Arguments: [d_date_sk#15 ASC NULLS FIRST], false, 0
 
-(107) SortMergeJoin
+(105) SortMergeJoin
 Left keys [1]: [ss_sold_date_sk#1]
 Right keys [1]: [d_date_sk#15]
 Join type: Inner
 Join condition: None
 
-(108) Project
+(106) Project
 Output [1]: [ss_quantity#5]
 Input [3]: [ss_sold_date_sk#1, ss_quantity#5, d_date_sk#15]
 
-(109) HashAggregate
+(107) HashAggregate
 Input [1]: [ss_quantity#5]
 Keys: []
 Functions [1]: [partial_sum(ss_quantity#5)]
 Aggregate Attributes [1]: [sum#17]
 Results [1]: [sum#21]
 
-(110) Exchange
+(108) Exchange
 Input [1]: [sum#21]
 Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=18]
 
-(111) HashAggregate
+(109) HashAggregate
 Input [1]: [sum#21]
 Keys: []
 Functions [1]: [sum(ss_quantity#5)]
 Aggregate Attributes [1]: [sum(ss_quantity#5)#19]
 Results [1]: [sum(ss_quantity#5)#19 AS sum(ss_quantity)#20]
 
-(112) AdaptiveSparkPlan
+(110) AdaptiveSparkPlan
 Output [1]: [sum(ss_quantity)#20]
 Arguments: isFinalPlan=true
 

--- a/dev/auron-it/src/main/resources/tpcds-plan-stability/spark-3.5/q58.txt
+++ b/dev/auron-it/src/main/resources/tpcds-plan-stability/spark-3.5/q58.txt
@@ -1,11 +1,11 @@
 == Physical Plan ==
 AdaptiveSparkPlan (244)
 +- == Final Plan ==
-   TakeOrderedAndProject (142)
-   +- * Project (141)
-      +- * SortMergeJoin Inner (140)
-         :- * Project (100)
-         :  +- * SortMergeJoin Inner (99)
+   NativeTakeOrdered (142)
+   +- NativeProject (141)
+      +- NativeSortMergeJoin Inner (140)
+         :- NativeProject (100)
+         :  +- NativeSortMergeJoin Inner (99)
          :     :- NativeSort (59)
          :     :  +- NativeFilter (58)
          :     :     +- NativeProject (57)
@@ -662,13 +662,13 @@ Condition : isnotnull(cs_item_rev#28)
 Input [2]: [item_id#27, cs_item_rev#28]
 Arguments: [item_id#27 ASC NULLS FIRST], false
 
-(99) SortMergeJoin [codegen id : X]
+(99) NativeSortMergeJoin
 Left keys [1]: [item_id#16]
 Right keys [1]: [item_id#27]
 Join type: Inner
 Join condition: ((((cast(ss_item_rev#17 as decimal(19,3)) >= (0.9 * cs_item_rev#28)) AND (cast(ss_item_rev#17 as decimal(20,3)) <= (1.1 * cs_item_rev#28))) AND (cast(cs_item_rev#28 as decimal(19,3)) >= (0.9 * ss_item_rev#17))) AND (cast(cs_item_rev#28 as decimal(20,3)) <= (1.1 * ss_item_rev#17)))
 
-(100) Project [codegen id : X]
+(100) NativeProject
 Output [3]: [item_id#16, ss_item_rev#17, cs_item_rev#28]
 Input [4]: [item_id#16, ss_item_rev#17, item_id#27, cs_item_rev#28]
 
@@ -834,19 +834,19 @@ Condition : isnotnull(ws_item_rev#39)
 Input [2]: [item_id#38, ws_item_rev#39]
 Arguments: [item_id#38 ASC NULLS FIRST], false
 
-(140) SortMergeJoin [codegen id : X]
+(140) NativeSortMergeJoin
 Left keys [1]: [item_id#16]
 Right keys [1]: [item_id#38]
 Join type: Inner
 Join condition: ((((((((cast(ss_item_rev#17 as decimal(19,3)) >= (0.9 * ws_item_rev#39)) AND (cast(ss_item_rev#17 as decimal(20,3)) <= (1.1 * ws_item_rev#39))) AND (cast(cs_item_rev#28 as decimal(19,3)) >= (0.9 * ws_item_rev#39))) AND (cast(cs_item_rev#28 as decimal(20,3)) <= (1.1 * ws_item_rev#39))) AND (cast(ws_item_rev#39 as decimal(19,3)) >= (0.9 * ss_item_rev#17))) AND (cast(ws_item_rev#39 as decimal(20,3)) <= (1.1 * ss_item_rev#17))) AND (cast(ws_item_rev#39 as decimal(19,3)) >= (0.9 * cs_item_rev#28))) AND (cast(ws_item_rev#39 as decimal(20,3)) <= (1.1 * cs_item_rev#28)))
 
-(141) Project [codegen id : X]
+(141) NativeProject
 Output [8]: [item_id#16, ss_item_rev#17, (((ss_item_rev#17 / ((ss_item_rev#17 + cs_item_rev#28) + ws_item_rev#39)) / 3) * 100) AS ss_dev#40, cs_item_rev#28, (((cs_item_rev#28 / ((ss_item_rev#17 + cs_item_rev#28) + ws_item_rev#39)) / 3) * 100) AS cs_dev#41, ws_item_rev#39, (((ws_item_rev#39 / ((ss_item_rev#17 + cs_item_rev#28) + ws_item_rev#39)) / 3) * 100) AS ws_dev#42, (((ss_item_rev#17 + cs_item_rev#28) + ws_item_rev#39) / 3) AS average#43]
 Input [5]: [item_id#16, ss_item_rev#17, cs_item_rev#28, item_id#38, ws_item_rev#39]
 
-(142) TakeOrderedAndProject
+(142) NativeTakeOrdered
 Input [8]: [item_id#16, ss_item_rev#17, ss_dev#40, cs_item_rev#28, cs_dev#41, ws_item_rev#39, ws_dev#42, average#43]
-Arguments: X, [item_id#16 ASC NULLS FIRST, ss_item_rev#17 ASC NULLS FIRST], [item_id#16, ss_item_rev#17, ss_dev#40, cs_item_rev#28, cs_dev#41, ws_item_rev#39, ws_dev#42, average#43]
+Arguments: X, X, [item_id#16 ASC NULLS FIRST, ss_item_rev#17 ASC NULLS FIRST]
 
 (143) Scan parquet
 Output [3]: [ss_sold_date_sk#1, ss_item_sk#2, ss_ext_sales_price#3]

--- a/dev/auron-it/src/main/resources/tpcds-plan-stability/spark-3.5/q6.txt
+++ b/dev/auron-it/src/main/resources/tpcds-plan-stability/spark-3.5/q6.txt
@@ -1,18 +1,18 @@
 == Physical Plan ==
-AdaptiveSparkPlan (147)
+AdaptiveSparkPlan (146)
 +- == Final Plan ==
-   NativeProject (95)
-   +- NativeTakeOrdered (94)
-      +- NativeFilter (93)
-         +- NativeProject (92)
-            +- NativeHashAggregate (91)
-               +- InputAdapter (90)
-                  +- AQEShuffleRead (89)
-                     +- ShuffleQueryStage (88), Statistics(X)
-                        +- NativeShuffleExchange (87)
-                           +- NativeHashAggregate (86)
-                              +- NativeProject (85)
-                                 +- NativeSortMergeJoin Inner (84)
+   NativeProject (94)
+   +- NativeTakeOrdered (93)
+      +- NativeFilter (92)
+         +- NativeProject (91)
+            +- NativeHashAggregate (90)
+               +- InputAdapter (89)
+                  +- AQEShuffleRead (88)
+                     +- ShuffleQueryStage (87), Statistics(X)
+                        +- NativeShuffleExchange (86)
+                           +- NativeHashAggregate (85)
+                              +- NativeProject (84)
+                                 +- NativeSortMergeJoin Inner (83)
                                     :- NativeSort (54)
                                     :  +- InputAdapter (53)
                                     :     +- AQEShuffleRead (52)
@@ -67,90 +67,89 @@ AdaptiveSparkPlan (147)
                                     :                                      +- NativeFilter (41)
                                     :                                         +- InputAdapter (40)
                                     :                                            +- NativeParquetScan  (39)
-                                    +- NativeSort (83)
-                                       +- InputAdapter (82)
-                                          +- AQEShuffleRead (81)
-                                             +- ShuffleQueryStage (80), Statistics(X)
-                                                +- NativeShuffleExchange (79)
-                                                   +- ConvertToNative (78)
-                                                      +- * Project (77)
-                                                         +- * SortMergeJoin Inner (76)
-                                                            :- NativeSort (62)
-                                                            :  +- InputAdapter (61)
-                                                            :     +- AQEShuffleRead (60)
-                                                            :        +- ShuffleQueryStage (59), Statistics(X)
-                                                            :           +- NativeShuffleExchange (58)
-                                                            :              +- NativeFilter (57)
-                                                            :                 +- InputAdapter (56)
-                                                            :                    +- NativeParquetScan  (55)
-                                                            +- NativeSort (75)
-                                                               +- NativeFilter (74)
-                                                                  +- NativeProject (73)
-                                                                     +- NativeHashAggregate (72)
-                                                                        +- InputAdapter (71)
-                                                                           +- AQEShuffleRead (70)
-                                                                              +- ShuffleQueryStage (69), Statistics(X)
-                                                                                 +- NativeShuffleExchange (68)
-                                                                                    +- NativeHashAggregate (67)
-                                                                                       +- NativeProject (66)
-                                                                                          +- NativeFilter (65)
-                                                                                             +- InputAdapter (64)
-                                                                                                +- NativeParquetScan  (63)
+                                    +- NativeSort (82)
+                                       +- InputAdapter (81)
+                                          +- AQEShuffleRead (80)
+                                             +- ShuffleQueryStage (79), Statistics(X)
+                                                +- NativeShuffleExchange (78)
+                                                   +- NativeProject (77)
+                                                      +- NativeSortMergeJoin Inner (76)
+                                                         :- NativeSort (62)
+                                                         :  +- InputAdapter (61)
+                                                         :     +- AQEShuffleRead (60)
+                                                         :        +- ShuffleQueryStage (59), Statistics(X)
+                                                         :           +- NativeShuffleExchange (58)
+                                                         :              +- NativeFilter (57)
+                                                         :                 +- InputAdapter (56)
+                                                         :                    +- NativeParquetScan  (55)
+                                                         +- NativeSort (75)
+                                                            +- NativeFilter (74)
+                                                               +- NativeProject (73)
+                                                                  +- NativeHashAggregate (72)
+                                                                     +- InputAdapter (71)
+                                                                        +- AQEShuffleRead (70)
+                                                                           +- ShuffleQueryStage (69), Statistics(X)
+                                                                              +- NativeShuffleExchange (68)
+                                                                                 +- NativeHashAggregate (67)
+                                                                                    +- NativeProject (66)
+                                                                                       +- NativeFilter (65)
+                                                                                          +- InputAdapter (64)
+                                                                                             +- NativeParquetScan  (63)
 +- == Initial Plan ==
-   TakeOrderedAndProject (146)
-   +- Filter (145)
-      +- HashAggregate (144)
-         +- Exchange (143)
-            +- HashAggregate (142)
-               +- Project (141)
-                  +- SortMergeJoin Inner (140)
-                     :- Sort (124)
-                     :  +- Exchange (123)
-                     :     +- Project (122)
-                     :        +- SortMergeJoin Inner (121)
-                     :           :- Sort (115)
-                     :           :  +- Exchange (114)
-                     :           :     +- Project (113)
-                     :           :        +- SortMergeJoin Inner (112)
-                     :           :           :- Sort (107)
-                     :           :           :  +- Exchange (106)
-                     :           :           :     +- Project (105)
-                     :           :           :        +- SortMergeJoin Inner (104)
-                     :           :           :           :- Sort (99)
-                     :           :           :           :  +- Exchange (98)
-                     :           :           :           :     +- Filter (97)
-                     :           :           :           :        +- Scan parquet (96)
-                     :           :           :           +- Sort (103)
-                     :           :           :              +- Exchange (102)
-                     :           :           :                 +- Filter (101)
-                     :           :           :                    +- Scan parquet (100)
-                     :           :           +- Sort (111)
-                     :           :              +- Exchange (110)
-                     :           :                 +- Filter (109)
-                     :           :                    +- Scan parquet (108)
-                     :           +- Sort (120)
-                     :              +- Exchange (119)
-                     :                 +- Project (118)
-                     :                    +- Filter (117)
-                     :                       +- Scan parquet (116)
-                     +- Sort (139)
-                        +- Exchange (138)
-                           +- Project (137)
-                              +- SortMergeJoin Inner (136)
-                                 :- Sort (128)
-                                 :  +- Exchange (127)
-                                 :     +- Filter (126)
-                                 :        +- Scan parquet (125)
-                                 +- Sort (135)
-                                    +- Filter (134)
-                                       +- HashAggregate (133)
-                                          +- Exchange (132)
-                                             +- HashAggregate (131)
-                                                +- Filter (130)
-                                                   +- Scan parquet (129)
+   TakeOrderedAndProject (145)
+   +- Filter (144)
+      +- HashAggregate (143)
+         +- Exchange (142)
+            +- HashAggregate (141)
+               +- Project (140)
+                  +- SortMergeJoin Inner (139)
+                     :- Sort (123)
+                     :  +- Exchange (122)
+                     :     +- Project (121)
+                     :        +- SortMergeJoin Inner (120)
+                     :           :- Sort (114)
+                     :           :  +- Exchange (113)
+                     :           :     +- Project (112)
+                     :           :        +- SortMergeJoin Inner (111)
+                     :           :           :- Sort (106)
+                     :           :           :  +- Exchange (105)
+                     :           :           :     +- Project (104)
+                     :           :           :        +- SortMergeJoin Inner (103)
+                     :           :           :           :- Sort (98)
+                     :           :           :           :  +- Exchange (97)
+                     :           :           :           :     +- Filter (96)
+                     :           :           :           :        +- Scan parquet (95)
+                     :           :           :           +- Sort (102)
+                     :           :           :              +- Exchange (101)
+                     :           :           :                 +- Filter (100)
+                     :           :           :                    +- Scan parquet (99)
+                     :           :           +- Sort (110)
+                     :           :              +- Exchange (109)
+                     :           :                 +- Filter (108)
+                     :           :                    +- Scan parquet (107)
+                     :           +- Sort (119)
+                     :              +- Exchange (118)
+                     :                 +- Project (117)
+                     :                    +- Filter (116)
+                     :                       +- Scan parquet (115)
+                     +- Sort (138)
+                        +- Exchange (137)
+                           +- Project (136)
+                              +- SortMergeJoin Inner (135)
+                                 :- Sort (127)
+                                 :  +- Exchange (126)
+                                 :     +- Filter (125)
+                                 :        +- Scan parquet (124)
+                                 +- Sort (134)
+                                    +- Filter (133)
+                                       +- HashAggregate (132)
+                                          +- Exchange (131)
+                                             +- HashAggregate (130)
+                                                +- Filter (129)
+                                                   +- Scan parquet (128)
 
 
-(96) Scan parquet
+(95) Scan parquet
 Output [2]: [ca_address_sk#1, ca_state#2]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
@@ -184,7 +183,7 @@ Input [2]: [#1#1, #2#2]
 Input [2]: [#1#1, #2#2]
 Arguments: [ca_address_sk#1 ASC NULLS FIRST], false
 
-(100) Scan parquet
+(99) Scan parquet
 Output [2]: [c_customer_sk#3, c_current_addr_sk#4]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
@@ -247,7 +246,7 @@ Input [2]: [ca_state#2, c_customer_sk#3]
 Input [2]: [ca_state#2, c_customer_sk#3]
 Arguments: [c_customer_sk#3 ASC NULLS FIRST], false
 
-(108) Scan parquet
+(107) Scan parquet
 Output [3]: [ss_sold_date_sk#5, ss_item_sk#6, ss_customer_sk#7]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
@@ -310,7 +309,7 @@ Input [3]: [ca_state#2, ss_sold_date_sk#5, ss_item_sk#6]
 Input [3]: [ca_state#2, ss_sold_date_sk#5, ss_item_sk#6]
 Arguments: [ss_sold_date_sk#5 ASC NULLS FIRST], false
 
-(116) Scan parquet
+(115) Scan parquet
 Output [2]: [d_date_sk#8, d_month_seq#9]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
@@ -377,7 +376,7 @@ Input [2]: [ca_state#2, ss_item_sk#6]
 Input [2]: [ca_state#2, ss_item_sk#6]
 Arguments: [ss_item_sk#6 ASC NULLS FIRST], false
 
-(125) Scan parquet
+(124) Scan parquet
 Output [3]: [i_item_sk#12, i_current_price#13, i_category#14]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
@@ -411,7 +410,7 @@ Input [3]: [#12#12, #13#13, #14#14]
 Input [3]: [#12#12, #13#13, #14#14]
 Arguments: [i_category#14 ASC NULLS FIRST], false
 
-(129) Scan parquet
+(128) Scan parquet
 Output [2]: [i_current_price#15, i_category#16]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
@@ -471,452 +470,449 @@ Condition : isnotnull(avg(i_current_price)#23)
 Input [2]: [avg(i_current_price)#23, i_category#16]
 Arguments: [i_category#16 ASC NULLS FIRST], false
 
-(76) SortMergeJoin [codegen id : X]
+(76) NativeSortMergeJoin
 Left keys [1]: [i_category#14]
 Right keys [1]: [i_category#16]
 Join type: Inner
 Join condition: (cast(i_current_price#13 as decimal(14,7)) > (1.2 * avg(i_current_price)#23))
 
-(77) Project [codegen id : X]
+(77) NativeProject
 Output [1]: [i_item_sk#12]
 Input [5]: [#12#12, #13#13, #14#14, avg(i_current_price)#23, i_category#16]
 
-(78) ConvertToNative
-Input [1]: [i_item_sk#12]
-
-(79) NativeShuffleExchange
+(78) NativeShuffleExchange
 Input [1]: [i_item_sk#12]
 Arguments: hashpartitioning(i_item_sk#12, 100), ENSURE_REQUIREMENTS, [plan_id=10]
 
-(80) ShuffleQueryStage
+(79) ShuffleQueryStage
 Output [1]: [i_item_sk#12]
 Arguments: X
 
-(81) AQEShuffleRead
+(80) AQEShuffleRead
 Input [1]: [i_item_sk#12]
 Arguments: coalesced
 
-(82) InputAdapter
+(81) InputAdapter
 Input [1]: [i_item_sk#12]
 
-(83) NativeSort
+(82) NativeSort
 Input [1]: [i_item_sk#12]
 Arguments: [i_item_sk#12 ASC NULLS FIRST], false
 
-(84) NativeSortMergeJoin
+(83) NativeSortMergeJoin
 Left keys [1]: [ss_item_sk#6]
 Right keys [1]: [i_item_sk#12]
 Join type: Inner
 Join condition: None
 
-(85) NativeProject
+(84) NativeProject
 Output [1]: [ca_state#2]
 Input [3]: [ca_state#2, ss_item_sk#6, i_item_sk#12]
 
-(86) NativeHashAggregate
+(85) NativeHashAggregate
 Input [1]: [ca_state#2]
 Keys [1]: [ca_state#2]
 Functions [1]: [partial_count(1)]
 Aggregate Attributes [1]: [count#24]
 Results [2]: [ca_state#2, #21]
 
-(87) NativeShuffleExchange
+(86) NativeShuffleExchange
 Input [2]: [ca_state#2, #21]
 Arguments: hashpartitioning(ca_state#2, 100), ENSURE_REQUIREMENTS, [plan_id=11]
 
-(88) ShuffleQueryStage
+(87) ShuffleQueryStage
 Output [2]: [ca_state#2, #21]
 Arguments: X
 
-(89) AQEShuffleRead
+(88) AQEShuffleRead
 Input [2]: [ca_state#2, #21]
 Arguments: coalesced
 
-(90) InputAdapter
+(89) InputAdapter
 Input [2]: [ca_state#2, #21]
 
-(91) NativeHashAggregate
+(90) NativeHashAggregate
 Input [2]: [ca_state#2, #21]
 Keys [1]: [ca_state#2]
 Functions [1]: [count(1)]
 Aggregate Attributes [1]: [count(1)#25]
 Results [2]: [ca_state#2, count(1)#25]
 
-(92) NativeProject
+(91) NativeProject
 Output [3]: [ca_state#2 AS state#26, count(1)#25 AS cnt#27, ca_state#2]
 Input [2]: [ca_state#2, count(1)#25]
 
-(93) NativeFilter
+(92) NativeFilter
 Input [3]: [state#26, cnt#27, ca_state#2]
 Condition : (cnt#27 >= 10)
 
-(94) NativeTakeOrdered
+(93) NativeTakeOrdered
 Input [3]: [state#26, cnt#27, ca_state#2]
 Arguments: X, X, [cnt#27 ASC NULLS FIRST, ca_state#2 ASC NULLS FIRST]
 
-(95) NativeProject
+(94) NativeProject
 Output [2]: [state#26, cnt#27]
 Input [3]: [state#26, cnt#27, ca_state#2]
 
-(96) Scan parquet
+(95) Scan parquet
 Output [2]: [ca_address_sk#1, ca_state#2]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(ca_address_sk)]
 ReadSchema: struct<ca_address_sk:int,ca_state:string>
 
-(97) Filter
+(96) Filter
 Input [2]: [ca_address_sk#1, ca_state#2]
 Condition : isnotnull(ca_address_sk#1)
 
-(98) Exchange
+(97) Exchange
 Input [2]: [ca_address_sk#1, ca_state#2]
 Arguments: hashpartitioning(ca_address_sk#1, 100), ENSURE_REQUIREMENTS, [plan_id=12]
 
-(99) Sort
+(98) Sort
 Input [2]: [ca_address_sk#1, ca_state#2]
 Arguments: [ca_address_sk#1 ASC NULLS FIRST], false, 0
 
-(100) Scan parquet
+(99) Scan parquet
 Output [2]: [c_customer_sk#3, c_current_addr_sk#4]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(c_current_addr_sk), IsNotNull(c_customer_sk)]
 ReadSchema: struct<c_customer_sk:int,c_current_addr_sk:int>
 
-(101) Filter
+(100) Filter
 Input [2]: [c_customer_sk#3, c_current_addr_sk#4]
 Condition : (isnotnull(c_current_addr_sk#4) AND isnotnull(c_customer_sk#3))
 
-(102) Exchange
+(101) Exchange
 Input [2]: [c_customer_sk#3, c_current_addr_sk#4]
 Arguments: hashpartitioning(c_current_addr_sk#4, 100), ENSURE_REQUIREMENTS, [plan_id=13]
 
-(103) Sort
+(102) Sort
 Input [2]: [c_customer_sk#3, c_current_addr_sk#4]
 Arguments: [c_current_addr_sk#4 ASC NULLS FIRST], false, 0
 
-(104) SortMergeJoin
+(103) SortMergeJoin
 Left keys [1]: [ca_address_sk#1]
 Right keys [1]: [c_current_addr_sk#4]
 Join type: Inner
 Join condition: None
 
-(105) Project
+(104) Project
 Output [2]: [ca_state#2, c_customer_sk#3]
 Input [4]: [ca_address_sk#1, ca_state#2, c_customer_sk#3, c_current_addr_sk#4]
 
-(106) Exchange
+(105) Exchange
 Input [2]: [ca_state#2, c_customer_sk#3]
 Arguments: hashpartitioning(c_customer_sk#3, 100), ENSURE_REQUIREMENTS, [plan_id=14]
 
-(107) Sort
+(106) Sort
 Input [2]: [ca_state#2, c_customer_sk#3]
 Arguments: [c_customer_sk#3 ASC NULLS FIRST], false, 0
 
-(108) Scan parquet
+(107) Scan parquet
 Output [3]: [ss_sold_date_sk#5, ss_item_sk#6, ss_customer_sk#7]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(ss_customer_sk), IsNotNull(ss_sold_date_sk), IsNotNull(ss_item_sk)]
 ReadSchema: struct<ss_sold_date_sk:int,ss_item_sk:int,ss_customer_sk:int>
 
-(109) Filter
+(108) Filter
 Input [3]: [ss_sold_date_sk#5, ss_item_sk#6, ss_customer_sk#7]
 Condition : ((isnotnull(ss_customer_sk#7) AND isnotnull(ss_sold_date_sk#5)) AND isnotnull(ss_item_sk#6))
 
-(110) Exchange
+(109) Exchange
 Input [3]: [ss_sold_date_sk#5, ss_item_sk#6, ss_customer_sk#7]
 Arguments: hashpartitioning(ss_customer_sk#7, 100), ENSURE_REQUIREMENTS, [plan_id=15]
 
-(111) Sort
+(110) Sort
 Input [3]: [ss_sold_date_sk#5, ss_item_sk#6, ss_customer_sk#7]
 Arguments: [ss_customer_sk#7 ASC NULLS FIRST], false, 0
 
-(112) SortMergeJoin
+(111) SortMergeJoin
 Left keys [1]: [c_customer_sk#3]
 Right keys [1]: [ss_customer_sk#7]
 Join type: Inner
 Join condition: None
 
-(113) Project
+(112) Project
 Output [3]: [ca_state#2, ss_sold_date_sk#5, ss_item_sk#6]
 Input [5]: [ca_state#2, c_customer_sk#3, ss_sold_date_sk#5, ss_item_sk#6, ss_customer_sk#7]
 
-(114) Exchange
+(113) Exchange
 Input [3]: [ca_state#2, ss_sold_date_sk#5, ss_item_sk#6]
 Arguments: hashpartitioning(ss_sold_date_sk#5, 100), ENSURE_REQUIREMENTS, [plan_id=16]
 
-(115) Sort
+(114) Sort
 Input [3]: [ca_state#2, ss_sold_date_sk#5, ss_item_sk#6]
 Arguments: [ss_sold_date_sk#5 ASC NULLS FIRST], false, 0
 
-(116) Scan parquet
+(115) Scan parquet
 Output [2]: [d_date_sk#8, d_month_seq#9]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(d_month_seq), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_month_seq:int>
 
-(117) Filter
+(116) Filter
 Input [2]: [d_date_sk#8, d_month_seq#9]
 Condition : ((isnotnull(d_month_seq#9) AND (d_month_seq#9 = Subquery subquery#10, [id=#11])) AND isnotnull(d_date_sk#8))
 
-(118) Project
+(117) Project
 Output [1]: [d_date_sk#8]
 Input [2]: [d_date_sk#8, d_month_seq#9]
 
-(119) Exchange
+(118) Exchange
 Input [1]: [d_date_sk#8]
 Arguments: hashpartitioning(d_date_sk#8, 100), ENSURE_REQUIREMENTS, [plan_id=17]
 
-(120) Sort
+(119) Sort
 Input [1]: [d_date_sk#8]
 Arguments: [d_date_sk#8 ASC NULLS FIRST], false, 0
 
-(121) SortMergeJoin
+(120) SortMergeJoin
 Left keys [1]: [ss_sold_date_sk#5]
 Right keys [1]: [d_date_sk#8]
 Join type: Inner
 Join condition: None
 
-(122) Project
+(121) Project
 Output [2]: [ca_state#2, ss_item_sk#6]
 Input [4]: [ca_state#2, ss_sold_date_sk#5, ss_item_sk#6, d_date_sk#8]
 
-(123) Exchange
+(122) Exchange
 Input [2]: [ca_state#2, ss_item_sk#6]
 Arguments: hashpartitioning(ss_item_sk#6, 100), ENSURE_REQUIREMENTS, [plan_id=18]
 
-(124) Sort
+(123) Sort
 Input [2]: [ca_state#2, ss_item_sk#6]
 Arguments: [ss_item_sk#6 ASC NULLS FIRST], false, 0
 
-(125) Scan parquet
+(124) Scan parquet
 Output [3]: [i_item_sk#12, i_current_price#13, i_category#14]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(i_current_price), IsNotNull(i_category), IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_current_price:decimal(7,2),i_category:string>
 
-(126) Filter
+(125) Filter
 Input [3]: [i_item_sk#12, i_current_price#13, i_category#14]
 Condition : ((isnotnull(i_current_price#13) AND isnotnull(i_category#14)) AND isnotnull(i_item_sk#12))
 
-(127) Exchange
+(126) Exchange
 Input [3]: [i_item_sk#12, i_current_price#13, i_category#14]
 Arguments: hashpartitioning(i_category#14, 100), ENSURE_REQUIREMENTS, [plan_id=19]
 
-(128) Sort
+(127) Sort
 Input [3]: [i_item_sk#12, i_current_price#13, i_category#14]
 Arguments: [i_category#14 ASC NULLS FIRST], false, 0
 
-(129) Scan parquet
+(128) Scan parquet
 Output [2]: [i_current_price#15, i_category#16]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(i_category)]
 ReadSchema: struct<i_current_price:decimal(7,2),i_category:string>
 
-(130) Filter
+(129) Filter
 Input [2]: [i_current_price#15, i_category#16]
 Condition : isnotnull(i_category#16)
 
-(131) HashAggregate
+(130) HashAggregate
 Input [2]: [i_current_price#15, i_category#16]
 Keys [1]: [i_category#16]
 Functions [1]: [partial_avg(UnscaledValue(i_current_price#15))]
 Aggregate Attributes [2]: [sum#18, count#19]
 Results [3]: [i_category#16, sum#28, count#29]
 
-(132) Exchange
+(131) Exchange
 Input [3]: [i_category#16, sum#28, count#29]
 Arguments: hashpartitioning(i_category#16, 100), ENSURE_REQUIREMENTS, [plan_id=20]
 
-(133) HashAggregate
+(132) HashAggregate
 Input [3]: [i_category#16, sum#28, count#29]
 Keys [1]: [i_category#16]
 Functions [1]: [avg(UnscaledValue(i_current_price#15))]
 Aggregate Attributes [1]: [avg(UnscaledValue(i_current_price#15))#22]
 Results [2]: [cast((avg(UnscaledValue(i_current_price#15))#22 / 100.0) as decimal(11,6)) AS avg(i_current_price)#23, i_category#16]
 
-(134) Filter
+(133) Filter
 Input [2]: [avg(i_current_price)#23, i_category#16]
 Condition : isnotnull(avg(i_current_price)#23)
 
-(135) Sort
+(134) Sort
 Input [2]: [avg(i_current_price)#23, i_category#16]
 Arguments: [i_category#16 ASC NULLS FIRST], false, 0
 
-(136) SortMergeJoin
+(135) SortMergeJoin
 Left keys [1]: [i_category#14]
 Right keys [1]: [i_category#16]
 Join type: Inner
 Join condition: (cast(i_current_price#13 as decimal(14,7)) > (1.2 * avg(i_current_price)#23))
 
-(137) Project
+(136) Project
 Output [1]: [i_item_sk#12]
 Input [5]: [i_item_sk#12, i_current_price#13, i_category#14, avg(i_current_price)#23, i_category#16]
 
-(138) Exchange
+(137) Exchange
 Input [1]: [i_item_sk#12]
 Arguments: hashpartitioning(i_item_sk#12, 100), ENSURE_REQUIREMENTS, [plan_id=21]
 
-(139) Sort
+(138) Sort
 Input [1]: [i_item_sk#12]
 Arguments: [i_item_sk#12 ASC NULLS FIRST], false, 0
 
-(140) SortMergeJoin
+(139) SortMergeJoin
 Left keys [1]: [ss_item_sk#6]
 Right keys [1]: [i_item_sk#12]
 Join type: Inner
 Join condition: None
 
-(141) Project
+(140) Project
 Output [1]: [ca_state#2]
 Input [3]: [ca_state#2, ss_item_sk#6, i_item_sk#12]
 
-(142) HashAggregate
+(141) HashAggregate
 Input [1]: [ca_state#2]
 Keys [1]: [ca_state#2]
 Functions [1]: [partial_count(1)]
 Aggregate Attributes [1]: [count#24]
 Results [2]: [ca_state#2, count#30]
 
-(143) Exchange
+(142) Exchange
 Input [2]: [ca_state#2, count#30]
 Arguments: hashpartitioning(ca_state#2, 100), ENSURE_REQUIREMENTS, [plan_id=22]
 
-(144) HashAggregate
+(143) HashAggregate
 Input [2]: [ca_state#2, count#30]
 Keys [1]: [ca_state#2]
 Functions [1]: [count(1)]
 Aggregate Attributes [1]: [count(1)#25]
 Results [3]: [ca_state#2 AS state#26, count(1)#25 AS cnt#27, ca_state#2]
 
-(145) Filter
+(144) Filter
 Input [3]: [state#26, cnt#27, ca_state#2]
 Condition : (cnt#27 >= 10)
 
-(146) TakeOrderedAndProject
+(145) TakeOrderedAndProject
 Input [3]: [state#26, cnt#27, ca_state#2]
 Arguments: X, [cnt#27 ASC NULLS FIRST, ca_state#2 ASC NULLS FIRST], [state#26, cnt#27]
 
-(147) AdaptiveSparkPlan
+(146) AdaptiveSparkPlan
 Output [2]: [state#26, cnt#27]
 Arguments: isFinalPlan=true
 
 ===== Subqueries =====
 
 Subquery:1 Hosting operator id = 41 Hosting Expression = Subquery subquery#10, [id=#11]
-AdaptiveSparkPlan (165)
+AdaptiveSparkPlan (164)
 +- == Final Plan ==
-   NativeProject (158)
-   +- NativeHashAggregate (157)
-      +- InputAdapter (156)
-         +- AQEShuffleRead (155)
-            +- ShuffleQueryStage (154), Statistics(X)
-               +- NativeShuffleExchange (153)
-                  +- NativeHashAggregate (152)
-                     +- NativeProject (151)
-                        +- NativeFilter (150)
-                           +- InputAdapter (149)
-                              +- NativeParquetScan  (148)
+   NativeProject (157)
+   +- NativeHashAggregate (156)
+      +- InputAdapter (155)
+         +- AQEShuffleRead (154)
+            +- ShuffleQueryStage (153), Statistics(X)
+               +- NativeShuffleExchange (152)
+                  +- NativeHashAggregate (151)
+                     +- NativeProject (150)
+                        +- NativeFilter (149)
+                           +- InputAdapter (148)
+                              +- NativeParquetScan  (147)
 +- == Initial Plan ==
-   HashAggregate (164)
-   +- Exchange (163)
-      +- HashAggregate (162)
-         +- Project (161)
-            +- Filter (160)
-               +- Scan parquet (159)
+   HashAggregate (163)
+   +- Exchange (162)
+      +- HashAggregate (161)
+         +- Project (160)
+            +- Filter (159)
+               +- Scan parquet (158)
 
 
-(159) Scan parquet
+(158) Scan parquet
 Output [3]: [d_month_seq#31, d_year#32, d_moy#33]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(d_year), IsNotNull(d_moy), EqualTo(d_year,2000), EqualTo(d_moy,1)]
 ReadSchema: struct<d_month_seq:int,d_year:int,d_moy:int>
 
-(149) InputAdapter
+(148) InputAdapter
 Input [3]: [d_month_seq#31, d_year#32, d_moy#33]
 Arguments: [#31, #32, #33]
 
-(150) NativeFilter
+(149) NativeFilter
 Input [3]: [#31#31, #32#32, #33#33]
 Condition : (((isnotnull(d_year#32) AND isnotnull(d_moy#33)) AND (d_year#32 = 2000)) AND (d_moy#33 = 1))
 
-(151) NativeProject
+(150) NativeProject
 Output [1]: [d_month_seq#31]
 Input [3]: [#31#31, #32#32, #33#33]
 
-(152) NativeHashAggregate
+(151) NativeHashAggregate
 Input [1]: [d_month_seq#31]
 Keys [1]: [d_month_seq#31]
 Functions: []
 Aggregate Attributes: []
 Results [1]: [d_month_seq#31]
 
-(153) NativeShuffleExchange
+(152) NativeShuffleExchange
 Input [1]: [d_month_seq#31]
 Arguments: hashpartitioning(d_month_seq#31, 100), ENSURE_REQUIREMENTS, [plan_id=23]
 
-(154) ShuffleQueryStage
+(153) ShuffleQueryStage
 Output [1]: [d_month_seq#31]
 Arguments: X
 
-(155) AQEShuffleRead
+(154) AQEShuffleRead
 Input [1]: [d_month_seq#31]
 Arguments: coalesced
 
-(156) InputAdapter
+(155) InputAdapter
 Input [1]: [d_month_seq#31]
 
-(157) NativeHashAggregate
+(156) NativeHashAggregate
 Input [1]: [d_month_seq#31]
 Keys [1]: [d_month_seq#31]
 Functions: []
 Aggregate Attributes: []
 Results [1]: [d_month_seq#31]
 
-(158) NativeProject
+(157) NativeProject
 Output [1]: [d_month_seq#31]
 Input [1]: [d_month_seq#31]
 
-(159) Scan parquet
+(158) Scan parquet
 Output [3]: [d_month_seq#31, d_year#32, d_moy#33]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(d_year), IsNotNull(d_moy), EqualTo(d_year,2000), EqualTo(d_moy,1)]
 ReadSchema: struct<d_month_seq:int,d_year:int,d_moy:int>
 
-(160) Filter
+(159) Filter
 Input [3]: [d_month_seq#31, d_year#32, d_moy#33]
 Condition : (((isnotnull(d_year#32) AND isnotnull(d_moy#33)) AND (d_year#32 = 2000)) AND (d_moy#33 = 1))
 
-(161) Project
+(160) Project
 Output [1]: [d_month_seq#31]
 Input [3]: [d_month_seq#31, d_year#32, d_moy#33]
 
-(162) HashAggregate
+(161) HashAggregate
 Input [1]: [d_month_seq#31]
 Keys [1]: [d_month_seq#31]
 Functions: []
 Aggregate Attributes: []
 Results [1]: [d_month_seq#31]
 
-(163) Exchange
+(162) Exchange
 Input [1]: [d_month_seq#31]
 Arguments: hashpartitioning(d_month_seq#31, 100), ENSURE_REQUIREMENTS, [plan_id=24]
 
-(164) HashAggregate
+(163) HashAggregate
 Input [1]: [d_month_seq#31]
 Keys [1]: [d_month_seq#31]
 Functions: []
 Aggregate Attributes: []
 Results [1]: [d_month_seq#31]
 
-(165) AdaptiveSparkPlan
+(164) AdaptiveSparkPlan
 Output [1]: [d_month_seq#31]
 Arguments: isFinalPlan=true
 

--- a/dev/auron-it/src/main/resources/tpcds-plan-stability/spark-3.5/q64.txt
+++ b/dev/auron-it/src/main/resources/tpcds-plan-stability/spark-3.5/q64.txt
@@ -1,820 +1,817 @@
 == Physical Plan ==
-AdaptiveSparkPlan (811)
+AdaptiveSparkPlan (808)
 +- == Final Plan ==
-   NativeSort (496)
-   +- InputAdapter (495)
-      +- AQEShuffleRead (494)
-         +- ShuffleQueryStage (493), Statistics(X)
-            +- NativeShuffleExchange (492)
-               +- ConvertToNative (491)
-                  +- * Project (490)
-                     +- * SortMergeJoin Inner (489)
-                        :- NativeSort (280)
-                        :  +- InputAdapter (279)
-                        :     +- AQEShuffleRead (278)
-                        :        +- ShuffleQueryStage (277), Statistics(X)
-                        :           +- NativeShuffleExchange (276)
-                        :              +- NativeProject (275)
-                        :                 +- NativeHashAggregate (274)
-                        :                    +- NativeHashAggregate (273)
-                        :                       +- NativeProject (272)
-                        :                          +- NativeProject (271)
-                        :                             +- NativeSortMergeJoin Inner (270)
-                        :                                :- NativeSort (260)
-                        :                                :  +- InputAdapter (259)
-                        :                                :     +- AQEShuffleRead (258)
-                        :                                :        +- ShuffleQueryStage (257), Statistics(X)
-                        :                                :           +- NativeShuffleExchange (256)
-                        :                                :              +- NativeProject (255)
-                        :                                :                 +- NativeSortMergeJoin Inner (254)
-                        :                                :                    :- NativeSort (247)
-                        :                                :                    :  +- InputAdapter (246)
-                        :                                :                    :     +- AQEShuffleRead (245)
-                        :                                :                    :        +- ShuffleQueryStage (244), Statistics(X)
-                        :                                :                    :           +- NativeShuffleExchange (243)
-                        :                                :                    :              +- NativeProject (242)
-                        :                                :                    :                 +- NativeSortMergeJoin Inner (241)
-                        :                                :                    :                    :- NativeSort (232)
-                        :                                :                    :                    :  +- InputAdapter (231)
-                        :                                :                    :                    :     +- AQEShuffleRead (230)
-                        :                                :                    :                    :        +- ShuffleQueryStage (229), Statistics(X)
-                        :                                :                    :                    :           +- NativeShuffleExchange (228)
-                        :                                :                    :                    :              +- NativeProject (227)
-                        :                                :                    :                    :                 +- NativeSortMergeJoin Inner (226)
-                        :                                :                    :                    :                    :- NativeSort (219)
-                        :                                :                    :                    :                    :  +- InputAdapter (218)
-                        :                                :                    :                    :                    :     +- AQEShuffleRead (217)
-                        :                                :                    :                    :                    :        +- ShuffleQueryStage (216), Statistics(X)
-                        :                                :                    :                    :                    :           +- NativeShuffleExchange (215)
-                        :                                :                    :                    :                    :              +- NativeProject (214)
-                        :                                :                    :                    :                    :                 +- NativeSortMergeJoin Inner (213)
-                        :                                :                    :                    :                    :                    :- NativeSort (204)
-                        :                                :                    :                    :                    :                    :  +- InputAdapter (203)
-                        :                                :                    :                    :                    :                    :     +- AQEShuffleRead (202)
-                        :                                :                    :                    :                    :                    :        +- ShuffleQueryStage (201), Statistics(X)
-                        :                                :                    :                    :                    :                    :           +- NativeShuffleExchange (200)
-                        :                                :                    :                    :                    :                    :              +- NativeProject (199)
-                        :                                :                    :                    :                    :                    :                 +- NativeSortMergeJoin Inner (198)
-                        :                                :                    :                    :                    :                    :                    :- NativeSort (191)
-                        :                                :                    :                    :                    :                    :                    :  +- InputAdapter (190)
-                        :                                :                    :                    :                    :                    :                    :     +- AQEShuffleRead (189)
-                        :                                :                    :                    :                    :                    :                    :        +- ShuffleQueryStage (188), Statistics(X)
-                        :                                :                    :                    :                    :                    :                    :           +- NativeShuffleExchange (187)
-                        :                                :                    :                    :                    :                    :                    :              +- NativeProject (186)
-                        :                                :                    :                    :                    :                    :                    :                 +- NativeSortMergeJoin Inner (185)
-                        :                                :                    :                    :                    :                    :                    :                    :- NativeSort (176)
-                        :                                :                    :                    :                    :                    :                    :                    :  +- InputAdapter (175)
-                        :                                :                    :                    :                    :                    :                    :                    :     +- AQEShuffleRead (174)
-                        :                                :                    :                    :                    :                    :                    :                    :        +- ShuffleQueryStage (173), Statistics(X)
-                        :                                :                    :                    :                    :                    :                    :                    :           +- NativeShuffleExchange (172)
-                        :                                :                    :                    :                    :                    :                    :                    :              +- NativeProject (171)
-                        :                                :                    :                    :                    :                    :                    :                    :                 +- NativeSortMergeJoin Inner (170)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :- NativeSort (161)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :  +- InputAdapter (160)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :     +- AQEShuffleRead (159)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :        +- ShuffleQueryStage (158), Statistics(X)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :           +- NativeShuffleExchange (157)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :              +- ConvertToNative (156)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                 +- * Project (155)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                    +- * SortMergeJoin Inner (154)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :- NativeSort (147)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :  +- InputAdapter (146)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :     +- AQEShuffleRead (145)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :        +- ShuffleQueryStage (144), Statistics(X)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :           +- NativeShuffleExchange (143)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :              +- NativeProject (142)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                 +- NativeSortMergeJoin Inner (141)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :- NativeSort (132)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :  +- InputAdapter (131)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :     +- AQEShuffleRead (130)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :        +- ShuffleQueryStage (129), Statistics(X)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :           +- NativeShuffleExchange (128)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :              +- NativeProject (127)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                 +- NativeSortMergeJoin Inner (126)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :- NativeSort (119)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :  +- InputAdapter (118)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :     +- AQEShuffleRead (117)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :        +- ShuffleQueryStage (116), Statistics(X)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :           +- NativeShuffleExchange (115)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :              +- NativeProject (114)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                 +- NativeSortMergeJoin Inner (113)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :- NativeSort (104)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :  +- InputAdapter (103)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :     +- AQEShuffleRead (102)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :        +- ShuffleQueryStage (101), Statistics(X)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :           +- NativeShuffleExchange (100)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :              +- NativeProject (99)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                 +- NativeSortMergeJoin Inner (98)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :- NativeSort (89)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :  +- InputAdapter (88)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :     +- AQEShuffleRead (87)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :        +- ShuffleQueryStage (86), Statistics(X)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :           +- NativeShuffleExchange (85)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :              +- NativeProject (84)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                 +- NativeSortMergeJoin Inner (83)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :- NativeSort (74)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :  +- InputAdapter (73)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :     +- AQEShuffleRead (72)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :        +- ShuffleQueryStage (71), Statistics(X)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :           +- NativeShuffleExchange (70)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :              +- NativeProject (69)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                 +- NativeSortMergeJoin Inner (68)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                    :- NativeSort (59)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                    :  +- InputAdapter (58)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                    :     +- AQEShuffleRead (57)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                    :        +- ShuffleQueryStage (56), Statistics(X)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                    :           +- NativeShuffleExchange (55)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                    :              +- NativeProject (54)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                    :                 +- NativeSortMergeJoin Inner (53)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                    :                    :- NativeSort (23)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                    :                    :  +- InputAdapter (22)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                    :                    :     +- AQEShuffleRead (21)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                    :                    :        +- ShuffleQueryStage (20), Statistics(X)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                    :                    :           +- NativeShuffleExchange (19)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                    :                    :              +- NativeProject (18)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                    :                    :                 +- NativeSortMergeJoin Inner (17)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                    :                    :                    :- NativeSort (8)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                    :                    :                    :  +- InputAdapter (7)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                    :                    :                    :     +- AQEShuffleRead (6)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                    :                    :                    :        +- ShuffleQueryStage (5), Statistics(X)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                    :                    :                    :           +- NativeShuffleExchange (4)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                    :                    :                    :              +- NativeFilter (3)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                    :                    :                    :                 +- InputAdapter (2)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                    :                    :                    :                    +- NativeParquetScan  (1)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                    :                    :                    +- NativeSort (16)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                    :                    :                       +- InputAdapter (15)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                    :                    :                          +- AQEShuffleRead (14)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                    :                    :                             +- ShuffleQueryStage (13), Statistics(X)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                    :                    :                                +- NativeShuffleExchange (12)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                    :                    :                                   +- NativeFilter (11)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                    :                    :                                      +- InputAdapter (10)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                    :                    :                                         +- NativeParquetScan  (9)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                    :                    +- NativeSort (52)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                    :                       +- NativeProject (51)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                    :                          +- NativeFilter (50)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                    :                             +- NativeProject (49)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                    :                                +- NativeHashAggregate (48)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                    :                                   +- InputAdapter (47)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                    :                                      +- AQEShuffleRead (46)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                    :                                         +- ShuffleQueryStage (45), Statistics(X)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                    :                                            +- NativeShuffleExchange (44)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                    :                                               +- NativeHashAggregate (43)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                    :                                                  +- NativeProject (42)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                    :                                                     +- NativeProject (41)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                    :                                                        +- NativeSortMergeJoin Inner (40)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                    :                                                           :- NativeSort (31)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                    :                                                           :  +- InputAdapter (30)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                    :                                                           :     +- AQEShuffleRead (29)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                    :                                                           :        +- ShuffleQueryStage (28), Statistics(X)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                    :                                                           :           +- NativeShuffleExchange (27)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                    :                                                           :              +- NativeFilter (26)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                    :                                                           :                 +- InputAdapter (25)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                    :                                                           :                    +- NativeParquetScan  (24)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                    :                                                           +- NativeSort (39)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                    :                                                              +- InputAdapter (38)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                    :                                                                 +- AQEShuffleRead (37)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                    :                                                                    +- ShuffleQueryStage (36), Statistics(X)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                    :                                                                       +- NativeShuffleExchange (35)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                    :                                                                          +- NativeFilter (34)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                    :                                                                             +- InputAdapter (33)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                    :                                                                                +- NativeParquetScan  (32)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                    +- NativeSort (67)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                       +- InputAdapter (66)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                          +- AQEShuffleRead (65)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                             +- ShuffleQueryStage (64), Statistics(X)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                                +- NativeShuffleExchange (63)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                                   +- NativeFilter (62)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                                      +- InputAdapter (61)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                                         +- NativeParquetScan  (60)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    +- NativeSort (82)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                       +- InputAdapter (81)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                          +- AQEShuffleRead (80)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                             +- ShuffleQueryStage (79), Statistics(X)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                                +- NativeShuffleExchange (78)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                                   +- NativeFilter (77)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                                      +- InputAdapter (76)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                                         +- NativeParquetScan  (75)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    +- NativeSort (97)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                       +- InputAdapter (96)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                          +- AQEShuffleRead (95)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                             +- ShuffleQueryStage (94), Statistics(X)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                                +- NativeShuffleExchange (93)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                                   +- NativeFilter (92)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                                      +- InputAdapter (91)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                                         +- NativeParquetScan  (90)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    +- NativeSort (112)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                       +- InputAdapter (111)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                          +- AQEShuffleRead (110)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                             +- ShuffleQueryStage (109), Statistics(X)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                                +- NativeShuffleExchange (108)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                                   +- NativeFilter (107)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                                      +- InputAdapter (106)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                                         +- NativeParquetScan  (105)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    +- NativeSort (125)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                       +- InputAdapter (124)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                          +- InputAdapter (123)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                             +- AQEShuffleRead (122)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                                +- ShuffleQueryStage (121), Statistics(X)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    :                                   +- ReusedExchange (120)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                    +- NativeSort (140)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                       +- InputAdapter (139)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                          +- AQEShuffleRead (138)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                             +- ShuffleQueryStage (137), Statistics(X)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                                +- NativeShuffleExchange (136)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                                   +- NativeFilter (135)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                                      +- InputAdapter (134)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       :                                         +- NativeParquetScan  (133)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                       +- NativeSort (153)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                          +- InputAdapter (152)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                             +- InputAdapter (151)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                                +- AQEShuffleRead (150)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                                   +- ShuffleQueryStage (149), Statistics(X)
-                        :                                :                    :                    :                    :                    :                    :                    :                    :                                      +- ReusedExchange (148)
-                        :                                :                    :                    :                    :                    :                    :                    :                    +- NativeSort (169)
-                        :                                :                    :                    :                    :                    :                    :                    :                       +- InputAdapter (168)
-                        :                                :                    :                    :                    :                    :                    :                    :                          +- AQEShuffleRead (167)
-                        :                                :                    :                    :                    :                    :                    :                    :                             +- ShuffleQueryStage (166), Statistics(X)
-                        :                                :                    :                    :                    :                    :                    :                    :                                +- NativeShuffleExchange (165)
-                        :                                :                    :                    :                    :                    :                    :                    :                                   +- NativeFilter (164)
-                        :                                :                    :                    :                    :                    :                    :                    :                                      +- InputAdapter (163)
-                        :                                :                    :                    :                    :                    :                    :                    :                                         +- NativeParquetScan  (162)
-                        :                                :                    :                    :                    :                    :                    :                    +- NativeSort (184)
-                        :                                :                    :                    :                    :                    :                    :                       +- InputAdapter (183)
-                        :                                :                    :                    :                    :                    :                    :                          +- AQEShuffleRead (182)
-                        :                                :                    :                    :                    :                    :                    :                             +- ShuffleQueryStage (181), Statistics(X)
-                        :                                :                    :                    :                    :                    :                    :                                +- NativeShuffleExchange (180)
-                        :                                :                    :                    :                    :                    :                    :                                   +- NativeFilter (179)
-                        :                                :                    :                    :                    :                    :                    :                                      +- InputAdapter (178)
-                        :                                :                    :                    :                    :                    :                    :                                         +- NativeParquetScan  (177)
-                        :                                :                    :                    :                    :                    :                    +- NativeSort (197)
-                        :                                :                    :                    :                    :                    :                       +- InputAdapter (196)
-                        :                                :                    :                    :                    :                    :                          +- InputAdapter (195)
-                        :                                :                    :                    :                    :                    :                             +- AQEShuffleRead (194)
-                        :                                :                    :                    :                    :                    :                                +- ShuffleQueryStage (193), Statistics(X)
-                        :                                :                    :                    :                    :                    :                                   +- ReusedExchange (192)
-                        :                                :                    :                    :                    :                    +- NativeSort (212)
-                        :                                :                    :                    :                    :                       +- InputAdapter (211)
-                        :                                :                    :                    :                    :                          +- AQEShuffleRead (210)
-                        :                                :                    :                    :                    :                             +- ShuffleQueryStage (209), Statistics(X)
-                        :                                :                    :                    :                    :                                +- NativeShuffleExchange (208)
-                        :                                :                    :                    :                    :                                   +- NativeFilter (207)
-                        :                                :                    :                    :                    :                                      +- InputAdapter (206)
-                        :                                :                    :                    :                    :                                         +- NativeParquetScan  (205)
-                        :                                :                    :                    :                    +- NativeSort (225)
-                        :                                :                    :                    :                       +- InputAdapter (224)
-                        :                                :                    :                    :                          +- InputAdapter (223)
-                        :                                :                    :                    :                             +- AQEShuffleRead (222)
-                        :                                :                    :                    :                                +- ShuffleQueryStage (221), Statistics(X)
-                        :                                :                    :                    :                                   +- ReusedExchange (220)
-                        :                                :                    :                    +- NativeSort (240)
-                        :                                :                    :                       +- InputAdapter (239)
-                        :                                :                    :                          +- AQEShuffleRead (238)
-                        :                                :                    :                             +- ShuffleQueryStage (237), Statistics(X)
-                        :                                :                    :                                +- NativeShuffleExchange (236)
-                        :                                :                    :                                   +- NativeFilter (235)
-                        :                                :                    :                                      +- InputAdapter (234)
-                        :                                :                    :                                         +- NativeParquetScan  (233)
-                        :                                :                    +- NativeSort (253)
-                        :                                :                       +- InputAdapter (252)
-                        :                                :                          +- InputAdapter (251)
-                        :                                :                             +- AQEShuffleRead (250)
-                        :                                :                                +- ShuffleQueryStage (249), Statistics(X)
-                        :                                :                                   +- ReusedExchange (248)
-                        :                                +- NativeSort (269)
-                        :                                   +- InputAdapter (268)
-                        :                                      +- AQEShuffleRead (267)
-                        :                                         +- ShuffleQueryStage (266), Statistics(X)
-                        :                                            +- NativeShuffleExchange (265)
-                        :                                               +- NativeProject (264)
-                        :                                                  +- NativeFilter (263)
-                        :                                                     +- InputAdapter (262)
-                        :                                                        +- NativeParquetScan  (261)
-                        +- NativeSort (488)
-                           +- InputAdapter (487)
-                              +- AQEShuffleRead (486)
-                                 +- ShuffleQueryStage (485), Statistics(X)
-                                    +- NativeShuffleExchange (484)
-                                       +- NativeProject (483)
-                                          +- NativeHashAggregate (482)
-                                             +- NativeHashAggregate (481)
-                                                +- NativeProject (480)
-                                                   +- NativeProject (479)
-                                                      +- NativeSortMergeJoin Inner (478)
-                                                         :- NativeSort (471)
-                                                         :  +- InputAdapter (470)
-                                                         :     +- AQEShuffleRead (469)
-                                                         :        +- ShuffleQueryStage (468), Statistics(X)
-                                                         :           +- NativeShuffleExchange (467)
-                                                         :              +- NativeProject (466)
-                                                         :                 +- NativeSortMergeJoin Inner (465)
-                                                         :                    :- NativeSort (458)
-                                                         :                    :  +- InputAdapter (457)
-                                                         :                    :     +- AQEShuffleRead (456)
-                                                         :                    :        +- ShuffleQueryStage (455), Statistics(X)
-                                                         :                    :           +- NativeShuffleExchange (454)
-                                                         :                    :              +- NativeProject (453)
-                                                         :                    :                 +- NativeSortMergeJoin Inner (452)
-                                                         :                    :                    :- NativeSort (445)
-                                                         :                    :                    :  +- InputAdapter (444)
-                                                         :                    :                    :     +- AQEShuffleRead (443)
-                                                         :                    :                    :        +- ShuffleQueryStage (442), Statistics(X)
-                                                         :                    :                    :           +- NativeShuffleExchange (441)
-                                                         :                    :                    :              +- NativeProject (440)
-                                                         :                    :                    :                 +- NativeSortMergeJoin Inner (439)
-                                                         :                    :                    :                    :- NativeSort (432)
-                                                         :                    :                    :                    :  +- InputAdapter (431)
-                                                         :                    :                    :                    :     +- AQEShuffleRead (430)
-                                                         :                    :                    :                    :        +- ShuffleQueryStage (429), Statistics(X)
-                                                         :                    :                    :                    :           +- NativeShuffleExchange (428)
-                                                         :                    :                    :                    :              +- NativeProject (427)
-                                                         :                    :                    :                    :                 +- NativeSortMergeJoin Inner (426)
-                                                         :                    :                    :                    :                    :- NativeSort (419)
-                                                         :                    :                    :                    :                    :  +- InputAdapter (418)
-                                                         :                    :                    :                    :                    :     +- AQEShuffleRead (417)
-                                                         :                    :                    :                    :                    :        +- ShuffleQueryStage (416), Statistics(X)
-                                                         :                    :                    :                    :                    :           +- NativeShuffleExchange (415)
-                                                         :                    :                    :                    :                    :              +- NativeProject (414)
-                                                         :                    :                    :                    :                    :                 +- NativeSortMergeJoin Inner (413)
-                                                         :                    :                    :                    :                    :                    :- NativeSort (406)
-                                                         :                    :                    :                    :                    :                    :  +- InputAdapter (405)
-                                                         :                    :                    :                    :                    :                    :     +- AQEShuffleRead (404)
-                                                         :                    :                    :                    :                    :                    :        +- ShuffleQueryStage (403), Statistics(X)
-                                                         :                    :                    :                    :                    :                    :           +- NativeShuffleExchange (402)
-                                                         :                    :                    :                    :                    :                    :              +- NativeProject (401)
-                                                         :                    :                    :                    :                    :                    :                 +- NativeSortMergeJoin Inner (400)
-                                                         :                    :                    :                    :                    :                    :                    :- NativeSort (393)
-                                                         :                    :                    :                    :                    :                    :                    :  +- InputAdapter (392)
-                                                         :                    :                    :                    :                    :                    :                    :     +- AQEShuffleRead (391)
-                                                         :                    :                    :                    :                    :                    :                    :        +- ShuffleQueryStage (390), Statistics(X)
-                                                         :                    :                    :                    :                    :                    :                    :           +- NativeShuffleExchange (389)
-                                                         :                    :                    :                    :                    :                    :                    :              +- NativeProject (388)
-                                                         :                    :                    :                    :                    :                    :                    :                 +- NativeSortMergeJoin Inner (387)
-                                                         :                    :                    :                    :                    :                    :                    :                    :- NativeSort (380)
-                                                         :                    :                    :                    :                    :                    :                    :                    :  +- InputAdapter (379)
-                                                         :                    :                    :                    :                    :                    :                    :                    :     +- AQEShuffleRead (378)
-                                                         :                    :                    :                    :                    :                    :                    :                    :        +- ShuffleQueryStage (377), Statistics(X)
-                                                         :                    :                    :                    :                    :                    :                    :                    :           +- NativeShuffleExchange (376)
-                                                         :                    :                    :                    :                    :                    :                    :                    :              +- ConvertToNative (375)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                 +- * Project (374)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                    +- * SortMergeJoin Inner (373)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :- NativeSort (366)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :  +- InputAdapter (365)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :     +- AQEShuffleRead (364)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :        +- ShuffleQueryStage (363), Statistics(X)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :           +- NativeShuffleExchange (362)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :              +- NativeProject (361)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                 +- NativeSortMergeJoin Inner (360)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                    :- NativeSort (353)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                    :  +- InputAdapter (352)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                    :     +- AQEShuffleRead (351)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                    :        +- ShuffleQueryStage (350), Statistics(X)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                    :           +- NativeShuffleExchange (349)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                    :              +- NativeProject (348)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                    :                 +- NativeSortMergeJoin Inner (347)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :- NativeSort (340)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :  +- InputAdapter (339)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :     +- AQEShuffleRead (338)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :        +- ShuffleQueryStage (337), Statistics(X)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :           +- NativeShuffleExchange (336)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :              +- NativeProject (335)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                 +- NativeSortMergeJoin Inner (334)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :- NativeSort (327)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :  +- InputAdapter (326)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :     +- AQEShuffleRead (325)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :        +- ShuffleQueryStage (324), Statistics(X)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :           +- NativeShuffleExchange (323)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :              +- NativeProject (322)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                 +- NativeSortMergeJoin Inner (321)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :- NativeSort (314)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :  +- InputAdapter (313)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :     +- AQEShuffleRead (312)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :        +- ShuffleQueryStage (311), Statistics(X)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :           +- NativeShuffleExchange (310)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :              +- NativeProject (309)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                 +- NativeSortMergeJoin Inner (308)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :- NativeSort (301)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :  +- InputAdapter (300)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :     +- AQEShuffleRead (299)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :        +- ShuffleQueryStage (298), Statistics(X)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :           +- NativeShuffleExchange (297)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :              +- NativeProject (296)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                 +- NativeSortMergeJoin Inner (295)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                    :- NativeSort (286)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                    :  +- InputAdapter (285)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                    :     +- InputAdapter (284)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                    :        +- AQEShuffleRead (283)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                    :           +- ShuffleQueryStage (282), Statistics(X)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                    :              +- ReusedExchange (281)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                    +- NativeSort (294)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                       +- InputAdapter (293)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                          +- AQEShuffleRead (292)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                             +- ShuffleQueryStage (291), Statistics(X)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                                +- NativeShuffleExchange (290)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                                   +- NativeFilter (289)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                                      +- InputAdapter (288)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    :                                         +- NativeParquetScan  (287)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                    +- NativeSort (307)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                       +- InputAdapter (306)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                          +- InputAdapter (305)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                             +- AQEShuffleRead (304)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                                +- ShuffleQueryStage (303), Statistics(X)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    :                                   +- ReusedExchange (302)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                    +- NativeSort (320)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                       +- InputAdapter (319)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                          +- InputAdapter (318)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                             +- AQEShuffleRead (317)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                                +- ShuffleQueryStage (316), Statistics(X)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    :                                   +- ReusedExchange (315)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                    +- NativeSort (333)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                       +- InputAdapter (332)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                          +- InputAdapter (331)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                             +- AQEShuffleRead (330)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                                +- ShuffleQueryStage (329), Statistics(X)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    :                                   +- ReusedExchange (328)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                    :                    +- NativeSort (346)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                    :                       +- InputAdapter (345)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                    :                          +- InputAdapter (344)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                    :                             +- AQEShuffleRead (343)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                    :                                +- ShuffleQueryStage (342), Statistics(X)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                    :                                   +- ReusedExchange (341)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                    +- NativeSort (359)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                       +- InputAdapter (358)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                          +- InputAdapter (357)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                             +- AQEShuffleRead (356)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                                +- ShuffleQueryStage (355), Statistics(X)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       :                                   +- ReusedExchange (354)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                       +- NativeSort (372)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                          +- InputAdapter (371)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                             +- InputAdapter (370)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                                +- AQEShuffleRead (369)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                                   +- ShuffleQueryStage (368), Statistics(X)
-                                                         :                    :                    :                    :                    :                    :                    :                    :                                      +- ReusedExchange (367)
-                                                         :                    :                    :                    :                    :                    :                    :                    +- NativeSort (386)
-                                                         :                    :                    :                    :                    :                    :                    :                       +- InputAdapter (385)
-                                                         :                    :                    :                    :                    :                    :                    :                          +- InputAdapter (384)
-                                                         :                    :                    :                    :                    :                    :                    :                             +- AQEShuffleRead (383)
-                                                         :                    :                    :                    :                    :                    :                    :                                +- ShuffleQueryStage (382), Statistics(X)
-                                                         :                    :                    :                    :                    :                    :                    :                                   +- ReusedExchange (381)
-                                                         :                    :                    :                    :                    :                    :                    +- NativeSort (399)
-                                                         :                    :                    :                    :                    :                    :                       +- InputAdapter (398)
-                                                         :                    :                    :                    :                    :                    :                          +- InputAdapter (397)
-                                                         :                    :                    :                    :                    :                    :                             +- AQEShuffleRead (396)
-                                                         :                    :                    :                    :                    :                    :                                +- ShuffleQueryStage (395), Statistics(X)
-                                                         :                    :                    :                    :                    :                    :                                   +- ReusedExchange (394)
-                                                         :                    :                    :                    :                    :                    +- NativeSort (412)
-                                                         :                    :                    :                    :                    :                       +- InputAdapter (411)
-                                                         :                    :                    :                    :                    :                          +- InputAdapter (410)
-                                                         :                    :                    :                    :                    :                             +- AQEShuffleRead (409)
-                                                         :                    :                    :                    :                    :                                +- ShuffleQueryStage (408), Statistics(X)
-                                                         :                    :                    :                    :                    :                                   +- ReusedExchange (407)
-                                                         :                    :                    :                    :                    +- NativeSort (425)
-                                                         :                    :                    :                    :                       +- InputAdapter (424)
-                                                         :                    :                    :                    :                          +- InputAdapter (423)
-                                                         :                    :                    :                    :                             +- AQEShuffleRead (422)
-                                                         :                    :                    :                    :                                +- ShuffleQueryStage (421), Statistics(X)
-                                                         :                    :                    :                    :                                   +- ReusedExchange (420)
-                                                         :                    :                    :                    +- NativeSort (438)
-                                                         :                    :                    :                       +- InputAdapter (437)
-                                                         :                    :                    :                          +- InputAdapter (436)
-                                                         :                    :                    :                             +- AQEShuffleRead (435)
-                                                         :                    :                    :                                +- ShuffleQueryStage (434), Statistics(X)
-                                                         :                    :                    :                                   +- ReusedExchange (433)
-                                                         :                    :                    +- NativeSort (451)
-                                                         :                    :                       +- InputAdapter (450)
-                                                         :                    :                          +- InputAdapter (449)
-                                                         :                    :                             +- AQEShuffleRead (448)
-                                                         :                    :                                +- ShuffleQueryStage (447), Statistics(X)
-                                                         :                    :                                   +- ReusedExchange (446)
-                                                         :                    +- NativeSort (464)
-                                                         :                       +- InputAdapter (463)
-                                                         :                          +- InputAdapter (462)
-                                                         :                             +- AQEShuffleRead (461)
-                                                         :                                +- ShuffleQueryStage (460), Statistics(X)
-                                                         :                                   +- ReusedExchange (459)
-                                                         +- NativeSort (477)
-                                                            +- InputAdapter (476)
-                                                               +- InputAdapter (475)
-                                                                  +- AQEShuffleRead (474)
-                                                                     +- ShuffleQueryStage (473), Statistics(X)
-                                                                        +- ReusedExchange (472)
+   NativeSort (493)
+   +- InputAdapter (492)
+      +- AQEShuffleRead (491)
+         +- ShuffleQueryStage (490), Statistics(X)
+            +- NativeShuffleExchange (489)
+               +- NativeProject (488)
+                  +- NativeSortMergeJoin Inner (487)
+                     :- NativeSort (279)
+                     :  +- InputAdapter (278)
+                     :     +- AQEShuffleRead (277)
+                     :        +- ShuffleQueryStage (276), Statistics(X)
+                     :           +- NativeShuffleExchange (275)
+                     :              +- NativeProject (274)
+                     :                 +- NativeHashAggregate (273)
+                     :                    +- NativeHashAggregate (272)
+                     :                       +- NativeProject (271)
+                     :                          +- NativeProject (270)
+                     :                             +- NativeSortMergeJoin Inner (269)
+                     :                                :- NativeSort (259)
+                     :                                :  +- InputAdapter (258)
+                     :                                :     +- AQEShuffleRead (257)
+                     :                                :        +- ShuffleQueryStage (256), Statistics(X)
+                     :                                :           +- NativeShuffleExchange (255)
+                     :                                :              +- NativeProject (254)
+                     :                                :                 +- NativeSortMergeJoin Inner (253)
+                     :                                :                    :- NativeSort (246)
+                     :                                :                    :  +- InputAdapter (245)
+                     :                                :                    :     +- AQEShuffleRead (244)
+                     :                                :                    :        +- ShuffleQueryStage (243), Statistics(X)
+                     :                                :                    :           +- NativeShuffleExchange (242)
+                     :                                :                    :              +- NativeProject (241)
+                     :                                :                    :                 +- NativeSortMergeJoin Inner (240)
+                     :                                :                    :                    :- NativeSort (231)
+                     :                                :                    :                    :  +- InputAdapter (230)
+                     :                                :                    :                    :     +- AQEShuffleRead (229)
+                     :                                :                    :                    :        +- ShuffleQueryStage (228), Statistics(X)
+                     :                                :                    :                    :           +- NativeShuffleExchange (227)
+                     :                                :                    :                    :              +- NativeProject (226)
+                     :                                :                    :                    :                 +- NativeSortMergeJoin Inner (225)
+                     :                                :                    :                    :                    :- NativeSort (218)
+                     :                                :                    :                    :                    :  +- InputAdapter (217)
+                     :                                :                    :                    :                    :     +- AQEShuffleRead (216)
+                     :                                :                    :                    :                    :        +- ShuffleQueryStage (215), Statistics(X)
+                     :                                :                    :                    :                    :           +- NativeShuffleExchange (214)
+                     :                                :                    :                    :                    :              +- NativeProject (213)
+                     :                                :                    :                    :                    :                 +- NativeSortMergeJoin Inner (212)
+                     :                                :                    :                    :                    :                    :- NativeSort (203)
+                     :                                :                    :                    :                    :                    :  +- InputAdapter (202)
+                     :                                :                    :                    :                    :                    :     +- AQEShuffleRead (201)
+                     :                                :                    :                    :                    :                    :        +- ShuffleQueryStage (200), Statistics(X)
+                     :                                :                    :                    :                    :                    :           +- NativeShuffleExchange (199)
+                     :                                :                    :                    :                    :                    :              +- NativeProject (198)
+                     :                                :                    :                    :                    :                    :                 +- NativeSortMergeJoin Inner (197)
+                     :                                :                    :                    :                    :                    :                    :- NativeSort (190)
+                     :                                :                    :                    :                    :                    :                    :  +- InputAdapter (189)
+                     :                                :                    :                    :                    :                    :                    :     +- AQEShuffleRead (188)
+                     :                                :                    :                    :                    :                    :                    :        +- ShuffleQueryStage (187), Statistics(X)
+                     :                                :                    :                    :                    :                    :                    :           +- NativeShuffleExchange (186)
+                     :                                :                    :                    :                    :                    :                    :              +- NativeProject (185)
+                     :                                :                    :                    :                    :                    :                    :                 +- NativeSortMergeJoin Inner (184)
+                     :                                :                    :                    :                    :                    :                    :                    :- NativeSort (175)
+                     :                                :                    :                    :                    :                    :                    :                    :  +- InputAdapter (174)
+                     :                                :                    :                    :                    :                    :                    :                    :     +- AQEShuffleRead (173)
+                     :                                :                    :                    :                    :                    :                    :                    :        +- ShuffleQueryStage (172), Statistics(X)
+                     :                                :                    :                    :                    :                    :                    :                    :           +- NativeShuffleExchange (171)
+                     :                                :                    :                    :                    :                    :                    :                    :              +- NativeProject (170)
+                     :                                :                    :                    :                    :                    :                    :                    :                 +- NativeSortMergeJoin Inner (169)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :- NativeSort (160)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :  +- InputAdapter (159)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :     +- AQEShuffleRead (158)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :        +- ShuffleQueryStage (157), Statistics(X)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :           +- NativeShuffleExchange (156)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :              +- NativeProject (155)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                 +- NativeSortMergeJoin Inner (154)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :- NativeSort (147)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :  +- InputAdapter (146)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :     +- AQEShuffleRead (145)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :        +- ShuffleQueryStage (144), Statistics(X)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :           +- NativeShuffleExchange (143)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :              +- NativeProject (142)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                 +- NativeSortMergeJoin Inner (141)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :- NativeSort (132)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :  +- InputAdapter (131)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :     +- AQEShuffleRead (130)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :        +- ShuffleQueryStage (129), Statistics(X)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :           +- NativeShuffleExchange (128)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :              +- NativeProject (127)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                 +- NativeSortMergeJoin Inner (126)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :- NativeSort (119)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :  +- InputAdapter (118)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :     +- AQEShuffleRead (117)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :        +- ShuffleQueryStage (116), Statistics(X)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :           +- NativeShuffleExchange (115)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :              +- NativeProject (114)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                 +- NativeSortMergeJoin Inner (113)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :- NativeSort (104)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :  +- InputAdapter (103)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :     +- AQEShuffleRead (102)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :        +- ShuffleQueryStage (101), Statistics(X)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :           +- NativeShuffleExchange (100)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :              +- NativeProject (99)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                 +- NativeSortMergeJoin Inner (98)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :- NativeSort (89)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :  +- InputAdapter (88)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :     +- AQEShuffleRead (87)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :        +- ShuffleQueryStage (86), Statistics(X)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :           +- NativeShuffleExchange (85)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :              +- NativeProject (84)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                 +- NativeSortMergeJoin Inner (83)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :- NativeSort (74)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :  +- InputAdapter (73)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :     +- AQEShuffleRead (72)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :        +- ShuffleQueryStage (71), Statistics(X)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :           +- NativeShuffleExchange (70)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :              +- NativeProject (69)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                 +- NativeSortMergeJoin Inner (68)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :- NativeSort (59)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :  +- InputAdapter (58)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :     +- AQEShuffleRead (57)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :        +- ShuffleQueryStage (56), Statistics(X)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :           +- NativeShuffleExchange (55)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :              +- NativeProject (54)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                 +- NativeSortMergeJoin Inner (53)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :- NativeSort (23)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :  +- InputAdapter (22)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :     +- AQEShuffleRead (21)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :        +- ShuffleQueryStage (20), Statistics(X)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :           +- NativeShuffleExchange (19)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :              +- NativeProject (18)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                 +- NativeSortMergeJoin Inner (17)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :- NativeSort (8)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :  +- InputAdapter (7)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :     +- AQEShuffleRead (6)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :        +- ShuffleQueryStage (5), Statistics(X)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :           +- NativeShuffleExchange (4)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :              +- NativeFilter (3)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                 +- InputAdapter (2)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    +- NativeParquetScan  (1)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    +- NativeSort (16)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                       +- InputAdapter (15)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                          +- AQEShuffleRead (14)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                             +- ShuffleQueryStage (13), Statistics(X)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                                +- NativeShuffleExchange (12)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                                   +- NativeFilter (11)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                                      +- InputAdapter (10)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                                         +- NativeParquetScan  (9)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    +- NativeSort (52)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                       +- NativeProject (51)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                          +- NativeFilter (50)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                             +- NativeProject (49)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                                +- NativeHashAggregate (48)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                                   +- InputAdapter (47)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                                      +- AQEShuffleRead (46)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                                         +- ShuffleQueryStage (45), Statistics(X)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                                            +- NativeShuffleExchange (44)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                                               +- NativeHashAggregate (43)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                                                  +- NativeProject (42)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                                                     +- NativeProject (41)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                                                        +- NativeSortMergeJoin Inner (40)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                                                           :- NativeSort (31)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                                                           :  +- InputAdapter (30)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                                                           :     +- AQEShuffleRead (29)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                                                           :        +- ShuffleQueryStage (28), Statistics(X)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                                                           :           +- NativeShuffleExchange (27)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                                                           :              +- NativeFilter (26)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                                                           :                 +- InputAdapter (25)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                                                           :                    +- NativeParquetScan  (24)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                                                           +- NativeSort (39)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                                                              +- InputAdapter (38)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                                                                 +- AQEShuffleRead (37)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                                                                    +- ShuffleQueryStage (36), Statistics(X)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                                                                       +- NativeShuffleExchange (35)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                                                                          +- NativeFilter (34)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                                                                             +- InputAdapter (33)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                                                                                +- NativeParquetScan  (32)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    +- NativeSort (67)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                       +- InputAdapter (66)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                          +- AQEShuffleRead (65)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                             +- ShuffleQueryStage (64), Statistics(X)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                                +- NativeShuffleExchange (63)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                                   +- NativeFilter (62)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                                      +- InputAdapter (61)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                                         +- NativeParquetScan  (60)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    +- NativeSort (82)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                       +- InputAdapter (81)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                          +- AQEShuffleRead (80)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                             +- ShuffleQueryStage (79), Statistics(X)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                                +- NativeShuffleExchange (78)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                                   +- NativeFilter (77)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                                      +- InputAdapter (76)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                                         +- NativeParquetScan  (75)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    +- NativeSort (97)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                       +- InputAdapter (96)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                          +- AQEShuffleRead (95)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                             +- ShuffleQueryStage (94), Statistics(X)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                                +- NativeShuffleExchange (93)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                                   +- NativeFilter (92)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                                      +- InputAdapter (91)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                                         +- NativeParquetScan  (90)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    +- NativeSort (112)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                       +- InputAdapter (111)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                          +- AQEShuffleRead (110)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                             +- ShuffleQueryStage (109), Statistics(X)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                                +- NativeShuffleExchange (108)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                                   +- NativeFilter (107)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                                      +- InputAdapter (106)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                                         +- NativeParquetScan  (105)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    +- NativeSort (125)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                       +- InputAdapter (124)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                          +- InputAdapter (123)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                             +- AQEShuffleRead (122)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                                +- ShuffleQueryStage (121), Statistics(X)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    :                                   +- ReusedExchange (120)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                    +- NativeSort (140)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                       +- InputAdapter (139)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                          +- AQEShuffleRead (138)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                             +- ShuffleQueryStage (137), Statistics(X)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                                +- NativeShuffleExchange (136)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                                   +- NativeFilter (135)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                                      +- InputAdapter (134)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    :                                         +- NativeParquetScan  (133)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                    +- NativeSort (153)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                       +- InputAdapter (152)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                          +- InputAdapter (151)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                             +- AQEShuffleRead (150)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                                +- ShuffleQueryStage (149), Statistics(X)
+                     :                                :                    :                    :                    :                    :                    :                    :                    :                                   +- ReusedExchange (148)
+                     :                                :                    :                    :                    :                    :                    :                    :                    +- NativeSort (168)
+                     :                                :                    :                    :                    :                    :                    :                    :                       +- InputAdapter (167)
+                     :                                :                    :                    :                    :                    :                    :                    :                          +- AQEShuffleRead (166)
+                     :                                :                    :                    :                    :                    :                    :                    :                             +- ShuffleQueryStage (165), Statistics(X)
+                     :                                :                    :                    :                    :                    :                    :                    :                                +- NativeShuffleExchange (164)
+                     :                                :                    :                    :                    :                    :                    :                    :                                   +- NativeFilter (163)
+                     :                                :                    :                    :                    :                    :                    :                    :                                      +- InputAdapter (162)
+                     :                                :                    :                    :                    :                    :                    :                    :                                         +- NativeParquetScan  (161)
+                     :                                :                    :                    :                    :                    :                    :                    +- NativeSort (183)
+                     :                                :                    :                    :                    :                    :                    :                       +- InputAdapter (182)
+                     :                                :                    :                    :                    :                    :                    :                          +- AQEShuffleRead (181)
+                     :                                :                    :                    :                    :                    :                    :                             +- ShuffleQueryStage (180), Statistics(X)
+                     :                                :                    :                    :                    :                    :                    :                                +- NativeShuffleExchange (179)
+                     :                                :                    :                    :                    :                    :                    :                                   +- NativeFilter (178)
+                     :                                :                    :                    :                    :                    :                    :                                      +- InputAdapter (177)
+                     :                                :                    :                    :                    :                    :                    :                                         +- NativeParquetScan  (176)
+                     :                                :                    :                    :                    :                    :                    +- NativeSort (196)
+                     :                                :                    :                    :                    :                    :                       +- InputAdapter (195)
+                     :                                :                    :                    :                    :                    :                          +- InputAdapter (194)
+                     :                                :                    :                    :                    :                    :                             +- AQEShuffleRead (193)
+                     :                                :                    :                    :                    :                    :                                +- ShuffleQueryStage (192), Statistics(X)
+                     :                                :                    :                    :                    :                    :                                   +- ReusedExchange (191)
+                     :                                :                    :                    :                    :                    +- NativeSort (211)
+                     :                                :                    :                    :                    :                       +- InputAdapter (210)
+                     :                                :                    :                    :                    :                          +- AQEShuffleRead (209)
+                     :                                :                    :                    :                    :                             +- ShuffleQueryStage (208), Statistics(X)
+                     :                                :                    :                    :                    :                                +- NativeShuffleExchange (207)
+                     :                                :                    :                    :                    :                                   +- NativeFilter (206)
+                     :                                :                    :                    :                    :                                      +- InputAdapter (205)
+                     :                                :                    :                    :                    :                                         +- NativeParquetScan  (204)
+                     :                                :                    :                    :                    +- NativeSort (224)
+                     :                                :                    :                    :                       +- InputAdapter (223)
+                     :                                :                    :                    :                          +- InputAdapter (222)
+                     :                                :                    :                    :                             +- AQEShuffleRead (221)
+                     :                                :                    :                    :                                +- ShuffleQueryStage (220), Statistics(X)
+                     :                                :                    :                    :                                   +- ReusedExchange (219)
+                     :                                :                    :                    +- NativeSort (239)
+                     :                                :                    :                       +- InputAdapter (238)
+                     :                                :                    :                          +- AQEShuffleRead (237)
+                     :                                :                    :                             +- ShuffleQueryStage (236), Statistics(X)
+                     :                                :                    :                                +- NativeShuffleExchange (235)
+                     :                                :                    :                                   +- NativeFilter (234)
+                     :                                :                    :                                      +- InputAdapter (233)
+                     :                                :                    :                                         +- NativeParquetScan  (232)
+                     :                                :                    +- NativeSort (252)
+                     :                                :                       +- InputAdapter (251)
+                     :                                :                          +- InputAdapter (250)
+                     :                                :                             +- AQEShuffleRead (249)
+                     :                                :                                +- ShuffleQueryStage (248), Statistics(X)
+                     :                                :                                   +- ReusedExchange (247)
+                     :                                +- NativeSort (268)
+                     :                                   +- InputAdapter (267)
+                     :                                      +- AQEShuffleRead (266)
+                     :                                         +- ShuffleQueryStage (265), Statistics(X)
+                     :                                            +- NativeShuffleExchange (264)
+                     :                                               +- NativeProject (263)
+                     :                                                  +- NativeFilter (262)
+                     :                                                     +- InputAdapter (261)
+                     :                                                        +- NativeParquetScan  (260)
+                     +- NativeSort (486)
+                        +- InputAdapter (485)
+                           +- AQEShuffleRead (484)
+                              +- ShuffleQueryStage (483), Statistics(X)
+                                 +- NativeShuffleExchange (482)
+                                    +- NativeProject (481)
+                                       +- NativeHashAggregate (480)
+                                          +- NativeHashAggregate (479)
+                                             +- NativeProject (478)
+                                                +- NativeProject (477)
+                                                   +- NativeSortMergeJoin Inner (476)
+                                                      :- NativeSort (469)
+                                                      :  +- InputAdapter (468)
+                                                      :     +- AQEShuffleRead (467)
+                                                      :        +- ShuffleQueryStage (466), Statistics(X)
+                                                      :           +- NativeShuffleExchange (465)
+                                                      :              +- NativeProject (464)
+                                                      :                 +- NativeSortMergeJoin Inner (463)
+                                                      :                    :- NativeSort (456)
+                                                      :                    :  +- InputAdapter (455)
+                                                      :                    :     +- AQEShuffleRead (454)
+                                                      :                    :        +- ShuffleQueryStage (453), Statistics(X)
+                                                      :                    :           +- NativeShuffleExchange (452)
+                                                      :                    :              +- NativeProject (451)
+                                                      :                    :                 +- NativeSortMergeJoin Inner (450)
+                                                      :                    :                    :- NativeSort (443)
+                                                      :                    :                    :  +- InputAdapter (442)
+                                                      :                    :                    :     +- AQEShuffleRead (441)
+                                                      :                    :                    :        +- ShuffleQueryStage (440), Statistics(X)
+                                                      :                    :                    :           +- NativeShuffleExchange (439)
+                                                      :                    :                    :              +- NativeProject (438)
+                                                      :                    :                    :                 +- NativeSortMergeJoin Inner (437)
+                                                      :                    :                    :                    :- NativeSort (430)
+                                                      :                    :                    :                    :  +- InputAdapter (429)
+                                                      :                    :                    :                    :     +- AQEShuffleRead (428)
+                                                      :                    :                    :                    :        +- ShuffleQueryStage (427), Statistics(X)
+                                                      :                    :                    :                    :           +- NativeShuffleExchange (426)
+                                                      :                    :                    :                    :              +- NativeProject (425)
+                                                      :                    :                    :                    :                 +- NativeSortMergeJoin Inner (424)
+                                                      :                    :                    :                    :                    :- NativeSort (417)
+                                                      :                    :                    :                    :                    :  +- InputAdapter (416)
+                                                      :                    :                    :                    :                    :     +- AQEShuffleRead (415)
+                                                      :                    :                    :                    :                    :        +- ShuffleQueryStage (414), Statistics(X)
+                                                      :                    :                    :                    :                    :           +- NativeShuffleExchange (413)
+                                                      :                    :                    :                    :                    :              +- NativeProject (412)
+                                                      :                    :                    :                    :                    :                 +- NativeSortMergeJoin Inner (411)
+                                                      :                    :                    :                    :                    :                    :- NativeSort (404)
+                                                      :                    :                    :                    :                    :                    :  +- InputAdapter (403)
+                                                      :                    :                    :                    :                    :                    :     +- AQEShuffleRead (402)
+                                                      :                    :                    :                    :                    :                    :        +- ShuffleQueryStage (401), Statistics(X)
+                                                      :                    :                    :                    :                    :                    :           +- NativeShuffleExchange (400)
+                                                      :                    :                    :                    :                    :                    :              +- NativeProject (399)
+                                                      :                    :                    :                    :                    :                    :                 +- NativeSortMergeJoin Inner (398)
+                                                      :                    :                    :                    :                    :                    :                    :- NativeSort (391)
+                                                      :                    :                    :                    :                    :                    :                    :  +- InputAdapter (390)
+                                                      :                    :                    :                    :                    :                    :                    :     +- AQEShuffleRead (389)
+                                                      :                    :                    :                    :                    :                    :                    :        +- ShuffleQueryStage (388), Statistics(X)
+                                                      :                    :                    :                    :                    :                    :                    :           +- NativeShuffleExchange (387)
+                                                      :                    :                    :                    :                    :                    :                    :              +- NativeProject (386)
+                                                      :                    :                    :                    :                    :                    :                    :                 +- NativeSortMergeJoin Inner (385)
+                                                      :                    :                    :                    :                    :                    :                    :                    :- NativeSort (378)
+                                                      :                    :                    :                    :                    :                    :                    :                    :  +- InputAdapter (377)
+                                                      :                    :                    :                    :                    :                    :                    :                    :     +- AQEShuffleRead (376)
+                                                      :                    :                    :                    :                    :                    :                    :                    :        +- ShuffleQueryStage (375), Statistics(X)
+                                                      :                    :                    :                    :                    :                    :                    :                    :           +- NativeShuffleExchange (374)
+                                                      :                    :                    :                    :                    :                    :                    :                    :              +- NativeProject (373)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                 +- NativeSortMergeJoin Inner (372)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :- NativeSort (365)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :  +- InputAdapter (364)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :     +- AQEShuffleRead (363)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :        +- ShuffleQueryStage (362), Statistics(X)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :           +- NativeShuffleExchange (361)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :              +- NativeProject (360)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                 +- NativeSortMergeJoin Inner (359)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                    :- NativeSort (352)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                    :  +- InputAdapter (351)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                    :     +- AQEShuffleRead (350)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                    :        +- ShuffleQueryStage (349), Statistics(X)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                    :           +- NativeShuffleExchange (348)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                    :              +- NativeProject (347)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                    :                 +- NativeSortMergeJoin Inner (346)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :- NativeSort (339)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :  +- InputAdapter (338)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :     +- AQEShuffleRead (337)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :        +- ShuffleQueryStage (336), Statistics(X)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :           +- NativeShuffleExchange (335)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :              +- NativeProject (334)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                 +- NativeSortMergeJoin Inner (333)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :- NativeSort (326)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :  +- InputAdapter (325)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :     +- AQEShuffleRead (324)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :        +- ShuffleQueryStage (323), Statistics(X)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :           +- NativeShuffleExchange (322)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :              +- NativeProject (321)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                 +- NativeSortMergeJoin Inner (320)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :- NativeSort (313)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :  +- InputAdapter (312)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :     +- AQEShuffleRead (311)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :        +- ShuffleQueryStage (310), Statistics(X)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :           +- NativeShuffleExchange (309)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :              +- NativeProject (308)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                 +- NativeSortMergeJoin Inner (307)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :- NativeSort (300)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :  +- InputAdapter (299)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :     +- AQEShuffleRead (298)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :        +- ShuffleQueryStage (297), Statistics(X)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :           +- NativeShuffleExchange (296)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :              +- NativeProject (295)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                 +- NativeSortMergeJoin Inner (294)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :- NativeSort (285)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :  +- InputAdapter (284)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :     +- InputAdapter (283)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :        +- AQEShuffleRead (282)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :           +- ShuffleQueryStage (281), Statistics(X)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :              +- ReusedExchange (280)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    +- NativeSort (293)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                       +- InputAdapter (292)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                          +- AQEShuffleRead (291)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                             +- ShuffleQueryStage (290), Statistics(X)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                                +- NativeShuffleExchange (289)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                                   +- NativeFilter (288)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                                      +- InputAdapter (287)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                                         +- NativeParquetScan  (286)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    +- NativeSort (306)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                       +- InputAdapter (305)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                          +- InputAdapter (304)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                             +- AQEShuffleRead (303)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                                +- ShuffleQueryStage (302), Statistics(X)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                                   +- ReusedExchange (301)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    +- NativeSort (319)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                       +- InputAdapter (318)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                          +- InputAdapter (317)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                             +- AQEShuffleRead (316)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                                +- ShuffleQueryStage (315), Statistics(X)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                                   +- ReusedExchange (314)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    +- NativeSort (332)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                       +- InputAdapter (331)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                          +- InputAdapter (330)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                             +- AQEShuffleRead (329)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                                +- ShuffleQueryStage (328), Statistics(X)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    :                                   +- ReusedExchange (327)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    +- NativeSort (345)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                    :                       +- InputAdapter (344)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                    :                          +- InputAdapter (343)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                    :                             +- AQEShuffleRead (342)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                    :                                +- ShuffleQueryStage (341), Statistics(X)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                    :                                   +- ReusedExchange (340)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                    +- NativeSort (358)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                       +- InputAdapter (357)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                          +- InputAdapter (356)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                             +- AQEShuffleRead (355)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                                +- ShuffleQueryStage (354), Statistics(X)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    :                                   +- ReusedExchange (353)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                    +- NativeSort (371)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                       +- InputAdapter (370)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                          +- InputAdapter (369)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                             +- AQEShuffleRead (368)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                                +- ShuffleQueryStage (367), Statistics(X)
+                                                      :                    :                    :                    :                    :                    :                    :                    :                                   +- ReusedExchange (366)
+                                                      :                    :                    :                    :                    :                    :                    :                    +- NativeSort (384)
+                                                      :                    :                    :                    :                    :                    :                    :                       +- InputAdapter (383)
+                                                      :                    :                    :                    :                    :                    :                    :                          +- InputAdapter (382)
+                                                      :                    :                    :                    :                    :                    :                    :                             +- AQEShuffleRead (381)
+                                                      :                    :                    :                    :                    :                    :                    :                                +- ShuffleQueryStage (380), Statistics(X)
+                                                      :                    :                    :                    :                    :                    :                    :                                   +- ReusedExchange (379)
+                                                      :                    :                    :                    :                    :                    :                    +- NativeSort (397)
+                                                      :                    :                    :                    :                    :                    :                       +- InputAdapter (396)
+                                                      :                    :                    :                    :                    :                    :                          +- InputAdapter (395)
+                                                      :                    :                    :                    :                    :                    :                             +- AQEShuffleRead (394)
+                                                      :                    :                    :                    :                    :                    :                                +- ShuffleQueryStage (393), Statistics(X)
+                                                      :                    :                    :                    :                    :                    :                                   +- ReusedExchange (392)
+                                                      :                    :                    :                    :                    :                    +- NativeSort (410)
+                                                      :                    :                    :                    :                    :                       +- InputAdapter (409)
+                                                      :                    :                    :                    :                    :                          +- InputAdapter (408)
+                                                      :                    :                    :                    :                    :                             +- AQEShuffleRead (407)
+                                                      :                    :                    :                    :                    :                                +- ShuffleQueryStage (406), Statistics(X)
+                                                      :                    :                    :                    :                    :                                   +- ReusedExchange (405)
+                                                      :                    :                    :                    :                    +- NativeSort (423)
+                                                      :                    :                    :                    :                       +- InputAdapter (422)
+                                                      :                    :                    :                    :                          +- InputAdapter (421)
+                                                      :                    :                    :                    :                             +- AQEShuffleRead (420)
+                                                      :                    :                    :                    :                                +- ShuffleQueryStage (419), Statistics(X)
+                                                      :                    :                    :                    :                                   +- ReusedExchange (418)
+                                                      :                    :                    :                    +- NativeSort (436)
+                                                      :                    :                    :                       +- InputAdapter (435)
+                                                      :                    :                    :                          +- InputAdapter (434)
+                                                      :                    :                    :                             +- AQEShuffleRead (433)
+                                                      :                    :                    :                                +- ShuffleQueryStage (432), Statistics(X)
+                                                      :                    :                    :                                   +- ReusedExchange (431)
+                                                      :                    :                    +- NativeSort (449)
+                                                      :                    :                       +- InputAdapter (448)
+                                                      :                    :                          +- InputAdapter (447)
+                                                      :                    :                             +- AQEShuffleRead (446)
+                                                      :                    :                                +- ShuffleQueryStage (445), Statistics(X)
+                                                      :                    :                                   +- ReusedExchange (444)
+                                                      :                    +- NativeSort (462)
+                                                      :                       +- InputAdapter (461)
+                                                      :                          +- InputAdapter (460)
+                                                      :                             +- AQEShuffleRead (459)
+                                                      :                                +- ShuffleQueryStage (458), Statistics(X)
+                                                      :                                   +- ReusedExchange (457)
+                                                      +- NativeSort (475)
+                                                         +- InputAdapter (474)
+                                                            +- InputAdapter (473)
+                                                               +- AQEShuffleRead (472)
+                                                                  +- ShuffleQueryStage (471), Statistics(X)
+                                                                     +- ReusedExchange (470)
 +- == Initial Plan ==
-   Sort (810)
-   +- Exchange (809)
-      +- Project (808)
-         +- SortMergeJoin Inner (807)
-            :- Sort (651)
-            :  +- Exchange (650)
-            :     +- HashAggregate (649)
-            :        +- HashAggregate (648)
-            :           +- Project (647)
-            :              +- SortMergeJoin Inner (646)
-            :                 :- Sort (640)
-            :                 :  +- Exchange (639)
-            :                 :     +- Project (638)
-            :                 :        +- SortMergeJoin Inner (637)
-            :                 :           :- Sort (632)
-            :                 :           :  +- Exchange (631)
-            :                 :           :     +- Project (630)
-            :                 :           :        +- SortMergeJoin Inner (629)
-            :                 :           :           :- Sort (624)
-            :                 :           :           :  +- Exchange (623)
-            :                 :           :           :     +- Project (622)
-            :                 :           :           :        +- SortMergeJoin Inner (621)
-            :                 :           :           :           :- Sort (616)
-            :                 :           :           :           :  +- Exchange (615)
-            :                 :           :           :           :     +- Project (614)
-            :                 :           :           :           :        +- SortMergeJoin Inner (613)
-            :                 :           :           :           :           :- Sort (608)
-            :                 :           :           :           :           :  +- Exchange (607)
-            :                 :           :           :           :           :     +- Project (606)
-            :                 :           :           :           :           :        +- SortMergeJoin Inner (605)
-            :                 :           :           :           :           :           :- Sort (600)
-            :                 :           :           :           :           :           :  +- Exchange (599)
-            :                 :           :           :           :           :           :     +- Project (598)
-            :                 :           :           :           :           :           :        +- SortMergeJoin Inner (597)
-            :                 :           :           :           :           :           :           :- Sort (592)
-            :                 :           :           :           :           :           :           :  +- Exchange (591)
-            :                 :           :           :           :           :           :           :     +- Project (590)
-            :                 :           :           :           :           :           :           :        +- SortMergeJoin Inner (589)
-            :                 :           :           :           :           :           :           :           :- Sort (584)
-            :                 :           :           :           :           :           :           :           :  +- Exchange (583)
-            :                 :           :           :           :           :           :           :           :     +- Project (582)
-            :                 :           :           :           :           :           :           :           :        +- SortMergeJoin Inner (581)
-            :                 :           :           :           :           :           :           :           :           :- Sort (576)
-            :                 :           :           :           :           :           :           :           :           :  +- Exchange (575)
-            :                 :           :           :           :           :           :           :           :           :     +- Project (574)
-            :                 :           :           :           :           :           :           :           :           :        +- SortMergeJoin Inner (573)
-            :                 :           :           :           :           :           :           :           :           :           :- Sort (568)
-            :                 :           :           :           :           :           :           :           :           :           :  +- Exchange (567)
-            :                 :           :           :           :           :           :           :           :           :           :     +- Project (566)
-            :                 :           :           :           :           :           :           :           :           :           :        +- SortMergeJoin Inner (565)
-            :                 :           :           :           :           :           :           :           :           :           :           :- Sort (560)
-            :                 :           :           :           :           :           :           :           :           :           :           :  +- Exchange (559)
-            :                 :           :           :           :           :           :           :           :           :           :           :     +- Project (558)
-            :                 :           :           :           :           :           :           :           :           :           :           :        +- SortMergeJoin Inner (557)
-            :                 :           :           :           :           :           :           :           :           :           :           :           :- Sort (552)
-            :                 :           :           :           :           :           :           :           :           :           :           :           :  +- Exchange (551)
-            :                 :           :           :           :           :           :           :           :           :           :           :           :     +- Project (550)
-            :                 :           :           :           :           :           :           :           :           :           :           :           :        +- SortMergeJoin Inner (549)
-            :                 :           :           :           :           :           :           :           :           :           :           :           :           :- Sort (544)
-            :                 :           :           :           :           :           :           :           :           :           :           :           :           :  +- Exchange (543)
-            :                 :           :           :           :           :           :           :           :           :           :           :           :           :     +- Project (542)
-            :                 :           :           :           :           :           :           :           :           :           :           :           :           :        +- SortMergeJoin Inner (541)
-            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :- Sort (536)
-            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :  +- Exchange (535)
-            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :     +- Project (534)
-            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :        +- SortMergeJoin Inner (533)
-            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :           :- Sort (528)
-            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :           :  +- Exchange (527)
-            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :           :     +- Project (526)
-            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :           :        +- SortMergeJoin Inner (525)
-            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :           :           :- Sort (508)
-            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :           :           :  +- Exchange (507)
-            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :           :           :     +- Project (506)
-            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :           :           :        +- SortMergeJoin Inner (505)
-            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :           :           :           :- Sort (500)
-            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :           :           :           :  +- Exchange (499)
-            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :           :           :           :     +- Filter (498)
-            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :           :           :           :        +- Scan parquet (497)
-            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :           :           :           +- Sort (504)
-            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :           :           :              +- Exchange (503)
-            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :           :           :                 +- Filter (502)
-            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :           :           :                    +- Scan parquet (501)
-            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :           :           +- Sort (524)
-            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :           :              +- Project (523)
-            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :           :                 +- Filter (522)
-            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :           :                    +- HashAggregate (521)
-            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :           :                       +- Exchange (520)
-            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :           :                          +- HashAggregate (519)
-            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :           :                             +- Project (518)
-            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :           :                                +- SortMergeJoin Inner (517)
-            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :           :                                   :- Sort (512)
-            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :           :                                   :  +- Exchange (511)
-            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :           :                                   :     +- Filter (510)
-            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :           :                                   :        +- Scan parquet (509)
-            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :           :                                   +- Sort (516)
-            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :           :                                      +- Exchange (515)
-            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :           :                                         +- Filter (514)
-            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :           :                                            +- Scan parquet (513)
-            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :           +- Sort (532)
-            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :              +- Exchange (531)
-            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :                 +- Filter (530)
-            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :                    +- Scan parquet (529)
-            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           +- Sort (540)
-            :                 :           :           :           :           :           :           :           :           :           :           :           :           :              +- Exchange (539)
-            :                 :           :           :           :           :           :           :           :           :           :           :           :           :                 +- Filter (538)
-            :                 :           :           :           :           :           :           :           :           :           :           :           :           :                    +- Scan parquet (537)
-            :                 :           :           :           :           :           :           :           :           :           :           :           :           +- Sort (548)
-            :                 :           :           :           :           :           :           :           :           :           :           :           :              +- Exchange (547)
-            :                 :           :           :           :           :           :           :           :           :           :           :           :                 +- Filter (546)
-            :                 :           :           :           :           :           :           :           :           :           :           :           :                    +- Scan parquet (545)
-            :                 :           :           :           :           :           :           :           :           :           :           :           +- Sort (556)
-            :                 :           :           :           :           :           :           :           :           :           :           :              +- Exchange (555)
-            :                 :           :           :           :           :           :           :           :           :           :           :                 +- Filter (554)
-            :                 :           :           :           :           :           :           :           :           :           :           :                    +- Scan parquet (553)
-            :                 :           :           :           :           :           :           :           :           :           :           +- Sort (564)
-            :                 :           :           :           :           :           :           :           :           :           :              +- Exchange (563)
-            :                 :           :           :           :           :           :           :           :           :           :                 +- Filter (562)
-            :                 :           :           :           :           :           :           :           :           :           :                    +- Scan parquet (561)
-            :                 :           :           :           :           :           :           :           :           :           +- Sort (572)
-            :                 :           :           :           :           :           :           :           :           :              +- Exchange (571)
-            :                 :           :           :           :           :           :           :           :           :                 +- Filter (570)
-            :                 :           :           :           :           :           :           :           :           :                    +- Scan parquet (569)
-            :                 :           :           :           :           :           :           :           :           +- Sort (580)
-            :                 :           :           :           :           :           :           :           :              +- Exchange (579)
-            :                 :           :           :           :           :           :           :           :                 +- Filter (578)
-            :                 :           :           :           :           :           :           :           :                    +- Scan parquet (577)
-            :                 :           :           :           :           :           :           :           +- Sort (588)
-            :                 :           :           :           :           :           :           :              +- Exchange (587)
-            :                 :           :           :           :           :           :           :                 +- Filter (586)
-            :                 :           :           :           :           :           :           :                    +- Scan parquet (585)
-            :                 :           :           :           :           :           :           +- Sort (596)
-            :                 :           :           :           :           :           :              +- Exchange (595)
-            :                 :           :           :           :           :           :                 +- Filter (594)
-            :                 :           :           :           :           :           :                    +- Scan parquet (593)
-            :                 :           :           :           :           :           +- Sort (604)
-            :                 :           :           :           :           :              +- Exchange (603)
-            :                 :           :           :           :           :                 +- Filter (602)
-            :                 :           :           :           :           :                    +- Scan parquet (601)
-            :                 :           :           :           :           +- Sort (612)
-            :                 :           :           :           :              +- Exchange (611)
-            :                 :           :           :           :                 +- Filter (610)
-            :                 :           :           :           :                    +- Scan parquet (609)
-            :                 :           :           :           +- Sort (620)
-            :                 :           :           :              +- Exchange (619)
-            :                 :           :           :                 +- Filter (618)
-            :                 :           :           :                    +- Scan parquet (617)
-            :                 :           :           +- Sort (628)
-            :                 :           :              +- Exchange (627)
-            :                 :           :                 +- Filter (626)
-            :                 :           :                    +- Scan parquet (625)
-            :                 :           +- Sort (636)
-            :                 :              +- Exchange (635)
-            :                 :                 +- Filter (634)
-            :                 :                    +- Scan parquet (633)
-            :                 +- Sort (645)
-            :                    +- Exchange (644)
-            :                       +- Project (643)
-            :                          +- Filter (642)
-            :                             +- Scan parquet (641)
-            +- Sort (806)
-               +- Exchange (805)
-                  +- HashAggregate (804)
-                     +- HashAggregate (803)
-                        +- Project (802)
-                           +- SortMergeJoin Inner (801)
-                              :- Sort (795)
-                              :  +- Exchange (794)
-                              :     +- Project (793)
-                              :        +- SortMergeJoin Inner (792)
-                              :           :- Sort (787)
-                              :           :  +- Exchange (786)
-                              :           :     +- Project (785)
-                              :           :        +- SortMergeJoin Inner (784)
-                              :           :           :- Sort (779)
-                              :           :           :  +- Exchange (778)
-                              :           :           :     +- Project (777)
-                              :           :           :        +- SortMergeJoin Inner (776)
-                              :           :           :           :- Sort (771)
-                              :           :           :           :  +- Exchange (770)
-                              :           :           :           :     +- Project (769)
-                              :           :           :           :        +- SortMergeJoin Inner (768)
-                              :           :           :           :           :- Sort (763)
-                              :           :           :           :           :  +- Exchange (762)
-                              :           :           :           :           :     +- Project (761)
-                              :           :           :           :           :        +- SortMergeJoin Inner (760)
-                              :           :           :           :           :           :- Sort (755)
-                              :           :           :           :           :           :  +- Exchange (754)
-                              :           :           :           :           :           :     +- Project (753)
-                              :           :           :           :           :           :        +- SortMergeJoin Inner (752)
-                              :           :           :           :           :           :           :- Sort (747)
-                              :           :           :           :           :           :           :  +- Exchange (746)
-                              :           :           :           :           :           :           :     +- Project (745)
-                              :           :           :           :           :           :           :        +- SortMergeJoin Inner (744)
-                              :           :           :           :           :           :           :           :- Sort (739)
-                              :           :           :           :           :           :           :           :  +- Exchange (738)
-                              :           :           :           :           :           :           :           :     +- Project (737)
-                              :           :           :           :           :           :           :           :        +- SortMergeJoin Inner (736)
-                              :           :           :           :           :           :           :           :           :- Sort (731)
-                              :           :           :           :           :           :           :           :           :  +- Exchange (730)
-                              :           :           :           :           :           :           :           :           :     +- Project (729)
-                              :           :           :           :           :           :           :           :           :        +- SortMergeJoin Inner (728)
-                              :           :           :           :           :           :           :           :           :           :- Sort (723)
-                              :           :           :           :           :           :           :           :           :           :  +- Exchange (722)
-                              :           :           :           :           :           :           :           :           :           :     +- Project (721)
-                              :           :           :           :           :           :           :           :           :           :        +- SortMergeJoin Inner (720)
-                              :           :           :           :           :           :           :           :           :           :           :- Sort (715)
-                              :           :           :           :           :           :           :           :           :           :           :  +- Exchange (714)
-                              :           :           :           :           :           :           :           :           :           :           :     +- Project (713)
-                              :           :           :           :           :           :           :           :           :           :           :        +- SortMergeJoin Inner (712)
-                              :           :           :           :           :           :           :           :           :           :           :           :- Sort (707)
-                              :           :           :           :           :           :           :           :           :           :           :           :  +- Exchange (706)
-                              :           :           :           :           :           :           :           :           :           :           :           :     +- Project (705)
-                              :           :           :           :           :           :           :           :           :           :           :           :        +- SortMergeJoin Inner (704)
-                              :           :           :           :           :           :           :           :           :           :           :           :           :- Sort (699)
-                              :           :           :           :           :           :           :           :           :           :           :           :           :  +- Exchange (698)
-                              :           :           :           :           :           :           :           :           :           :           :           :           :     +- Project (697)
-                              :           :           :           :           :           :           :           :           :           :           :           :           :        +- SortMergeJoin Inner (696)
-                              :           :           :           :           :           :           :           :           :           :           :           :           :           :- Sort (691)
-                              :           :           :           :           :           :           :           :           :           :           :           :           :           :  +- Exchange (690)
-                              :           :           :           :           :           :           :           :           :           :           :           :           :           :     +- Project (689)
-                              :           :           :           :           :           :           :           :           :           :           :           :           :           :        +- SortMergeJoin Inner (688)
-                              :           :           :           :           :           :           :           :           :           :           :           :           :           :           :- Sort (683)
-                              :           :           :           :           :           :           :           :           :           :           :           :           :           :           :  +- Exchange (682)
-                              :           :           :           :           :           :           :           :           :           :           :           :           :           :           :     +- Project (681)
-                              :           :           :           :           :           :           :           :           :           :           :           :           :           :           :        +- SortMergeJoin Inner (680)
-                              :           :           :           :           :           :           :           :           :           :           :           :           :           :           :           :- Sort (663)
-                              :           :           :           :           :           :           :           :           :           :           :           :           :           :           :           :  +- Exchange (662)
-                              :           :           :           :           :           :           :           :           :           :           :           :           :           :           :           :     +- Project (661)
-                              :           :           :           :           :           :           :           :           :           :           :           :           :           :           :           :        +- SortMergeJoin Inner (660)
-                              :           :           :           :           :           :           :           :           :           :           :           :           :           :           :           :           :- Sort (655)
-                              :           :           :           :           :           :           :           :           :           :           :           :           :           :           :           :           :  +- Exchange (654)
-                              :           :           :           :           :           :           :           :           :           :           :           :           :           :           :           :           :     +- Filter (653)
-                              :           :           :           :           :           :           :           :           :           :           :           :           :           :           :           :           :        +- Scan parquet (652)
-                              :           :           :           :           :           :           :           :           :           :           :           :           :           :           :           :           +- Sort (659)
-                              :           :           :           :           :           :           :           :           :           :           :           :           :           :           :           :              +- Exchange (658)
-                              :           :           :           :           :           :           :           :           :           :           :           :           :           :           :           :                 +- Filter (657)
-                              :           :           :           :           :           :           :           :           :           :           :           :           :           :           :           :                    +- Scan parquet (656)
-                              :           :           :           :           :           :           :           :           :           :           :           :           :           :           :           +- Sort (679)
-                              :           :           :           :           :           :           :           :           :           :           :           :           :           :           :              +- Project (678)
-                              :           :           :           :           :           :           :           :           :           :           :           :           :           :           :                 +- Filter (677)
-                              :           :           :           :           :           :           :           :           :           :           :           :           :           :           :                    +- HashAggregate (676)
-                              :           :           :           :           :           :           :           :           :           :           :           :           :           :           :                       +- Exchange (675)
-                              :           :           :           :           :           :           :           :           :           :           :           :           :           :           :                          +- HashAggregate (674)
-                              :           :           :           :           :           :           :           :           :           :           :           :           :           :           :                             +- Project (673)
-                              :           :           :           :           :           :           :           :           :           :           :           :           :           :           :                                +- SortMergeJoin Inner (672)
-                              :           :           :           :           :           :           :           :           :           :           :           :           :           :           :                                   :- Sort (667)
-                              :           :           :           :           :           :           :           :           :           :           :           :           :           :           :                                   :  +- Exchange (666)
-                              :           :           :           :           :           :           :           :           :           :           :           :           :           :           :                                   :     +- Filter (665)
-                              :           :           :           :           :           :           :           :           :           :           :           :           :           :           :                                   :        +- Scan parquet (664)
-                              :           :           :           :           :           :           :           :           :           :           :           :           :           :           :                                   +- Sort (671)
-                              :           :           :           :           :           :           :           :           :           :           :           :           :           :           :                                      +- Exchange (670)
-                              :           :           :           :           :           :           :           :           :           :           :           :           :           :           :                                         +- Filter (669)
-                              :           :           :           :           :           :           :           :           :           :           :           :           :           :           :                                            +- Scan parquet (668)
-                              :           :           :           :           :           :           :           :           :           :           :           :           :           :           +- Sort (687)
-                              :           :           :           :           :           :           :           :           :           :           :           :           :           :              +- Exchange (686)
-                              :           :           :           :           :           :           :           :           :           :           :           :           :           :                 +- Filter (685)
-                              :           :           :           :           :           :           :           :           :           :           :           :           :           :                    +- Scan parquet (684)
-                              :           :           :           :           :           :           :           :           :           :           :           :           :           +- Sort (695)
-                              :           :           :           :           :           :           :           :           :           :           :           :           :              +- Exchange (694)
-                              :           :           :           :           :           :           :           :           :           :           :           :           :                 +- Filter (693)
-                              :           :           :           :           :           :           :           :           :           :           :           :           :                    +- Scan parquet (692)
-                              :           :           :           :           :           :           :           :           :           :           :           :           +- Sort (703)
-                              :           :           :           :           :           :           :           :           :           :           :           :              +- Exchange (702)
-                              :           :           :           :           :           :           :           :           :           :           :           :                 +- Filter (701)
-                              :           :           :           :           :           :           :           :           :           :           :           :                    +- Scan parquet (700)
-                              :           :           :           :           :           :           :           :           :           :           :           +- Sort (711)
-                              :           :           :           :           :           :           :           :           :           :           :              +- Exchange (710)
-                              :           :           :           :           :           :           :           :           :           :           :                 +- Filter (709)
-                              :           :           :           :           :           :           :           :           :           :           :                    +- Scan parquet (708)
-                              :           :           :           :           :           :           :           :           :           :           +- Sort (719)
-                              :           :           :           :           :           :           :           :           :           :              +- Exchange (718)
-                              :           :           :           :           :           :           :           :           :           :                 +- Filter (717)
-                              :           :           :           :           :           :           :           :           :           :                    +- Scan parquet (716)
-                              :           :           :           :           :           :           :           :           :           +- Sort (727)
-                              :           :           :           :           :           :           :           :           :              +- Exchange (726)
-                              :           :           :           :           :           :           :           :           :                 +- Filter (725)
-                              :           :           :           :           :           :           :           :           :                    +- Scan parquet (724)
-                              :           :           :           :           :           :           :           :           +- Sort (735)
-                              :           :           :           :           :           :           :           :              +- Exchange (734)
-                              :           :           :           :           :           :           :           :                 +- Filter (733)
-                              :           :           :           :           :           :           :           :                    +- Scan parquet (732)
-                              :           :           :           :           :           :           :           +- Sort (743)
-                              :           :           :           :           :           :           :              +- Exchange (742)
-                              :           :           :           :           :           :           :                 +- Filter (741)
-                              :           :           :           :           :           :           :                    +- Scan parquet (740)
-                              :           :           :           :           :           :           +- Sort (751)
-                              :           :           :           :           :           :              +- Exchange (750)
-                              :           :           :           :           :           :                 +- Filter (749)
-                              :           :           :           :           :           :                    +- Scan parquet (748)
-                              :           :           :           :           :           +- Sort (759)
-                              :           :           :           :           :              +- Exchange (758)
-                              :           :           :           :           :                 +- Filter (757)
-                              :           :           :           :           :                    +- Scan parquet (756)
-                              :           :           :           :           +- Sort (767)
-                              :           :           :           :              +- Exchange (766)
-                              :           :           :           :                 +- Filter (765)
-                              :           :           :           :                    +- Scan parquet (764)
-                              :           :           :           +- Sort (775)
-                              :           :           :              +- Exchange (774)
-                              :           :           :                 +- Filter (773)
-                              :           :           :                    +- Scan parquet (772)
-                              :           :           +- Sort (783)
-                              :           :              +- Exchange (782)
-                              :           :                 +- Filter (781)
-                              :           :                    +- Scan parquet (780)
-                              :           +- Sort (791)
-                              :              +- Exchange (790)
-                              :                 +- Filter (789)
-                              :                    +- Scan parquet (788)
-                              +- Sort (800)
-                                 +- Exchange (799)
-                                    +- Project (798)
-                                       +- Filter (797)
-                                          +- Scan parquet (796)
+   Sort (807)
+   +- Exchange (806)
+      +- Project (805)
+         +- SortMergeJoin Inner (804)
+            :- Sort (648)
+            :  +- Exchange (647)
+            :     +- HashAggregate (646)
+            :        +- HashAggregate (645)
+            :           +- Project (644)
+            :              +- SortMergeJoin Inner (643)
+            :                 :- Sort (637)
+            :                 :  +- Exchange (636)
+            :                 :     +- Project (635)
+            :                 :        +- SortMergeJoin Inner (634)
+            :                 :           :- Sort (629)
+            :                 :           :  +- Exchange (628)
+            :                 :           :     +- Project (627)
+            :                 :           :        +- SortMergeJoin Inner (626)
+            :                 :           :           :- Sort (621)
+            :                 :           :           :  +- Exchange (620)
+            :                 :           :           :     +- Project (619)
+            :                 :           :           :        +- SortMergeJoin Inner (618)
+            :                 :           :           :           :- Sort (613)
+            :                 :           :           :           :  +- Exchange (612)
+            :                 :           :           :           :     +- Project (611)
+            :                 :           :           :           :        +- SortMergeJoin Inner (610)
+            :                 :           :           :           :           :- Sort (605)
+            :                 :           :           :           :           :  +- Exchange (604)
+            :                 :           :           :           :           :     +- Project (603)
+            :                 :           :           :           :           :        +- SortMergeJoin Inner (602)
+            :                 :           :           :           :           :           :- Sort (597)
+            :                 :           :           :           :           :           :  +- Exchange (596)
+            :                 :           :           :           :           :           :     +- Project (595)
+            :                 :           :           :           :           :           :        +- SortMergeJoin Inner (594)
+            :                 :           :           :           :           :           :           :- Sort (589)
+            :                 :           :           :           :           :           :           :  +- Exchange (588)
+            :                 :           :           :           :           :           :           :     +- Project (587)
+            :                 :           :           :           :           :           :           :        +- SortMergeJoin Inner (586)
+            :                 :           :           :           :           :           :           :           :- Sort (581)
+            :                 :           :           :           :           :           :           :           :  +- Exchange (580)
+            :                 :           :           :           :           :           :           :           :     +- Project (579)
+            :                 :           :           :           :           :           :           :           :        +- SortMergeJoin Inner (578)
+            :                 :           :           :           :           :           :           :           :           :- Sort (573)
+            :                 :           :           :           :           :           :           :           :           :  +- Exchange (572)
+            :                 :           :           :           :           :           :           :           :           :     +- Project (571)
+            :                 :           :           :           :           :           :           :           :           :        +- SortMergeJoin Inner (570)
+            :                 :           :           :           :           :           :           :           :           :           :- Sort (565)
+            :                 :           :           :           :           :           :           :           :           :           :  +- Exchange (564)
+            :                 :           :           :           :           :           :           :           :           :           :     +- Project (563)
+            :                 :           :           :           :           :           :           :           :           :           :        +- SortMergeJoin Inner (562)
+            :                 :           :           :           :           :           :           :           :           :           :           :- Sort (557)
+            :                 :           :           :           :           :           :           :           :           :           :           :  +- Exchange (556)
+            :                 :           :           :           :           :           :           :           :           :           :           :     +- Project (555)
+            :                 :           :           :           :           :           :           :           :           :           :           :        +- SortMergeJoin Inner (554)
+            :                 :           :           :           :           :           :           :           :           :           :           :           :- Sort (549)
+            :                 :           :           :           :           :           :           :           :           :           :           :           :  +- Exchange (548)
+            :                 :           :           :           :           :           :           :           :           :           :           :           :     +- Project (547)
+            :                 :           :           :           :           :           :           :           :           :           :           :           :        +- SortMergeJoin Inner (546)
+            :                 :           :           :           :           :           :           :           :           :           :           :           :           :- Sort (541)
+            :                 :           :           :           :           :           :           :           :           :           :           :           :           :  +- Exchange (540)
+            :                 :           :           :           :           :           :           :           :           :           :           :           :           :     +- Project (539)
+            :                 :           :           :           :           :           :           :           :           :           :           :           :           :        +- SortMergeJoin Inner (538)
+            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :- Sort (533)
+            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :  +- Exchange (532)
+            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :     +- Project (531)
+            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :        +- SortMergeJoin Inner (530)
+            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :           :- Sort (525)
+            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :           :  +- Exchange (524)
+            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :           :     +- Project (523)
+            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :           :        +- SortMergeJoin Inner (522)
+            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :           :           :- Sort (505)
+            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :           :           :  +- Exchange (504)
+            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :           :           :     +- Project (503)
+            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :           :           :        +- SortMergeJoin Inner (502)
+            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :           :           :           :- Sort (497)
+            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :           :           :           :  +- Exchange (496)
+            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :           :           :           :     +- Filter (495)
+            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :           :           :           :        +- Scan parquet (494)
+            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :           :           :           +- Sort (501)
+            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :           :           :              +- Exchange (500)
+            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :           :           :                 +- Filter (499)
+            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :           :           :                    +- Scan parquet (498)
+            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :           :           +- Sort (521)
+            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :           :              +- Project (520)
+            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :           :                 +- Filter (519)
+            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :           :                    +- HashAggregate (518)
+            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :           :                       +- Exchange (517)
+            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :           :                          +- HashAggregate (516)
+            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :           :                             +- Project (515)
+            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :           :                                +- SortMergeJoin Inner (514)
+            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :           :                                   :- Sort (509)
+            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :           :                                   :  +- Exchange (508)
+            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :           :                                   :     +- Filter (507)
+            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :           :                                   :        +- Scan parquet (506)
+            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :           :                                   +- Sort (513)
+            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :           :                                      +- Exchange (512)
+            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :           :                                         +- Filter (511)
+            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :           :                                            +- Scan parquet (510)
+            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :           +- Sort (529)
+            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :              +- Exchange (528)
+            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :                 +- Filter (527)
+            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           :                    +- Scan parquet (526)
+            :                 :           :           :           :           :           :           :           :           :           :           :           :           :           +- Sort (537)
+            :                 :           :           :           :           :           :           :           :           :           :           :           :           :              +- Exchange (536)
+            :                 :           :           :           :           :           :           :           :           :           :           :           :           :                 +- Filter (535)
+            :                 :           :           :           :           :           :           :           :           :           :           :           :           :                    +- Scan parquet (534)
+            :                 :           :           :           :           :           :           :           :           :           :           :           :           +- Sort (545)
+            :                 :           :           :           :           :           :           :           :           :           :           :           :              +- Exchange (544)
+            :                 :           :           :           :           :           :           :           :           :           :           :           :                 +- Filter (543)
+            :                 :           :           :           :           :           :           :           :           :           :           :           :                    +- Scan parquet (542)
+            :                 :           :           :           :           :           :           :           :           :           :           :           +- Sort (553)
+            :                 :           :           :           :           :           :           :           :           :           :           :              +- Exchange (552)
+            :                 :           :           :           :           :           :           :           :           :           :           :                 +- Filter (551)
+            :                 :           :           :           :           :           :           :           :           :           :           :                    +- Scan parquet (550)
+            :                 :           :           :           :           :           :           :           :           :           :           +- Sort (561)
+            :                 :           :           :           :           :           :           :           :           :           :              +- Exchange (560)
+            :                 :           :           :           :           :           :           :           :           :           :                 +- Filter (559)
+            :                 :           :           :           :           :           :           :           :           :           :                    +- Scan parquet (558)
+            :                 :           :           :           :           :           :           :           :           :           +- Sort (569)
+            :                 :           :           :           :           :           :           :           :           :              +- Exchange (568)
+            :                 :           :           :           :           :           :           :           :           :                 +- Filter (567)
+            :                 :           :           :           :           :           :           :           :           :                    +- Scan parquet (566)
+            :                 :           :           :           :           :           :           :           :           +- Sort (577)
+            :                 :           :           :           :           :           :           :           :              +- Exchange (576)
+            :                 :           :           :           :           :           :           :           :                 +- Filter (575)
+            :                 :           :           :           :           :           :           :           :                    +- Scan parquet (574)
+            :                 :           :           :           :           :           :           :           +- Sort (585)
+            :                 :           :           :           :           :           :           :              +- Exchange (584)
+            :                 :           :           :           :           :           :           :                 +- Filter (583)
+            :                 :           :           :           :           :           :           :                    +- Scan parquet (582)
+            :                 :           :           :           :           :           :           +- Sort (593)
+            :                 :           :           :           :           :           :              +- Exchange (592)
+            :                 :           :           :           :           :           :                 +- Filter (591)
+            :                 :           :           :           :           :           :                    +- Scan parquet (590)
+            :                 :           :           :           :           :           +- Sort (601)
+            :                 :           :           :           :           :              +- Exchange (600)
+            :                 :           :           :           :           :                 +- Filter (599)
+            :                 :           :           :           :           :                    +- Scan parquet (598)
+            :                 :           :           :           :           +- Sort (609)
+            :                 :           :           :           :              +- Exchange (608)
+            :                 :           :           :           :                 +- Filter (607)
+            :                 :           :           :           :                    +- Scan parquet (606)
+            :                 :           :           :           +- Sort (617)
+            :                 :           :           :              +- Exchange (616)
+            :                 :           :           :                 +- Filter (615)
+            :                 :           :           :                    +- Scan parquet (614)
+            :                 :           :           +- Sort (625)
+            :                 :           :              +- Exchange (624)
+            :                 :           :                 +- Filter (623)
+            :                 :           :                    +- Scan parquet (622)
+            :                 :           +- Sort (633)
+            :                 :              +- Exchange (632)
+            :                 :                 +- Filter (631)
+            :                 :                    +- Scan parquet (630)
+            :                 +- Sort (642)
+            :                    +- Exchange (641)
+            :                       +- Project (640)
+            :                          +- Filter (639)
+            :                             +- Scan parquet (638)
+            +- Sort (803)
+               +- Exchange (802)
+                  +- HashAggregate (801)
+                     +- HashAggregate (800)
+                        +- Project (799)
+                           +- SortMergeJoin Inner (798)
+                              :- Sort (792)
+                              :  +- Exchange (791)
+                              :     +- Project (790)
+                              :        +- SortMergeJoin Inner (789)
+                              :           :- Sort (784)
+                              :           :  +- Exchange (783)
+                              :           :     +- Project (782)
+                              :           :        +- SortMergeJoin Inner (781)
+                              :           :           :- Sort (776)
+                              :           :           :  +- Exchange (775)
+                              :           :           :     +- Project (774)
+                              :           :           :        +- SortMergeJoin Inner (773)
+                              :           :           :           :- Sort (768)
+                              :           :           :           :  +- Exchange (767)
+                              :           :           :           :     +- Project (766)
+                              :           :           :           :        +- SortMergeJoin Inner (765)
+                              :           :           :           :           :- Sort (760)
+                              :           :           :           :           :  +- Exchange (759)
+                              :           :           :           :           :     +- Project (758)
+                              :           :           :           :           :        +- SortMergeJoin Inner (757)
+                              :           :           :           :           :           :- Sort (752)
+                              :           :           :           :           :           :  +- Exchange (751)
+                              :           :           :           :           :           :     +- Project (750)
+                              :           :           :           :           :           :        +- SortMergeJoin Inner (749)
+                              :           :           :           :           :           :           :- Sort (744)
+                              :           :           :           :           :           :           :  +- Exchange (743)
+                              :           :           :           :           :           :           :     +- Project (742)
+                              :           :           :           :           :           :           :        +- SortMergeJoin Inner (741)
+                              :           :           :           :           :           :           :           :- Sort (736)
+                              :           :           :           :           :           :           :           :  +- Exchange (735)
+                              :           :           :           :           :           :           :           :     +- Project (734)
+                              :           :           :           :           :           :           :           :        +- SortMergeJoin Inner (733)
+                              :           :           :           :           :           :           :           :           :- Sort (728)
+                              :           :           :           :           :           :           :           :           :  +- Exchange (727)
+                              :           :           :           :           :           :           :           :           :     +- Project (726)
+                              :           :           :           :           :           :           :           :           :        +- SortMergeJoin Inner (725)
+                              :           :           :           :           :           :           :           :           :           :- Sort (720)
+                              :           :           :           :           :           :           :           :           :           :  +- Exchange (719)
+                              :           :           :           :           :           :           :           :           :           :     +- Project (718)
+                              :           :           :           :           :           :           :           :           :           :        +- SortMergeJoin Inner (717)
+                              :           :           :           :           :           :           :           :           :           :           :- Sort (712)
+                              :           :           :           :           :           :           :           :           :           :           :  +- Exchange (711)
+                              :           :           :           :           :           :           :           :           :           :           :     +- Project (710)
+                              :           :           :           :           :           :           :           :           :           :           :        +- SortMergeJoin Inner (709)
+                              :           :           :           :           :           :           :           :           :           :           :           :- Sort (704)
+                              :           :           :           :           :           :           :           :           :           :           :           :  +- Exchange (703)
+                              :           :           :           :           :           :           :           :           :           :           :           :     +- Project (702)
+                              :           :           :           :           :           :           :           :           :           :           :           :        +- SortMergeJoin Inner (701)
+                              :           :           :           :           :           :           :           :           :           :           :           :           :- Sort (696)
+                              :           :           :           :           :           :           :           :           :           :           :           :           :  +- Exchange (695)
+                              :           :           :           :           :           :           :           :           :           :           :           :           :     +- Project (694)
+                              :           :           :           :           :           :           :           :           :           :           :           :           :        +- SortMergeJoin Inner (693)
+                              :           :           :           :           :           :           :           :           :           :           :           :           :           :- Sort (688)
+                              :           :           :           :           :           :           :           :           :           :           :           :           :           :  +- Exchange (687)
+                              :           :           :           :           :           :           :           :           :           :           :           :           :           :     +- Project (686)
+                              :           :           :           :           :           :           :           :           :           :           :           :           :           :        +- SortMergeJoin Inner (685)
+                              :           :           :           :           :           :           :           :           :           :           :           :           :           :           :- Sort (680)
+                              :           :           :           :           :           :           :           :           :           :           :           :           :           :           :  +- Exchange (679)
+                              :           :           :           :           :           :           :           :           :           :           :           :           :           :           :     +- Project (678)
+                              :           :           :           :           :           :           :           :           :           :           :           :           :           :           :        +- SortMergeJoin Inner (677)
+                              :           :           :           :           :           :           :           :           :           :           :           :           :           :           :           :- Sort (660)
+                              :           :           :           :           :           :           :           :           :           :           :           :           :           :           :           :  +- Exchange (659)
+                              :           :           :           :           :           :           :           :           :           :           :           :           :           :           :           :     +- Project (658)
+                              :           :           :           :           :           :           :           :           :           :           :           :           :           :           :           :        +- SortMergeJoin Inner (657)
+                              :           :           :           :           :           :           :           :           :           :           :           :           :           :           :           :           :- Sort (652)
+                              :           :           :           :           :           :           :           :           :           :           :           :           :           :           :           :           :  +- Exchange (651)
+                              :           :           :           :           :           :           :           :           :           :           :           :           :           :           :           :           :     +- Filter (650)
+                              :           :           :           :           :           :           :           :           :           :           :           :           :           :           :           :           :        +- Scan parquet (649)
+                              :           :           :           :           :           :           :           :           :           :           :           :           :           :           :           :           +- Sort (656)
+                              :           :           :           :           :           :           :           :           :           :           :           :           :           :           :           :              +- Exchange (655)
+                              :           :           :           :           :           :           :           :           :           :           :           :           :           :           :           :                 +- Filter (654)
+                              :           :           :           :           :           :           :           :           :           :           :           :           :           :           :           :                    +- Scan parquet (653)
+                              :           :           :           :           :           :           :           :           :           :           :           :           :           :           :           +- Sort (676)
+                              :           :           :           :           :           :           :           :           :           :           :           :           :           :           :              +- Project (675)
+                              :           :           :           :           :           :           :           :           :           :           :           :           :           :           :                 +- Filter (674)
+                              :           :           :           :           :           :           :           :           :           :           :           :           :           :           :                    +- HashAggregate (673)
+                              :           :           :           :           :           :           :           :           :           :           :           :           :           :           :                       +- Exchange (672)
+                              :           :           :           :           :           :           :           :           :           :           :           :           :           :           :                          +- HashAggregate (671)
+                              :           :           :           :           :           :           :           :           :           :           :           :           :           :           :                             +- Project (670)
+                              :           :           :           :           :           :           :           :           :           :           :           :           :           :           :                                +- SortMergeJoin Inner (669)
+                              :           :           :           :           :           :           :           :           :           :           :           :           :           :           :                                   :- Sort (664)
+                              :           :           :           :           :           :           :           :           :           :           :           :           :           :           :                                   :  +- Exchange (663)
+                              :           :           :           :           :           :           :           :           :           :           :           :           :           :           :                                   :     +- Filter (662)
+                              :           :           :           :           :           :           :           :           :           :           :           :           :           :           :                                   :        +- Scan parquet (661)
+                              :           :           :           :           :           :           :           :           :           :           :           :           :           :           :                                   +- Sort (668)
+                              :           :           :           :           :           :           :           :           :           :           :           :           :           :           :                                      +- Exchange (667)
+                              :           :           :           :           :           :           :           :           :           :           :           :           :           :           :                                         +- Filter (666)
+                              :           :           :           :           :           :           :           :           :           :           :           :           :           :           :                                            +- Scan parquet (665)
+                              :           :           :           :           :           :           :           :           :           :           :           :           :           :           +- Sort (684)
+                              :           :           :           :           :           :           :           :           :           :           :           :           :           :              +- Exchange (683)
+                              :           :           :           :           :           :           :           :           :           :           :           :           :           :                 +- Filter (682)
+                              :           :           :           :           :           :           :           :           :           :           :           :           :           :                    +- Scan parquet (681)
+                              :           :           :           :           :           :           :           :           :           :           :           :           :           +- Sort (692)
+                              :           :           :           :           :           :           :           :           :           :           :           :           :              +- Exchange (691)
+                              :           :           :           :           :           :           :           :           :           :           :           :           :                 +- Filter (690)
+                              :           :           :           :           :           :           :           :           :           :           :           :           :                    +- Scan parquet (689)
+                              :           :           :           :           :           :           :           :           :           :           :           :           +- Sort (700)
+                              :           :           :           :           :           :           :           :           :           :           :           :              +- Exchange (699)
+                              :           :           :           :           :           :           :           :           :           :           :           :                 +- Filter (698)
+                              :           :           :           :           :           :           :           :           :           :           :           :                    +- Scan parquet (697)
+                              :           :           :           :           :           :           :           :           :           :           :           +- Sort (708)
+                              :           :           :           :           :           :           :           :           :           :           :              +- Exchange (707)
+                              :           :           :           :           :           :           :           :           :           :           :                 +- Filter (706)
+                              :           :           :           :           :           :           :           :           :           :           :                    +- Scan parquet (705)
+                              :           :           :           :           :           :           :           :           :           :           +- Sort (716)
+                              :           :           :           :           :           :           :           :           :           :              +- Exchange (715)
+                              :           :           :           :           :           :           :           :           :           :                 +- Filter (714)
+                              :           :           :           :           :           :           :           :           :           :                    +- Scan parquet (713)
+                              :           :           :           :           :           :           :           :           :           +- Sort (724)
+                              :           :           :           :           :           :           :           :           :              +- Exchange (723)
+                              :           :           :           :           :           :           :           :           :                 +- Filter (722)
+                              :           :           :           :           :           :           :           :           :                    +- Scan parquet (721)
+                              :           :           :           :           :           :           :           :           +- Sort (732)
+                              :           :           :           :           :           :           :           :              +- Exchange (731)
+                              :           :           :           :           :           :           :           :                 +- Filter (730)
+                              :           :           :           :           :           :           :           :                    +- Scan parquet (729)
+                              :           :           :           :           :           :           :           +- Sort (740)
+                              :           :           :           :           :           :           :              +- Exchange (739)
+                              :           :           :           :           :           :           :                 +- Filter (738)
+                              :           :           :           :           :           :           :                    +- Scan parquet (737)
+                              :           :           :           :           :           :           +- Sort (748)
+                              :           :           :           :           :           :              +- Exchange (747)
+                              :           :           :           :           :           :                 +- Filter (746)
+                              :           :           :           :           :           :                    +- Scan parquet (745)
+                              :           :           :           :           :           +- Sort (756)
+                              :           :           :           :           :              +- Exchange (755)
+                              :           :           :           :           :                 +- Filter (754)
+                              :           :           :           :           :                    +- Scan parquet (753)
+                              :           :           :           :           +- Sort (764)
+                              :           :           :           :              +- Exchange (763)
+                              :           :           :           :                 +- Filter (762)
+                              :           :           :           :                    +- Scan parquet (761)
+                              :           :           :           +- Sort (772)
+                              :           :           :              +- Exchange (771)
+                              :           :           :                 +- Filter (770)
+                              :           :           :                    +- Scan parquet (769)
+                              :           :           +- Sort (780)
+                              :           :              +- Exchange (779)
+                              :           :                 +- Filter (778)
+                              :           :                    +- Scan parquet (777)
+                              :           +- Sort (788)
+                              :              +- Exchange (787)
+                              :                 +- Filter (786)
+                              :                    +- Scan parquet (785)
+                              +- Sort (797)
+                                 +- Exchange (796)
+                                    +- Project (795)
+                                       +- Filter (794)
+                                          +- Scan parquet (793)
 
 
-(497) Scan parquet
+(494) Scan parquet
 Output [12]: [ss_sold_date_sk#1, ss_item_sk#2, ss_customer_sk#3, ss_cdemo_sk#4, ss_hdemo_sk#5, ss_addr_sk#6, ss_store_sk#7, ss_promo_sk#8, ss_ticket_number#9, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
@@ -848,7 +845,7 @@ Input [12]: [#1#1, #2#2, #3#3, #4#4, #5#5, #6#6, #7#7, #8#8, #9#9, #10#10, #11#1
 Input [12]: [#1#1, #2#2, #3#3, #4#4, #5#5, #6#6, #7#7, #8#8, #9#9, #10#10, #11#11, #12#12]
 Arguments: [ss_item_sk#2 ASC NULLS FIRST, ss_ticket_number#9 ASC NULLS FIRST], false
 
-(501) Scan parquet
+(498) Scan parquet
 Output [2]: [sr_item_sk#13, sr_ticket_number#14]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
@@ -911,7 +908,7 @@ Input [11]: [ss_sold_date_sk#1, ss_item_sk#2, ss_customer_sk#3, ss_cdemo_sk#4, s
 Input [11]: [ss_sold_date_sk#1, ss_item_sk#2, ss_customer_sk#3, ss_cdemo_sk#4, ss_hdemo_sk#5, ss_addr_sk#6, ss_store_sk#7, ss_promo_sk#8, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12]
 Arguments: [ss_item_sk#2 ASC NULLS FIRST], false
 
-(509) Scan parquet
+(506) Scan parquet
 Output [3]: [cs_item_sk#15, cs_order_number#16, cs_ext_list_price#17]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
@@ -945,7 +942,7 @@ Input [3]: [#15#15, #16#16, #17#17]
 Input [3]: [#15#15, #16#16, #17#17]
 Arguments: [cs_item_sk#15 ASC NULLS FIRST, cs_order_number#16 ASC NULLS FIRST], false
 
-(513) Scan parquet
+(510) Scan parquet
 Output [5]: [cr_item_sk#18, cr_order_number#19, cr_refunded_cash#20, cr_reversed_charge#21, cr_store_credit#22]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
@@ -1067,7 +1064,7 @@ Input [11]: [ss_sold_date_sk#1, ss_item_sk#2, ss_customer_sk#3, ss_cdemo_sk#4, s
 Input [11]: [ss_sold_date_sk#1, ss_item_sk#2, ss_customer_sk#3, ss_cdemo_sk#4, ss_hdemo_sk#5, ss_addr_sk#6, ss_store_sk#7, ss_promo_sk#8, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12]
 Arguments: [ss_sold_date_sk#1 ASC NULLS FIRST], false
 
-(529) Scan parquet
+(526) Scan parquet
 Output [2]: [d_date_sk#34, d_year#35]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
@@ -1130,7 +1127,7 @@ Input [11]: [ss_item_sk#2, ss_customer_sk#3, ss_cdemo_sk#4, ss_hdemo_sk#5, ss_ad
 Input [11]: [ss_item_sk#2, ss_customer_sk#3, ss_cdemo_sk#4, ss_hdemo_sk#5, ss_addr_sk#6, ss_store_sk#7, ss_promo_sk#8, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35]
 Arguments: [ss_store_sk#7 ASC NULLS FIRST], false
 
-(537) Scan parquet
+(534) Scan parquet
 Output [3]: [s_store_sk#36, s_store_name#37, s_zip#38]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
@@ -1193,7 +1190,7 @@ Input [12]: [ss_item_sk#2, ss_customer_sk#3, ss_cdemo_sk#4, ss_hdemo_sk#5, ss_ad
 Input [12]: [ss_item_sk#2, ss_customer_sk#3, ss_cdemo_sk#4, ss_hdemo_sk#5, ss_addr_sk#6, ss_promo_sk#8, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38]
 Arguments: [ss_customer_sk#3 ASC NULLS FIRST], false
 
-(545) Scan parquet
+(542) Scan parquet
 Output [6]: [c_customer_sk#39, c_current_cdemo_sk#40, c_current_hdemo_sk#41, c_current_addr_sk#42, c_first_shipto_date_sk#43, c_first_sales_date_sk#44]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
@@ -1256,7 +1253,7 @@ Input [16]: [ss_item_sk#2, ss_cdemo_sk#4, ss_hdemo_sk#5, ss_addr_sk#6, ss_promo_
 Input [16]: [ss_item_sk#2, ss_cdemo_sk#4, ss_hdemo_sk#5, ss_addr_sk#6, ss_promo_sk#8, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, c_current_cdemo_sk#40, c_current_hdemo_sk#41, c_current_addr_sk#42, c_first_shipto_date_sk#43, c_first_sales_date_sk#44]
 Arguments: [c_first_sales_date_sk#44 ASC NULLS FIRST], false
 
-(553) Scan parquet
+(550) Scan parquet
 Output [2]: [d_date_sk#45, d_year#46]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
@@ -1370,7 +1367,7 @@ Input [16]: [ss_item_sk#2, ss_cdemo_sk#4, ss_hdemo_sk#5, ss_addr_sk#6, ss_promo_
 Input [16]: [ss_item_sk#2, ss_cdemo_sk#4, ss_hdemo_sk#5, ss_addr_sk#6, ss_promo_sk#8, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, c_current_cdemo_sk#40, c_current_hdemo_sk#41, c_current_addr_sk#42, d_year#46, d_year#48]
 Arguments: [ss_cdemo_sk#4 ASC NULLS FIRST], false
 
-(569) Scan parquet
+(566) Scan parquet
 Output [2]: [cd_demo_sk#49, cd_marital_status#50]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
@@ -1455,2857 +1452,2848 @@ Input [2]: [#51#51, #52#52]
 Input [2]: [#51#51, #52#52]
 Arguments: [cd_demo_sk#51 ASC NULLS FIRST], false
 
-(154) SortMergeJoin [codegen id : X]
+(154) NativeSortMergeJoin
 Left keys [1]: [c_current_cdemo_sk#40]
 Right keys [1]: [cd_demo_sk#51]
 Join type: Inner
 Join condition: NOT (cd_marital_status#50 = cd_marital_status#52)
 
-(155) Project [codegen id : X]
+(155) NativeProject
 Output [14]: [ss_item_sk#2, ss_hdemo_sk#5, ss_addr_sk#6, ss_promo_sk#8, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, c_current_hdemo_sk#41, c_current_addr_sk#42, d_year#46, d_year#48]
 Input [18]: [ss_item_sk#2, ss_hdemo_sk#5, ss_addr_sk#6, ss_promo_sk#8, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, c_current_cdemo_sk#40, c_current_hdemo_sk#41, c_current_addr_sk#42, d_year#46, d_year#48, cd_marital_status#50, #51#51, #52#52]
 
-(156) ConvertToNative
-Input [14]: [ss_item_sk#2, ss_hdemo_sk#5, ss_addr_sk#6, ss_promo_sk#8, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, c_current_hdemo_sk#41, c_current_addr_sk#42, d_year#46, d_year#48]
-
-(157) NativeShuffleExchange
+(156) NativeShuffleExchange
 Input [14]: [ss_item_sk#2, ss_hdemo_sk#5, ss_addr_sk#6, ss_promo_sk#8, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, c_current_hdemo_sk#41, c_current_addr_sk#42, d_year#46, d_year#48]
 Arguments: hashpartitioning(ss_promo_sk#8, 100), ENSURE_REQUIREMENTS, [plan_id=19]
 
-(158) ShuffleQueryStage
+(157) ShuffleQueryStage
 Output [14]: [ss_item_sk#2, ss_hdemo_sk#5, ss_addr_sk#6, ss_promo_sk#8, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, c_current_hdemo_sk#41, c_current_addr_sk#42, d_year#46, d_year#48]
 Arguments: X
 
-(159) AQEShuffleRead
+(158) AQEShuffleRead
 Input [14]: [ss_item_sk#2, ss_hdemo_sk#5, ss_addr_sk#6, ss_promo_sk#8, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, c_current_hdemo_sk#41, c_current_addr_sk#42, d_year#46, d_year#48]
 Arguments: coalesced
 
-(160) InputAdapter
+(159) InputAdapter
 Input [14]: [ss_item_sk#2, ss_hdemo_sk#5, ss_addr_sk#6, ss_promo_sk#8, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, c_current_hdemo_sk#41, c_current_addr_sk#42, d_year#46, d_year#48]
 
-(161) NativeSort
+(160) NativeSort
 Input [14]: [ss_item_sk#2, ss_hdemo_sk#5, ss_addr_sk#6, ss_promo_sk#8, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, c_current_hdemo_sk#41, c_current_addr_sk#42, d_year#46, d_year#48]
 Arguments: [ss_promo_sk#8 ASC NULLS FIRST], false
 
-(585) Scan parquet
+(582) Scan parquet
 Output [1]: [p_promo_sk#53]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(p_promo_sk)]
 ReadSchema: struct<p_promo_sk:int>
 
-(163) InputAdapter
+(162) InputAdapter
 Input [1]: [p_promo_sk#53]
 Arguments: [#53]
 
-(164) NativeFilter
+(163) NativeFilter
 Input [1]: [#53#53]
 Condition : isnotnull(p_promo_sk#53)
 
-(165) NativeShuffleExchange
+(164) NativeShuffleExchange
 Input [1]: [#53#53]
 Arguments: hashpartitioning(p_promo_sk#53, 100), ENSURE_REQUIREMENTS, [plan_id=20]
 
-(166) ShuffleQueryStage
+(165) ShuffleQueryStage
 Output [1]: [#53#53]
 Arguments: X
 
-(167) AQEShuffleRead
+(166) AQEShuffleRead
 Input [1]: [#53#53]
 Arguments: coalesced
 
-(168) InputAdapter
+(167) InputAdapter
 Input [1]: [#53#53]
 
-(169) NativeSort
+(168) NativeSort
 Input [1]: [#53#53]
 Arguments: [p_promo_sk#53 ASC NULLS FIRST], false
 
-(170) NativeSortMergeJoin
+(169) NativeSortMergeJoin
 Left keys [1]: [ss_promo_sk#8]
 Right keys [1]: [p_promo_sk#53]
 Join type: Inner
 Join condition: None
 
-(171) NativeProject
+(170) NativeProject
 Output [13]: [ss_item_sk#2, ss_hdemo_sk#5, ss_addr_sk#6, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, c_current_hdemo_sk#41, c_current_addr_sk#42, d_year#46, d_year#48]
 Input [15]: [ss_item_sk#2, ss_hdemo_sk#5, ss_addr_sk#6, ss_promo_sk#8, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, c_current_hdemo_sk#41, c_current_addr_sk#42, d_year#46, d_year#48, #53#53]
 
-(172) NativeShuffleExchange
+(171) NativeShuffleExchange
 Input [13]: [ss_item_sk#2, ss_hdemo_sk#5, ss_addr_sk#6, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, c_current_hdemo_sk#41, c_current_addr_sk#42, d_year#46, d_year#48]
 Arguments: hashpartitioning(ss_hdemo_sk#5, 100), ENSURE_REQUIREMENTS, [plan_id=21]
 
-(173) ShuffleQueryStage
+(172) ShuffleQueryStage
 Output [13]: [ss_item_sk#2, ss_hdemo_sk#5, ss_addr_sk#6, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, c_current_hdemo_sk#41, c_current_addr_sk#42, d_year#46, d_year#48]
 Arguments: X
 
-(174) AQEShuffleRead
+(173) AQEShuffleRead
 Input [13]: [ss_item_sk#2, ss_hdemo_sk#5, ss_addr_sk#6, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, c_current_hdemo_sk#41, c_current_addr_sk#42, d_year#46, d_year#48]
 Arguments: coalesced
 
-(175) InputAdapter
+(174) InputAdapter
 Input [13]: [ss_item_sk#2, ss_hdemo_sk#5, ss_addr_sk#6, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, c_current_hdemo_sk#41, c_current_addr_sk#42, d_year#46, d_year#48]
 
-(176) NativeSort
+(175) NativeSort
 Input [13]: [ss_item_sk#2, ss_hdemo_sk#5, ss_addr_sk#6, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, c_current_hdemo_sk#41, c_current_addr_sk#42, d_year#46, d_year#48]
 Arguments: [ss_hdemo_sk#5 ASC NULLS FIRST], false
 
-(593) Scan parquet
+(590) Scan parquet
 Output [2]: [hd_demo_sk#54, hd_income_band_sk#55]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(hd_demo_sk), IsNotNull(hd_income_band_sk)]
 ReadSchema: struct<hd_demo_sk:int,hd_income_band_sk:int>
 
-(178) InputAdapter
+(177) InputAdapter
 Input [2]: [hd_demo_sk#54, hd_income_band_sk#55]
 Arguments: [#54, #55]
 
-(179) NativeFilter
+(178) NativeFilter
 Input [2]: [#54#54, #55#55]
 Condition : (isnotnull(hd_demo_sk#54) AND isnotnull(hd_income_band_sk#55))
 
-(180) NativeShuffleExchange
+(179) NativeShuffleExchange
 Input [2]: [#54#54, #55#55]
 Arguments: hashpartitioning(hd_demo_sk#54, 100), ENSURE_REQUIREMENTS, [plan_id=22]
 
-(181) ShuffleQueryStage
+(180) ShuffleQueryStage
 Output [2]: [#54#54, #55#55]
 Arguments: X
 
-(182) AQEShuffleRead
+(181) AQEShuffleRead
 Input [2]: [#54#54, #55#55]
 Arguments: coalesced
 
-(183) InputAdapter
+(182) InputAdapter
 Input [2]: [#54#54, #55#55]
 
-(184) NativeSort
+(183) NativeSort
 Input [2]: [#54#54, #55#55]
 Arguments: [hd_demo_sk#54 ASC NULLS FIRST], false
 
-(185) NativeSortMergeJoin
+(184) NativeSortMergeJoin
 Left keys [1]: [ss_hdemo_sk#5]
 Right keys [1]: [hd_demo_sk#54]
 Join type: Inner
 Join condition: None
 
-(186) NativeProject
+(185) NativeProject
 Output [13]: [ss_item_sk#2, ss_addr_sk#6, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, c_current_hdemo_sk#41, c_current_addr_sk#42, d_year#46, d_year#48, hd_income_band_sk#55]
 Input [15]: [ss_item_sk#2, ss_hdemo_sk#5, ss_addr_sk#6, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, c_current_hdemo_sk#41, c_current_addr_sk#42, d_year#46, d_year#48, #54#54, #55#55]
 
-(187) NativeShuffleExchange
+(186) NativeShuffleExchange
 Input [13]: [ss_item_sk#2, ss_addr_sk#6, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, c_current_hdemo_sk#41, c_current_addr_sk#42, d_year#46, d_year#48, hd_income_band_sk#55]
 Arguments: hashpartitioning(c_current_hdemo_sk#41, 100), ENSURE_REQUIREMENTS, [plan_id=23]
 
-(188) ShuffleQueryStage
+(187) ShuffleQueryStage
 Output [13]: [ss_item_sk#2, ss_addr_sk#6, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, c_current_hdemo_sk#41, c_current_addr_sk#42, d_year#46, d_year#48, hd_income_band_sk#55]
 Arguments: X
 
-(189) AQEShuffleRead
+(188) AQEShuffleRead
 Input [13]: [ss_item_sk#2, ss_addr_sk#6, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, c_current_hdemo_sk#41, c_current_addr_sk#42, d_year#46, d_year#48, hd_income_band_sk#55]
 Arguments: coalesced
 
-(190) InputAdapter
+(189) InputAdapter
 Input [13]: [ss_item_sk#2, ss_addr_sk#6, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, c_current_hdemo_sk#41, c_current_addr_sk#42, d_year#46, d_year#48, hd_income_band_sk#55]
 
-(191) NativeSort
+(190) NativeSort
 Input [13]: [ss_item_sk#2, ss_addr_sk#6, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, c_current_hdemo_sk#41, c_current_addr_sk#42, d_year#46, d_year#48, hd_income_band_sk#55]
 Arguments: [c_current_hdemo_sk#41 ASC NULLS FIRST], false
 
-(192) ReusedExchange [Reuses operator id: 180]
+(191) ReusedExchange [Reuses operator id: 179]
 Output [2]: [hd_demo_sk#56, hd_income_band_sk#57]
 
-(193) ShuffleQueryStage
+(192) ShuffleQueryStage
 Output [2]: [hd_demo_sk#56, hd_income_band_sk#57]
 Arguments: X
 
-(194) AQEShuffleRead
+(193) AQEShuffleRead
 Input [2]: [hd_demo_sk#56, hd_income_band_sk#57]
 Arguments: coalesced
 
-(195) InputAdapter
+(194) InputAdapter
 Input [2]: [hd_demo_sk#56, hd_income_band_sk#57]
 Arguments: [#56, #57]
 
-(196) InputAdapter
+(195) InputAdapter
 Input [2]: [#56#56, #57#57]
 
-(197) NativeSort
+(196) NativeSort
 Input [2]: [#56#56, #57#57]
 Arguments: [hd_demo_sk#56 ASC NULLS FIRST], false
 
-(198) NativeSortMergeJoin
+(197) NativeSortMergeJoin
 Left keys [1]: [c_current_hdemo_sk#41]
 Right keys [1]: [hd_demo_sk#56]
 Join type: Inner
 Join condition: None
 
-(199) NativeProject
+(198) NativeProject
 Output [13]: [ss_item_sk#2, ss_addr_sk#6, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, c_current_addr_sk#42, d_year#46, d_year#48, hd_income_band_sk#55, hd_income_band_sk#57]
 Input [15]: [ss_item_sk#2, ss_addr_sk#6, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, c_current_hdemo_sk#41, c_current_addr_sk#42, d_year#46, d_year#48, hd_income_band_sk#55, #56#56, #57#57]
 
-(200) NativeShuffleExchange
+(199) NativeShuffleExchange
 Input [13]: [ss_item_sk#2, ss_addr_sk#6, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, c_current_addr_sk#42, d_year#46, d_year#48, hd_income_band_sk#55, hd_income_band_sk#57]
 Arguments: hashpartitioning(ss_addr_sk#6, 100), ENSURE_REQUIREMENTS, [plan_id=24]
 
-(201) ShuffleQueryStage
+(200) ShuffleQueryStage
 Output [13]: [ss_item_sk#2, ss_addr_sk#6, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, c_current_addr_sk#42, d_year#46, d_year#48, hd_income_band_sk#55, hd_income_band_sk#57]
 Arguments: X
 
-(202) AQEShuffleRead
+(201) AQEShuffleRead
 Input [13]: [ss_item_sk#2, ss_addr_sk#6, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, c_current_addr_sk#42, d_year#46, d_year#48, hd_income_band_sk#55, hd_income_band_sk#57]
 Arguments: coalesced
 
-(203) InputAdapter
+(202) InputAdapter
 Input [13]: [ss_item_sk#2, ss_addr_sk#6, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, c_current_addr_sk#42, d_year#46, d_year#48, hd_income_band_sk#55, hd_income_band_sk#57]
 
-(204) NativeSort
+(203) NativeSort
 Input [13]: [ss_item_sk#2, ss_addr_sk#6, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, c_current_addr_sk#42, d_year#46, d_year#48, hd_income_band_sk#55, hd_income_band_sk#57]
 Arguments: [ss_addr_sk#6 ASC NULLS FIRST], false
 
-(609) Scan parquet
+(606) Scan parquet
 Output [5]: [ca_address_sk#58, ca_street_number#59, ca_street_name#60, ca_city#61, ca_zip#62]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(ca_address_sk)]
 ReadSchema: struct<ca_address_sk:int,ca_street_number:string,ca_street_name:string,ca_city:string,ca_zip:string>
 
-(206) InputAdapter
+(205) InputAdapter
 Input [5]: [ca_address_sk#58, ca_street_number#59, ca_street_name#60, ca_city#61, ca_zip#62]
 Arguments: [#58, #59, #60, #61, #62]
 
-(207) NativeFilter
+(206) NativeFilter
 Input [5]: [#58#58, #59#59, #60#60, #61#61, #62#62]
 Condition : isnotnull(ca_address_sk#58)
 
-(208) NativeShuffleExchange
+(207) NativeShuffleExchange
 Input [5]: [#58#58, #59#59, #60#60, #61#61, #62#62]
 Arguments: hashpartitioning(ca_address_sk#58, 100), ENSURE_REQUIREMENTS, [plan_id=25]
 
-(209) ShuffleQueryStage
+(208) ShuffleQueryStage
 Output [5]: [#58#58, #59#59, #60#60, #61#61, #62#62]
 Arguments: X
 
-(210) AQEShuffleRead
+(209) AQEShuffleRead
 Input [5]: [#58#58, #59#59, #60#60, #61#61, #62#62]
 Arguments: coalesced
 
-(211) InputAdapter
+(210) InputAdapter
 Input [5]: [#58#58, #59#59, #60#60, #61#61, #62#62]
 
-(212) NativeSort
+(211) NativeSort
 Input [5]: [#58#58, #59#59, #60#60, #61#61, #62#62]
 Arguments: [ca_address_sk#58 ASC NULLS FIRST], false
 
-(213) NativeSortMergeJoin
+(212) NativeSortMergeJoin
 Left keys [1]: [ss_addr_sk#6]
 Right keys [1]: [ca_address_sk#58]
 Join type: Inner
 Join condition: None
 
-(214) NativeProject
+(213) NativeProject
 Output [16]: [ss_item_sk#2, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, c_current_addr_sk#42, d_year#46, d_year#48, hd_income_band_sk#55, hd_income_band_sk#57, ca_street_number#59, ca_street_name#60, ca_city#61, ca_zip#62]
 Input [18]: [ss_item_sk#2, ss_addr_sk#6, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, c_current_addr_sk#42, d_year#46, d_year#48, hd_income_band_sk#55, hd_income_band_sk#57, #58#58, #59#59, #60#60, #61#61, #62#62]
 
-(215) NativeShuffleExchange
+(214) NativeShuffleExchange
 Input [16]: [ss_item_sk#2, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, c_current_addr_sk#42, d_year#46, d_year#48, hd_income_band_sk#55, hd_income_band_sk#57, ca_street_number#59, ca_street_name#60, ca_city#61, ca_zip#62]
 Arguments: hashpartitioning(c_current_addr_sk#42, 100), ENSURE_REQUIREMENTS, [plan_id=26]
 
-(216) ShuffleQueryStage
+(215) ShuffleQueryStage
 Output [16]: [ss_item_sk#2, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, c_current_addr_sk#42, d_year#46, d_year#48, hd_income_band_sk#55, hd_income_band_sk#57, ca_street_number#59, ca_street_name#60, ca_city#61, ca_zip#62]
 Arguments: X
 
-(217) AQEShuffleRead
+(216) AQEShuffleRead
 Input [16]: [ss_item_sk#2, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, c_current_addr_sk#42, d_year#46, d_year#48, hd_income_band_sk#55, hd_income_band_sk#57, ca_street_number#59, ca_street_name#60, ca_city#61, ca_zip#62]
 Arguments: coalesced
 
-(218) InputAdapter
+(217) InputAdapter
 Input [16]: [ss_item_sk#2, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, c_current_addr_sk#42, d_year#46, d_year#48, hd_income_band_sk#55, hd_income_band_sk#57, ca_street_number#59, ca_street_name#60, ca_city#61, ca_zip#62]
 
-(219) NativeSort
+(218) NativeSort
 Input [16]: [ss_item_sk#2, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, c_current_addr_sk#42, d_year#46, d_year#48, hd_income_band_sk#55, hd_income_band_sk#57, ca_street_number#59, ca_street_name#60, ca_city#61, ca_zip#62]
 Arguments: [c_current_addr_sk#42 ASC NULLS FIRST], false
 
-(220) ReusedExchange [Reuses operator id: 208]
+(219) ReusedExchange [Reuses operator id: 207]
 Output [5]: [ca_address_sk#63, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67]
 
-(221) ShuffleQueryStage
+(220) ShuffleQueryStage
 Output [5]: [ca_address_sk#63, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67]
 Arguments: X
 
-(222) AQEShuffleRead
+(221) AQEShuffleRead
 Input [5]: [ca_address_sk#63, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67]
 Arguments: coalesced
 
-(223) InputAdapter
+(222) InputAdapter
 Input [5]: [ca_address_sk#63, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67]
 Arguments: [#63, #64, #65, #66, #67]
 
-(224) InputAdapter
+(223) InputAdapter
 Input [5]: [#63#63, #64#64, #65#65, #66#66, #67#67]
 
-(225) NativeSort
+(224) NativeSort
 Input [5]: [#63#63, #64#64, #65#65, #66#66, #67#67]
 Arguments: [ca_address_sk#63 ASC NULLS FIRST], false
 
-(226) NativeSortMergeJoin
+(225) NativeSortMergeJoin
 Left keys [1]: [c_current_addr_sk#42]
 Right keys [1]: [ca_address_sk#63]
 Join type: Inner
 Join condition: None
 
-(227) NativeProject
+(226) NativeProject
 Output [19]: [ss_item_sk#2, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, d_year#46, d_year#48, hd_income_band_sk#55, hd_income_band_sk#57, ca_street_number#59, ca_street_name#60, ca_city#61, ca_zip#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67]
 Input [21]: [ss_item_sk#2, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, c_current_addr_sk#42, d_year#46, d_year#48, hd_income_band_sk#55, hd_income_band_sk#57, ca_street_number#59, ca_street_name#60, ca_city#61, ca_zip#62, #63#63, #64#64, #65#65, #66#66, #67#67]
 
-(228) NativeShuffleExchange
+(227) NativeShuffleExchange
 Input [19]: [ss_item_sk#2, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, d_year#46, d_year#48, hd_income_band_sk#55, hd_income_band_sk#57, ca_street_number#59, ca_street_name#60, ca_city#61, ca_zip#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67]
 Arguments: hashpartitioning(hd_income_band_sk#55, 100), ENSURE_REQUIREMENTS, [plan_id=27]
 
-(229) ShuffleQueryStage
+(228) ShuffleQueryStage
 Output [19]: [ss_item_sk#2, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, d_year#46, d_year#48, hd_income_band_sk#55, hd_income_band_sk#57, ca_street_number#59, ca_street_name#60, ca_city#61, ca_zip#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67]
 Arguments: X
 
-(230) AQEShuffleRead
+(229) AQEShuffleRead
 Input [19]: [ss_item_sk#2, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, d_year#46, d_year#48, hd_income_band_sk#55, hd_income_band_sk#57, ca_street_number#59, ca_street_name#60, ca_city#61, ca_zip#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67]
 Arguments: coalesced
 
-(231) InputAdapter
+(230) InputAdapter
 Input [19]: [ss_item_sk#2, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, d_year#46, d_year#48, hd_income_band_sk#55, hd_income_band_sk#57, ca_street_number#59, ca_street_name#60, ca_city#61, ca_zip#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67]
 
-(232) NativeSort
+(231) NativeSort
 Input [19]: [ss_item_sk#2, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, d_year#46, d_year#48, hd_income_band_sk#55, hd_income_band_sk#57, ca_street_number#59, ca_street_name#60, ca_city#61, ca_zip#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67]
 Arguments: [hd_income_band_sk#55 ASC NULLS FIRST], false
 
-(625) Scan parquet
+(622) Scan parquet
 Output [1]: [ib_income_band_sk#68]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(ib_income_band_sk)]
 ReadSchema: struct<ib_income_band_sk:int>
 
-(234) InputAdapter
+(233) InputAdapter
 Input [1]: [ib_income_band_sk#68]
 Arguments: [#68]
 
-(235) NativeFilter
+(234) NativeFilter
 Input [1]: [#68#68]
 Condition : isnotnull(ib_income_band_sk#68)
 
-(236) NativeShuffleExchange
+(235) NativeShuffleExchange
 Input [1]: [#68#68]
 Arguments: hashpartitioning(ib_income_band_sk#68, 100), ENSURE_REQUIREMENTS, [plan_id=28]
 
-(237) ShuffleQueryStage
+(236) ShuffleQueryStage
 Output [1]: [#68#68]
 Arguments: X
 
-(238) AQEShuffleRead
+(237) AQEShuffleRead
 Input [1]: [#68#68]
 Arguments: coalesced
 
-(239) InputAdapter
+(238) InputAdapter
 Input [1]: [#68#68]
 
-(240) NativeSort
+(239) NativeSort
 Input [1]: [#68#68]
 Arguments: [ib_income_band_sk#68 ASC NULLS FIRST], false
 
-(241) NativeSortMergeJoin
+(240) NativeSortMergeJoin
 Left keys [1]: [hd_income_band_sk#55]
 Right keys [1]: [ib_income_band_sk#68]
 Join type: Inner
 Join condition: None
 
-(242) NativeProject
+(241) NativeProject
 Output [18]: [ss_item_sk#2, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, d_year#46, d_year#48, hd_income_band_sk#57, ca_street_number#59, ca_street_name#60, ca_city#61, ca_zip#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67]
 Input [20]: [ss_item_sk#2, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, d_year#46, d_year#48, hd_income_band_sk#55, hd_income_band_sk#57, ca_street_number#59, ca_street_name#60, ca_city#61, ca_zip#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, #68#68]
 
-(243) NativeShuffleExchange
+(242) NativeShuffleExchange
 Input [18]: [ss_item_sk#2, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, d_year#46, d_year#48, hd_income_band_sk#57, ca_street_number#59, ca_street_name#60, ca_city#61, ca_zip#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67]
 Arguments: hashpartitioning(hd_income_band_sk#57, 100), ENSURE_REQUIREMENTS, [plan_id=29]
 
-(244) ShuffleQueryStage
+(243) ShuffleQueryStage
 Output [18]: [ss_item_sk#2, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, d_year#46, d_year#48, hd_income_band_sk#57, ca_street_number#59, ca_street_name#60, ca_city#61, ca_zip#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67]
 Arguments: X
 
-(245) AQEShuffleRead
+(244) AQEShuffleRead
 Input [18]: [ss_item_sk#2, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, d_year#46, d_year#48, hd_income_band_sk#57, ca_street_number#59, ca_street_name#60, ca_city#61, ca_zip#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67]
 Arguments: coalesced
 
-(246) InputAdapter
+(245) InputAdapter
 Input [18]: [ss_item_sk#2, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, d_year#46, d_year#48, hd_income_band_sk#57, ca_street_number#59, ca_street_name#60, ca_city#61, ca_zip#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67]
 
-(247) NativeSort
+(246) NativeSort
 Input [18]: [ss_item_sk#2, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, d_year#46, d_year#48, hd_income_band_sk#57, ca_street_number#59, ca_street_name#60, ca_city#61, ca_zip#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67]
 Arguments: [hd_income_band_sk#57 ASC NULLS FIRST], false
 
-(248) ReusedExchange [Reuses operator id: 236]
+(247) ReusedExchange [Reuses operator id: 235]
 Output [1]: [ib_income_band_sk#69]
 
-(249) ShuffleQueryStage
+(248) ShuffleQueryStage
 Output [1]: [ib_income_band_sk#69]
 Arguments: X
 
-(250) AQEShuffleRead
+(249) AQEShuffleRead
 Input [1]: [ib_income_band_sk#69]
 Arguments: coalesced
 
-(251) InputAdapter
+(250) InputAdapter
 Input [1]: [ib_income_band_sk#69]
 Arguments: [#69]
 
-(252) InputAdapter
+(251) InputAdapter
 Input [1]: [#69#69]
 
-(253) NativeSort
+(252) NativeSort
 Input [1]: [#69#69]
 Arguments: [ib_income_band_sk#69 ASC NULLS FIRST], false
 
-(254) NativeSortMergeJoin
+(253) NativeSortMergeJoin
 Left keys [1]: [hd_income_band_sk#57]
 Right keys [1]: [ib_income_band_sk#69]
 Join type: Inner
 Join condition: None
 
-(255) NativeProject
+(254) NativeProject
 Output [17]: [ss_item_sk#2, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, d_year#46, d_year#48, ca_street_number#59, ca_street_name#60, ca_city#61, ca_zip#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67]
 Input [19]: [ss_item_sk#2, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, d_year#46, d_year#48, hd_income_band_sk#57, ca_street_number#59, ca_street_name#60, ca_city#61, ca_zip#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, #69#69]
 
-(256) NativeShuffleExchange
+(255) NativeShuffleExchange
 Input [17]: [ss_item_sk#2, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, d_year#46, d_year#48, ca_street_number#59, ca_street_name#60, ca_city#61, ca_zip#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67]
 Arguments: hashpartitioning(ss_item_sk#2, 100), ENSURE_REQUIREMENTS, [plan_id=30]
 
-(257) ShuffleQueryStage
+(256) ShuffleQueryStage
 Output [17]: [ss_item_sk#2, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, d_year#46, d_year#48, ca_street_number#59, ca_street_name#60, ca_city#61, ca_zip#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67]
 Arguments: X
 
-(258) AQEShuffleRead
+(257) AQEShuffleRead
 Input [17]: [ss_item_sk#2, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, d_year#46, d_year#48, ca_street_number#59, ca_street_name#60, ca_city#61, ca_zip#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67]
 Arguments: coalesced
 
-(259) InputAdapter
+(258) InputAdapter
 Input [17]: [ss_item_sk#2, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, d_year#46, d_year#48, ca_street_number#59, ca_street_name#60, ca_city#61, ca_zip#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67]
 
-(260) NativeSort
+(259) NativeSort
 Input [17]: [ss_item_sk#2, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, d_year#46, d_year#48, ca_street_number#59, ca_street_name#60, ca_city#61, ca_zip#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67]
 Arguments: [ss_item_sk#2 ASC NULLS FIRST], false
 
-(641) Scan parquet
+(638) Scan parquet
 Output [4]: [i_item_sk#70, i_current_price#71, i_color#72, i_product_name#73]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(i_current_price), In(i_color, [burlywood,floral,indian,medium,purple,spring]), GreaterThanOrEqual(i_current_price,64.00), LessThanOrEqual(i_current_price,74.00), GreaterThanOrEqual(i_current_price,65.00), LessThanOrEqual(i_current_price,79.00), IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_current_price:decimal(7,2),i_color:string,i_product_name:string>
 
-(262) InputAdapter
+(261) InputAdapter
 Input [4]: [i_item_sk#70, i_current_price#71, i_color#72, i_product_name#73]
 Arguments: [#70, #71, #72, #73]
 
-(263) NativeFilter
+(262) NativeFilter
 Input [4]: [#70#70, #71#71, #72#72, #73#73]
 Condition : ((((((isnotnull(i_current_price#71) AND i_color#72 IN (purple,burlywood,indian,spring,floral,medium)) AND (i_current_price#71 >= 64.00)) AND (i_current_price#71 <= 74.00)) AND (i_current_price#71 >= 65.00)) AND (i_current_price#71 <= 79.00)) AND isnotnull(i_item_sk#70))
 
-(264) NativeProject
+(263) NativeProject
 Output [2]: [i_item_sk#70, i_product_name#73]
 Input [4]: [#70#70, #71#71, #72#72, #73#73]
 
-(265) NativeShuffleExchange
+(264) NativeShuffleExchange
 Input [2]: [i_item_sk#70, i_product_name#73]
 Arguments: hashpartitioning(i_item_sk#70, 100), ENSURE_REQUIREMENTS, [plan_id=31]
 
-(266) ShuffleQueryStage
+(265) ShuffleQueryStage
 Output [2]: [i_item_sk#70, i_product_name#73]
 Arguments: X
 
-(267) AQEShuffleRead
+(266) AQEShuffleRead
 Input [2]: [i_item_sk#70, i_product_name#73]
 Arguments: coalesced
 
-(268) InputAdapter
+(267) InputAdapter
 Input [2]: [i_item_sk#70, i_product_name#73]
 
-(269) NativeSort
+(268) NativeSort
 Input [2]: [i_item_sk#70, i_product_name#73]
 Arguments: [i_item_sk#70 ASC NULLS FIRST], false
 
-(270) NativeSortMergeJoin
+(269) NativeSortMergeJoin
 Left keys [1]: [ss_item_sk#2]
 Right keys [1]: [i_item_sk#70]
 Join type: Inner
 Join condition: None
 
-(271) NativeProject
+(270) NativeProject
 Output [18]: [ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, d_year#46, d_year#48, s_store_name#37, s_zip#38, ca_street_number#59, ca_street_name#60, ca_city#61, ca_zip#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, i_item_sk#70, i_product_name#73]
 Input [19]: [ss_item_sk#2, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, d_year#46, d_year#48, ca_street_number#59, ca_street_name#60, ca_city#61, ca_zip#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, i_item_sk#70, i_product_name#73]
 
-(272) NativeProject
+(271) NativeProject
 Output [18]: [i_product_name#73 AS i_product_name#73, i_item_sk#70 AS i_item_sk#70, s_store_name#37 AS s_store_name#37, s_zip#38 AS s_zip#38, ca_street_number#59 AS ca_street_number#59, ca_street_name#60 AS ca_street_name#60, ca_city#61 AS ca_city#61, ca_zip#62 AS ca_zip#62, ca_street_number#64 AS ca_street_number#64, ca_street_name#65 AS ca_street_name#65, ca_city#66 AS ca_city#66, ca_zip#67 AS ca_zip#67, d_year#35 AS d_year#35, d_year#46 AS d_year#46, d_year#48 AS d_year#48, UnscaledValue(ss_wholesale_cost#10) AS _c15#74, UnscaledValue(ss_list_price#11) AS _c16#75, UnscaledValue(ss_coupon_amt#12) AS _c17#76]
 Input [18]: [ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, d_year#46, d_year#48, s_store_name#37, s_zip#38, ca_street_number#59, ca_street_name#60, ca_city#61, ca_zip#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, i_item_sk#70, i_product_name#73]
 
-(273) NativeHashAggregate
+(272) NativeHashAggregate
 Input [18]: [i_product_name#73, i_item_sk#70, s_store_name#37, s_zip#38, ca_street_number#59, ca_street_name#60, ca_city#61, ca_zip#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, d_year#35, d_year#46, d_year#48, _c15#74, _c16#75, _c17#76]
 Keys [15]: [i_product_name#73, i_item_sk#70, s_store_name#37, s_zip#38, ca_street_number#59, ca_street_name#60, ca_city#61, ca_zip#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, d_year#35, d_year#46, d_year#48]
 Functions [4]: [partial_count(1), partial_sum(_c15#74), partial_sum(_c16#75), partial_sum(_c17#76)]
 Aggregate Attributes [4]: [count#77, sum#78, sum#79, sum#80]
 Results [19]: [i_product_name#73, i_item_sk#70, s_store_name#37, s_zip#38, ca_street_number#59, ca_street_name#60, ca_city#61, ca_zip#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, d_year#35, d_year#46, d_year#48, #28, #28, #28, #28]
 
-(274) NativeHashAggregate
+(273) NativeHashAggregate
 Input [19]: [i_product_name#73, i_item_sk#70, s_store_name#37, s_zip#38, ca_street_number#59, ca_street_name#60, ca_city#61, ca_zip#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, d_year#35, d_year#46, d_year#48, #28, #28, #28, #28]
 Keys [15]: [i_product_name#73, i_item_sk#70, s_store_name#37, s_zip#38, ca_street_number#59, ca_street_name#60, ca_city#61, ca_zip#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, d_year#35, d_year#46, d_year#48]
 Functions [4]: [count(1), sum(UnscaledValue(ss_wholesale_cost#10)), sum(UnscaledValue(ss_list_price#11)), sum(UnscaledValue(ss_coupon_amt#12))]
 Aggregate Attributes [4]: [count(1)#81, sum(UnscaledValue(ss_wholesale_cost#10))#82, sum(UnscaledValue(ss_list_price#11))#83, sum(UnscaledValue(ss_coupon_amt#12))#84]
 Results [19]: [i_product_name#73, i_item_sk#70, s_store_name#37, s_zip#38, ca_street_number#59, ca_street_name#60, ca_city#61, ca_zip#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, d_year#35, d_year#46, d_year#48, count(1)#81, sum(UnscaledValue(ss_wholesale_cost#10))#82, sum(UnscaledValue(ss_list_price#11))#83, sum(UnscaledValue(ss_coupon_amt#12))#84]
 
-(275) NativeProject
+(274) NativeProject
 Output [17]: [i_product_name#73 AS product_name#85, i_item_sk#70 AS item_sk#86, s_store_name#37 AS store_name#87, s_zip#38 AS store_zip#88, ca_street_number#59 AS b_street_number#89, ca_street_name#60 AS b_streen_name#90, ca_city#61 AS b_city#91, ca_zip#62 AS b_zip#92, ca_street_number#64 AS c_street_number#93, ca_street_name#65 AS c_street_name#94, ca_city#66 AS c_city#95, ca_zip#67 AS c_zip#96, d_year#35 AS syear#97, count(1)#81 AS cnt#98, MakeDecimal(sum(UnscaledValue(ss_wholesale_cost#10))#82,17,2) AS s1#99, MakeDecimal(sum(UnscaledValue(ss_list_price#11))#83,17,2) AS s2#100, MakeDecimal(sum(UnscaledValue(ss_coupon_amt#12))#84,17,2) AS s3#101]
 Input [19]: [i_product_name#73, i_item_sk#70, s_store_name#37, s_zip#38, ca_street_number#59, ca_street_name#60, ca_city#61, ca_zip#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, d_year#35, d_year#46, d_year#48, count(1)#81, sum(UnscaledValue(ss_wholesale_cost#10))#82, sum(UnscaledValue(ss_list_price#11))#83, sum(UnscaledValue(ss_coupon_amt#12))#84]
 
-(276) NativeShuffleExchange
+(275) NativeShuffleExchange
 Input [17]: [product_name#85, item_sk#86, store_name#87, store_zip#88, b_street_number#89, b_streen_name#90, b_city#91, b_zip#92, c_street_number#93, c_street_name#94, c_city#95, c_zip#96, syear#97, cnt#98, s1#99, s2#100, s3#101]
 Arguments: hashpartitioning(item_sk#86, store_name#87, store_zip#88, 100), ENSURE_REQUIREMENTS, [plan_id=32]
 
-(277) ShuffleQueryStage
+(276) ShuffleQueryStage
 Output [17]: [product_name#85, item_sk#86, store_name#87, store_zip#88, b_street_number#89, b_streen_name#90, b_city#91, b_zip#92, c_street_number#93, c_street_name#94, c_city#95, c_zip#96, syear#97, cnt#98, s1#99, s2#100, s3#101]
 Arguments: X
 
-(278) AQEShuffleRead
+(277) AQEShuffleRead
 Input [17]: [product_name#85, item_sk#86, store_name#87, store_zip#88, b_street_number#89, b_streen_name#90, b_city#91, b_zip#92, c_street_number#93, c_street_name#94, c_city#95, c_zip#96, syear#97, cnt#98, s1#99, s2#100, s3#101]
 Arguments: coalesced
 
-(279) InputAdapter
+(278) InputAdapter
 Input [17]: [product_name#85, item_sk#86, store_name#87, store_zip#88, b_street_number#89, b_streen_name#90, b_city#91, b_zip#92, c_street_number#93, c_street_name#94, c_city#95, c_zip#96, syear#97, cnt#98, s1#99, s2#100, s3#101]
 
-(280) NativeSort
+(279) NativeSort
 Input [17]: [product_name#85, item_sk#86, store_name#87, store_zip#88, b_street_number#89, b_streen_name#90, b_city#91, b_zip#92, c_street_number#93, c_street_name#94, c_city#95, c_zip#96, syear#97, cnt#98, s1#99, s2#100, s3#101]
 Arguments: [item_sk#86 ASC NULLS FIRST, store_name#87 ASC NULLS FIRST, store_zip#88 ASC NULLS FIRST], false
 
-(281) ReusedExchange [Reuses operator id: 55]
+(280) ReusedExchange [Reuses operator id: 55]
 Output [11]: [ss_sold_date_sk#102, ss_item_sk#103, ss_customer_sk#104, ss_cdemo_sk#105, ss_hdemo_sk#106, ss_addr_sk#107, ss_store_sk#108, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112]
 
-(282) ShuffleQueryStage
+(281) ShuffleQueryStage
 Output [11]: [ss_sold_date_sk#102, ss_item_sk#103, ss_customer_sk#104, ss_cdemo_sk#105, ss_hdemo_sk#106, ss_addr_sk#107, ss_store_sk#108, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112]
 Arguments: X
 
-(283) AQEShuffleRead
+(282) AQEShuffleRead
 Input [11]: [ss_sold_date_sk#102, ss_item_sk#103, ss_customer_sk#104, ss_cdemo_sk#105, ss_hdemo_sk#106, ss_addr_sk#107, ss_store_sk#108, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112]
 Arguments: coalesced
 
-(284) InputAdapter
+(283) InputAdapter
 Input [11]: [ss_sold_date_sk#102, ss_item_sk#103, ss_customer_sk#104, ss_cdemo_sk#105, ss_hdemo_sk#106, ss_addr_sk#107, ss_store_sk#108, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112]
 Arguments: [#102, #103, #104, #105, #106, #107, #108, #109, #110, #111, #112]
 
-(285) InputAdapter
+(284) InputAdapter
 Input [11]: [#102#102, #103#103, #104#104, #105#105, #106#106, #107#107, #108#108, #109#109, #110#110, #111#111, #112#112]
 
-(286) NativeSort
+(285) NativeSort
 Input [11]: [#102#102, #103#103, #104#104, #105#105, #106#106, #107#107, #108#108, #109#109, #110#110, #111#111, #112#112]
 Arguments: [ss_sold_date_sk#102 ASC NULLS FIRST], false
 
-(684) Scan parquet
+(681) Scan parquet
 Output [2]: [d_date_sk#113, d_year#114]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2000), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
-(288) InputAdapter
+(287) InputAdapter
 Input [2]: [d_date_sk#113, d_year#114]
 Arguments: [#113, #114]
 
-(289) NativeFilter
+(288) NativeFilter
 Input [2]: [#113#113, #114#114]
 Condition : ((isnotnull(d_year#114) AND (d_year#114 = 2000)) AND isnotnull(d_date_sk#113))
 
-(290) NativeShuffleExchange
+(289) NativeShuffleExchange
 Input [2]: [#113#113, #114#114]
 Arguments: hashpartitioning(d_date_sk#113, 100), ENSURE_REQUIREMENTS, [plan_id=33]
 
-(291) ShuffleQueryStage
+(290) ShuffleQueryStage
 Output [2]: [#113#113, #114#114]
 Arguments: X
 
-(292) AQEShuffleRead
+(291) AQEShuffleRead
 Input [2]: [#113#113, #114#114]
 Arguments: coalesced
 
-(293) InputAdapter
+(292) InputAdapter
 Input [2]: [#113#113, #114#114]
 
-(294) NativeSort
+(293) NativeSort
 Input [2]: [#113#113, #114#114]
 Arguments: [d_date_sk#113 ASC NULLS FIRST], false
 
-(295) NativeSortMergeJoin
+(294) NativeSortMergeJoin
 Left keys [1]: [ss_sold_date_sk#102]
 Right keys [1]: [d_date_sk#113]
 Join type: Inner
 Join condition: None
 
-(296) NativeProject
+(295) NativeProject
 Output [11]: [ss_item_sk#103, ss_customer_sk#104, ss_cdemo_sk#105, ss_hdemo_sk#106, ss_addr_sk#107, ss_store_sk#108, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114]
 Input [13]: [#102#102, #103#103, #104#104, #105#105, #106#106, #107#107, #108#108, #109#109, #110#110, #111#111, #112#112, #113#113, #114#114]
 
-(297) NativeShuffleExchange
+(296) NativeShuffleExchange
 Input [11]: [ss_item_sk#103, ss_customer_sk#104, ss_cdemo_sk#105, ss_hdemo_sk#106, ss_addr_sk#107, ss_store_sk#108, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114]
 Arguments: hashpartitioning(ss_store_sk#108, 100), ENSURE_REQUIREMENTS, [plan_id=34]
 
-(298) ShuffleQueryStage
+(297) ShuffleQueryStage
 Output [11]: [ss_item_sk#103, ss_customer_sk#104, ss_cdemo_sk#105, ss_hdemo_sk#106, ss_addr_sk#107, ss_store_sk#108, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114]
 Arguments: X
 
-(299) AQEShuffleRead
+(298) AQEShuffleRead
 Input [11]: [ss_item_sk#103, ss_customer_sk#104, ss_cdemo_sk#105, ss_hdemo_sk#106, ss_addr_sk#107, ss_store_sk#108, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114]
 Arguments: coalesced
 
-(300) InputAdapter
+(299) InputAdapter
 Input [11]: [ss_item_sk#103, ss_customer_sk#104, ss_cdemo_sk#105, ss_hdemo_sk#106, ss_addr_sk#107, ss_store_sk#108, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114]
 
-(301) NativeSort
+(300) NativeSort
 Input [11]: [ss_item_sk#103, ss_customer_sk#104, ss_cdemo_sk#105, ss_hdemo_sk#106, ss_addr_sk#107, ss_store_sk#108, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114]
 Arguments: [ss_store_sk#108 ASC NULLS FIRST], false
 
-(302) ReusedExchange [Reuses operator id: 78]
+(301) ReusedExchange [Reuses operator id: 78]
 Output [3]: [s_store_sk#115, s_store_name#116, s_zip#117]
 
-(303) ShuffleQueryStage
+(302) ShuffleQueryStage
 Output [3]: [s_store_sk#115, s_store_name#116, s_zip#117]
 Arguments: X
 
-(304) AQEShuffleRead
+(303) AQEShuffleRead
 Input [3]: [s_store_sk#115, s_store_name#116, s_zip#117]
 Arguments: coalesced
 
-(305) InputAdapter
+(304) InputAdapter
 Input [3]: [s_store_sk#115, s_store_name#116, s_zip#117]
 Arguments: [#115, #116, #117]
 
-(306) InputAdapter
+(305) InputAdapter
 Input [3]: [#115#115, #116#116, #117#117]
 
-(307) NativeSort
+(306) NativeSort
 Input [3]: [#115#115, #116#116, #117#117]
 Arguments: [s_store_sk#115 ASC NULLS FIRST], false
 
-(308) NativeSortMergeJoin
+(307) NativeSortMergeJoin
 Left keys [1]: [ss_store_sk#108]
 Right keys [1]: [s_store_sk#115]
 Join type: Inner
 Join condition: None
 
-(309) NativeProject
+(308) NativeProject
 Output [12]: [ss_item_sk#103, ss_customer_sk#104, ss_cdemo_sk#105, ss_hdemo_sk#106, ss_addr_sk#107, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117]
 Input [14]: [ss_item_sk#103, ss_customer_sk#104, ss_cdemo_sk#105, ss_hdemo_sk#106, ss_addr_sk#107, ss_store_sk#108, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, #115#115, #116#116, #117#117]
 
-(310) NativeShuffleExchange
+(309) NativeShuffleExchange
 Input [12]: [ss_item_sk#103, ss_customer_sk#104, ss_cdemo_sk#105, ss_hdemo_sk#106, ss_addr_sk#107, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117]
 Arguments: hashpartitioning(ss_customer_sk#104, 100), ENSURE_REQUIREMENTS, [plan_id=35]
 
-(311) ShuffleQueryStage
+(310) ShuffleQueryStage
 Output [12]: [ss_item_sk#103, ss_customer_sk#104, ss_cdemo_sk#105, ss_hdemo_sk#106, ss_addr_sk#107, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117]
 Arguments: X
 
-(312) AQEShuffleRead
+(311) AQEShuffleRead
 Input [12]: [ss_item_sk#103, ss_customer_sk#104, ss_cdemo_sk#105, ss_hdemo_sk#106, ss_addr_sk#107, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117]
 Arguments: coalesced
 
-(313) InputAdapter
+(312) InputAdapter
 Input [12]: [ss_item_sk#103, ss_customer_sk#104, ss_cdemo_sk#105, ss_hdemo_sk#106, ss_addr_sk#107, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117]
 
-(314) NativeSort
+(313) NativeSort
 Input [12]: [ss_item_sk#103, ss_customer_sk#104, ss_cdemo_sk#105, ss_hdemo_sk#106, ss_addr_sk#107, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117]
 Arguments: [ss_customer_sk#104 ASC NULLS FIRST], false
 
-(315) ReusedExchange [Reuses operator id: 93]
+(314) ReusedExchange [Reuses operator id: 93]
 Output [6]: [c_customer_sk#118, c_current_cdemo_sk#119, c_current_hdemo_sk#120, c_current_addr_sk#121, c_first_shipto_date_sk#122, c_first_sales_date_sk#123]
 
-(316) ShuffleQueryStage
+(315) ShuffleQueryStage
 Output [6]: [c_customer_sk#118, c_current_cdemo_sk#119, c_current_hdemo_sk#120, c_current_addr_sk#121, c_first_shipto_date_sk#122, c_first_sales_date_sk#123]
 Arguments: X
 
-(317) AQEShuffleRead
+(316) AQEShuffleRead
 Input [6]: [c_customer_sk#118, c_current_cdemo_sk#119, c_current_hdemo_sk#120, c_current_addr_sk#121, c_first_shipto_date_sk#122, c_first_sales_date_sk#123]
 Arguments: coalesced
 
-(318) InputAdapter
+(317) InputAdapter
 Input [6]: [c_customer_sk#118, c_current_cdemo_sk#119, c_current_hdemo_sk#120, c_current_addr_sk#121, c_first_shipto_date_sk#122, c_first_sales_date_sk#123]
 Arguments: [#118, #119, #120, #121, #122, #123]
 
-(319) InputAdapter
+(318) InputAdapter
 Input [6]: [#118#118, #119#119, #120#120, #121#121, #122#122, #123#123]
 
-(320) NativeSort
+(319) NativeSort
 Input [6]: [#118#118, #119#119, #120#120, #121#121, #122#122, #123#123]
 Arguments: [c_customer_sk#118 ASC NULLS FIRST], false
 
-(321) NativeSortMergeJoin
+(320) NativeSortMergeJoin
 Left keys [1]: [ss_customer_sk#104]
 Right keys [1]: [c_customer_sk#118]
 Join type: Inner
 Join condition: None
 
-(322) NativeProject
+(321) NativeProject
 Output [16]: [ss_item_sk#103, ss_cdemo_sk#105, ss_hdemo_sk#106, ss_addr_sk#107, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_cdemo_sk#119, c_current_hdemo_sk#120, c_current_addr_sk#121, c_first_shipto_date_sk#122, c_first_sales_date_sk#123]
 Input [18]: [ss_item_sk#103, ss_customer_sk#104, ss_cdemo_sk#105, ss_hdemo_sk#106, ss_addr_sk#107, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, #118#118, #119#119, #120#120, #121#121, #122#122, #123#123]
 
-(323) NativeShuffleExchange
+(322) NativeShuffleExchange
 Input [16]: [ss_item_sk#103, ss_cdemo_sk#105, ss_hdemo_sk#106, ss_addr_sk#107, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_cdemo_sk#119, c_current_hdemo_sk#120, c_current_addr_sk#121, c_first_shipto_date_sk#122, c_first_sales_date_sk#123]
 Arguments: hashpartitioning(c_first_sales_date_sk#123, 100), ENSURE_REQUIREMENTS, [plan_id=36]
 
-(324) ShuffleQueryStage
+(323) ShuffleQueryStage
 Output [16]: [ss_item_sk#103, ss_cdemo_sk#105, ss_hdemo_sk#106, ss_addr_sk#107, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_cdemo_sk#119, c_current_hdemo_sk#120, c_current_addr_sk#121, c_first_shipto_date_sk#122, c_first_sales_date_sk#123]
 Arguments: X
 
-(325) AQEShuffleRead
+(324) AQEShuffleRead
 Input [16]: [ss_item_sk#103, ss_cdemo_sk#105, ss_hdemo_sk#106, ss_addr_sk#107, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_cdemo_sk#119, c_current_hdemo_sk#120, c_current_addr_sk#121, c_first_shipto_date_sk#122, c_first_sales_date_sk#123]
 Arguments: coalesced
 
-(326) InputAdapter
+(325) InputAdapter
 Input [16]: [ss_item_sk#103, ss_cdemo_sk#105, ss_hdemo_sk#106, ss_addr_sk#107, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_cdemo_sk#119, c_current_hdemo_sk#120, c_current_addr_sk#121, c_first_shipto_date_sk#122, c_first_sales_date_sk#123]
 
-(327) NativeSort
+(326) NativeSort
 Input [16]: [ss_item_sk#103, ss_cdemo_sk#105, ss_hdemo_sk#106, ss_addr_sk#107, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_cdemo_sk#119, c_current_hdemo_sk#120, c_current_addr_sk#121, c_first_shipto_date_sk#122, c_first_sales_date_sk#123]
 Arguments: [c_first_sales_date_sk#123 ASC NULLS FIRST], false
 
-(328) ReusedExchange [Reuses operator id: 108]
+(327) ReusedExchange [Reuses operator id: 108]
 Output [2]: [d_date_sk#124, d_year#125]
 
-(329) ShuffleQueryStage
+(328) ShuffleQueryStage
 Output [2]: [d_date_sk#124, d_year#125]
 Arguments: X
 
-(330) AQEShuffleRead
+(329) AQEShuffleRead
 Input [2]: [d_date_sk#124, d_year#125]
 Arguments: coalesced
 
-(331) InputAdapter
+(330) InputAdapter
 Input [2]: [d_date_sk#124, d_year#125]
 Arguments: [#124, #125]
 
-(332) InputAdapter
+(331) InputAdapter
 Input [2]: [#124#124, #125#125]
 
-(333) NativeSort
+(332) NativeSort
 Input [2]: [#124#124, #125#125]
 Arguments: [d_date_sk#124 ASC NULLS FIRST], false
 
-(334) NativeSortMergeJoin
+(333) NativeSortMergeJoin
 Left keys [1]: [c_first_sales_date_sk#123]
 Right keys [1]: [d_date_sk#124]
 Join type: Inner
 Join condition: None
 
-(335) NativeProject
+(334) NativeProject
 Output [16]: [ss_item_sk#103, ss_cdemo_sk#105, ss_hdemo_sk#106, ss_addr_sk#107, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_cdemo_sk#119, c_current_hdemo_sk#120, c_current_addr_sk#121, c_first_shipto_date_sk#122, d_year#125]
 Input [18]: [ss_item_sk#103, ss_cdemo_sk#105, ss_hdemo_sk#106, ss_addr_sk#107, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_cdemo_sk#119, c_current_hdemo_sk#120, c_current_addr_sk#121, c_first_shipto_date_sk#122, c_first_sales_date_sk#123, #124#124, #125#125]
 
-(336) NativeShuffleExchange
+(335) NativeShuffleExchange
 Input [16]: [ss_item_sk#103, ss_cdemo_sk#105, ss_hdemo_sk#106, ss_addr_sk#107, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_cdemo_sk#119, c_current_hdemo_sk#120, c_current_addr_sk#121, c_first_shipto_date_sk#122, d_year#125]
 Arguments: hashpartitioning(c_first_shipto_date_sk#122, 100), ENSURE_REQUIREMENTS, [plan_id=37]
 
-(337) ShuffleQueryStage
+(336) ShuffleQueryStage
 Output [16]: [ss_item_sk#103, ss_cdemo_sk#105, ss_hdemo_sk#106, ss_addr_sk#107, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_cdemo_sk#119, c_current_hdemo_sk#120, c_current_addr_sk#121, c_first_shipto_date_sk#122, d_year#125]
 Arguments: X
 
-(338) AQEShuffleRead
+(337) AQEShuffleRead
 Input [16]: [ss_item_sk#103, ss_cdemo_sk#105, ss_hdemo_sk#106, ss_addr_sk#107, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_cdemo_sk#119, c_current_hdemo_sk#120, c_current_addr_sk#121, c_first_shipto_date_sk#122, d_year#125]
 Arguments: coalesced
 
-(339) InputAdapter
+(338) InputAdapter
 Input [16]: [ss_item_sk#103, ss_cdemo_sk#105, ss_hdemo_sk#106, ss_addr_sk#107, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_cdemo_sk#119, c_current_hdemo_sk#120, c_current_addr_sk#121, c_first_shipto_date_sk#122, d_year#125]
 
-(340) NativeSort
+(339) NativeSort
 Input [16]: [ss_item_sk#103, ss_cdemo_sk#105, ss_hdemo_sk#106, ss_addr_sk#107, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_cdemo_sk#119, c_current_hdemo_sk#120, c_current_addr_sk#121, c_first_shipto_date_sk#122, d_year#125]
 Arguments: [c_first_shipto_date_sk#122 ASC NULLS FIRST], false
 
-(341) ReusedExchange [Reuses operator id: 108]
+(340) ReusedExchange [Reuses operator id: 108]
 Output [2]: [d_date_sk#126, d_year#127]
 
-(342) ShuffleQueryStage
+(341) ShuffleQueryStage
 Output [2]: [d_date_sk#126, d_year#127]
 Arguments: X
 
-(343) AQEShuffleRead
+(342) AQEShuffleRead
 Input [2]: [d_date_sk#126, d_year#127]
 Arguments: coalesced
 
-(344) InputAdapter
+(343) InputAdapter
 Input [2]: [d_date_sk#126, d_year#127]
 Arguments: [#126, #127]
 
-(345) InputAdapter
+(344) InputAdapter
 Input [2]: [#126#126, #127#127]
 
-(346) NativeSort
+(345) NativeSort
 Input [2]: [#126#126, #127#127]
 Arguments: [d_date_sk#126 ASC NULLS FIRST], false
 
-(347) NativeSortMergeJoin
+(346) NativeSortMergeJoin
 Left keys [1]: [c_first_shipto_date_sk#122]
 Right keys [1]: [d_date_sk#126]
 Join type: Inner
 Join condition: None
 
-(348) NativeProject
+(347) NativeProject
 Output [16]: [ss_item_sk#103, ss_cdemo_sk#105, ss_hdemo_sk#106, ss_addr_sk#107, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_cdemo_sk#119, c_current_hdemo_sk#120, c_current_addr_sk#121, d_year#125, d_year#127]
 Input [18]: [ss_item_sk#103, ss_cdemo_sk#105, ss_hdemo_sk#106, ss_addr_sk#107, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_cdemo_sk#119, c_current_hdemo_sk#120, c_current_addr_sk#121, c_first_shipto_date_sk#122, d_year#125, #126#126, #127#127]
 
-(349) NativeShuffleExchange
+(348) NativeShuffleExchange
 Input [16]: [ss_item_sk#103, ss_cdemo_sk#105, ss_hdemo_sk#106, ss_addr_sk#107, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_cdemo_sk#119, c_current_hdemo_sk#120, c_current_addr_sk#121, d_year#125, d_year#127]
 Arguments: hashpartitioning(ss_cdemo_sk#105, 100), ENSURE_REQUIREMENTS, [plan_id=38]
 
-(350) ShuffleQueryStage
+(349) ShuffleQueryStage
 Output [16]: [ss_item_sk#103, ss_cdemo_sk#105, ss_hdemo_sk#106, ss_addr_sk#107, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_cdemo_sk#119, c_current_hdemo_sk#120, c_current_addr_sk#121, d_year#125, d_year#127]
 Arguments: X
 
-(351) AQEShuffleRead
+(350) AQEShuffleRead
 Input [16]: [ss_item_sk#103, ss_cdemo_sk#105, ss_hdemo_sk#106, ss_addr_sk#107, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_cdemo_sk#119, c_current_hdemo_sk#120, c_current_addr_sk#121, d_year#125, d_year#127]
 Arguments: coalesced
 
-(352) InputAdapter
+(351) InputAdapter
 Input [16]: [ss_item_sk#103, ss_cdemo_sk#105, ss_hdemo_sk#106, ss_addr_sk#107, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_cdemo_sk#119, c_current_hdemo_sk#120, c_current_addr_sk#121, d_year#125, d_year#127]
 
-(353) NativeSort
+(352) NativeSort
 Input [16]: [ss_item_sk#103, ss_cdemo_sk#105, ss_hdemo_sk#106, ss_addr_sk#107, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_cdemo_sk#119, c_current_hdemo_sk#120, c_current_addr_sk#121, d_year#125, d_year#127]
 Arguments: [ss_cdemo_sk#105 ASC NULLS FIRST], false
 
-(354) ReusedExchange [Reuses operator id: 136]
+(353) ReusedExchange [Reuses operator id: 136]
 Output [2]: [cd_demo_sk#128, cd_marital_status#129]
 
-(355) ShuffleQueryStage
+(354) ShuffleQueryStage
 Output [2]: [cd_demo_sk#128, cd_marital_status#129]
 Arguments: X
 
-(356) AQEShuffleRead
+(355) AQEShuffleRead
 Input [2]: [cd_demo_sk#128, cd_marital_status#129]
 Arguments: coalesced
 
-(357) InputAdapter
+(356) InputAdapter
 Input [2]: [cd_demo_sk#128, cd_marital_status#129]
 Arguments: [#128, #129]
 
-(358) InputAdapter
+(357) InputAdapter
 Input [2]: [#128#128, #129#129]
 
-(359) NativeSort
+(358) NativeSort
 Input [2]: [#128#128, #129#129]
 Arguments: [cd_demo_sk#128 ASC NULLS FIRST], false
 
-(360) NativeSortMergeJoin
+(359) NativeSortMergeJoin
 Left keys [1]: [ss_cdemo_sk#105]
 Right keys [1]: [cd_demo_sk#128]
 Join type: Inner
 Join condition: None
 
-(361) NativeProject
+(360) NativeProject
 Output [16]: [ss_item_sk#103, ss_hdemo_sk#106, ss_addr_sk#107, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_cdemo_sk#119, c_current_hdemo_sk#120, c_current_addr_sk#121, d_year#125, d_year#127, cd_marital_status#129]
 Input [18]: [ss_item_sk#103, ss_cdemo_sk#105, ss_hdemo_sk#106, ss_addr_sk#107, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_cdemo_sk#119, c_current_hdemo_sk#120, c_current_addr_sk#121, d_year#125, d_year#127, #128#128, #129#129]
 
-(362) NativeShuffleExchange
+(361) NativeShuffleExchange
 Input [16]: [ss_item_sk#103, ss_hdemo_sk#106, ss_addr_sk#107, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_cdemo_sk#119, c_current_hdemo_sk#120, c_current_addr_sk#121, d_year#125, d_year#127, cd_marital_status#129]
 Arguments: hashpartitioning(c_current_cdemo_sk#119, 100), ENSURE_REQUIREMENTS, [plan_id=39]
 
-(363) ShuffleQueryStage
+(362) ShuffleQueryStage
 Output [16]: [ss_item_sk#103, ss_hdemo_sk#106, ss_addr_sk#107, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_cdemo_sk#119, c_current_hdemo_sk#120, c_current_addr_sk#121, d_year#125, d_year#127, cd_marital_status#129]
 Arguments: X
 
-(364) AQEShuffleRead
+(363) AQEShuffleRead
 Input [16]: [ss_item_sk#103, ss_hdemo_sk#106, ss_addr_sk#107, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_cdemo_sk#119, c_current_hdemo_sk#120, c_current_addr_sk#121, d_year#125, d_year#127, cd_marital_status#129]
 Arguments: coalesced
 
-(365) InputAdapter
+(364) InputAdapter
 Input [16]: [ss_item_sk#103, ss_hdemo_sk#106, ss_addr_sk#107, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_cdemo_sk#119, c_current_hdemo_sk#120, c_current_addr_sk#121, d_year#125, d_year#127, cd_marital_status#129]
 
-(366) NativeSort
+(365) NativeSort
 Input [16]: [ss_item_sk#103, ss_hdemo_sk#106, ss_addr_sk#107, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_cdemo_sk#119, c_current_hdemo_sk#120, c_current_addr_sk#121, d_year#125, d_year#127, cd_marital_status#129]
 Arguments: [c_current_cdemo_sk#119 ASC NULLS FIRST], false
 
-(367) ReusedExchange [Reuses operator id: 136]
+(366) ReusedExchange [Reuses operator id: 136]
 Output [2]: [cd_demo_sk#130, cd_marital_status#131]
 
-(368) ShuffleQueryStage
+(367) ShuffleQueryStage
 Output [2]: [cd_demo_sk#130, cd_marital_status#131]
 Arguments: X
 
-(369) AQEShuffleRead
+(368) AQEShuffleRead
 Input [2]: [cd_demo_sk#130, cd_marital_status#131]
 Arguments: coalesced
 
-(370) InputAdapter
+(369) InputAdapter
 Input [2]: [cd_demo_sk#130, cd_marital_status#131]
 Arguments: [#130, #131]
 
-(371) InputAdapter
+(370) InputAdapter
 Input [2]: [#130#130, #131#131]
 
-(372) NativeSort
+(371) NativeSort
 Input [2]: [#130#130, #131#131]
 Arguments: [cd_demo_sk#130 ASC NULLS FIRST], false
 
-(373) SortMergeJoin [codegen id : X]
+(372) NativeSortMergeJoin
 Left keys [1]: [c_current_cdemo_sk#119]
 Right keys [1]: [cd_demo_sk#130]
 Join type: Inner
 Join condition: NOT (cd_marital_status#129 = cd_marital_status#131)
 
-(374) Project [codegen id : X]
+(373) NativeProject
 Output [14]: [ss_item_sk#103, ss_hdemo_sk#106, ss_addr_sk#107, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_hdemo_sk#120, c_current_addr_sk#121, d_year#125, d_year#127]
 Input [18]: [ss_item_sk#103, ss_hdemo_sk#106, ss_addr_sk#107, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_cdemo_sk#119, c_current_hdemo_sk#120, c_current_addr_sk#121, d_year#125, d_year#127, cd_marital_status#129, #130#130, #131#131]
 
-(375) ConvertToNative
-Input [14]: [ss_item_sk#103, ss_hdemo_sk#106, ss_addr_sk#107, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_hdemo_sk#120, c_current_addr_sk#121, d_year#125, d_year#127]
-
-(376) NativeShuffleExchange
+(374) NativeShuffleExchange
 Input [14]: [ss_item_sk#103, ss_hdemo_sk#106, ss_addr_sk#107, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_hdemo_sk#120, c_current_addr_sk#121, d_year#125, d_year#127]
 Arguments: hashpartitioning(ss_promo_sk#109, 100), ENSURE_REQUIREMENTS, [plan_id=40]
 
-(377) ShuffleQueryStage
+(375) ShuffleQueryStage
 Output [14]: [ss_item_sk#103, ss_hdemo_sk#106, ss_addr_sk#107, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_hdemo_sk#120, c_current_addr_sk#121, d_year#125, d_year#127]
 Arguments: X
 
-(378) AQEShuffleRead
+(376) AQEShuffleRead
 Input [14]: [ss_item_sk#103, ss_hdemo_sk#106, ss_addr_sk#107, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_hdemo_sk#120, c_current_addr_sk#121, d_year#125, d_year#127]
 Arguments: coalesced
 
-(379) InputAdapter
+(377) InputAdapter
 Input [14]: [ss_item_sk#103, ss_hdemo_sk#106, ss_addr_sk#107, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_hdemo_sk#120, c_current_addr_sk#121, d_year#125, d_year#127]
 
-(380) NativeSort
+(378) NativeSort
 Input [14]: [ss_item_sk#103, ss_hdemo_sk#106, ss_addr_sk#107, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_hdemo_sk#120, c_current_addr_sk#121, d_year#125, d_year#127]
 Arguments: [ss_promo_sk#109 ASC NULLS FIRST], false
 
-(381) ReusedExchange [Reuses operator id: 165]
+(379) ReusedExchange [Reuses operator id: 164]
 Output [1]: [p_promo_sk#132]
 
-(382) ShuffleQueryStage
+(380) ShuffleQueryStage
 Output [1]: [p_promo_sk#132]
 Arguments: X
 
-(383) AQEShuffleRead
+(381) AQEShuffleRead
 Input [1]: [p_promo_sk#132]
 Arguments: coalesced
 
-(384) InputAdapter
+(382) InputAdapter
 Input [1]: [p_promo_sk#132]
 Arguments: [#132]
 
-(385) InputAdapter
+(383) InputAdapter
 Input [1]: [#132#132]
 
-(386) NativeSort
+(384) NativeSort
 Input [1]: [#132#132]
 Arguments: [p_promo_sk#132 ASC NULLS FIRST], false
 
-(387) NativeSortMergeJoin
+(385) NativeSortMergeJoin
 Left keys [1]: [ss_promo_sk#109]
 Right keys [1]: [p_promo_sk#132]
 Join type: Inner
 Join condition: None
 
-(388) NativeProject
+(386) NativeProject
 Output [13]: [ss_item_sk#103, ss_hdemo_sk#106, ss_addr_sk#107, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_hdemo_sk#120, c_current_addr_sk#121, d_year#125, d_year#127]
 Input [15]: [ss_item_sk#103, ss_hdemo_sk#106, ss_addr_sk#107, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_hdemo_sk#120, c_current_addr_sk#121, d_year#125, d_year#127, #132#132]
 
-(389) NativeShuffleExchange
+(387) NativeShuffleExchange
 Input [13]: [ss_item_sk#103, ss_hdemo_sk#106, ss_addr_sk#107, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_hdemo_sk#120, c_current_addr_sk#121, d_year#125, d_year#127]
 Arguments: hashpartitioning(ss_hdemo_sk#106, 100), ENSURE_REQUIREMENTS, [plan_id=41]
 
-(390) ShuffleQueryStage
+(388) ShuffleQueryStage
 Output [13]: [ss_item_sk#103, ss_hdemo_sk#106, ss_addr_sk#107, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_hdemo_sk#120, c_current_addr_sk#121, d_year#125, d_year#127]
 Arguments: X
 
-(391) AQEShuffleRead
+(389) AQEShuffleRead
 Input [13]: [ss_item_sk#103, ss_hdemo_sk#106, ss_addr_sk#107, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_hdemo_sk#120, c_current_addr_sk#121, d_year#125, d_year#127]
 Arguments: coalesced
 
-(392) InputAdapter
+(390) InputAdapter
 Input [13]: [ss_item_sk#103, ss_hdemo_sk#106, ss_addr_sk#107, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_hdemo_sk#120, c_current_addr_sk#121, d_year#125, d_year#127]
 
-(393) NativeSort
+(391) NativeSort
 Input [13]: [ss_item_sk#103, ss_hdemo_sk#106, ss_addr_sk#107, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_hdemo_sk#120, c_current_addr_sk#121, d_year#125, d_year#127]
 Arguments: [ss_hdemo_sk#106 ASC NULLS FIRST], false
 
-(394) ReusedExchange [Reuses operator id: 180]
+(392) ReusedExchange [Reuses operator id: 179]
 Output [2]: [hd_demo_sk#133, hd_income_band_sk#134]
 
-(395) ShuffleQueryStage
+(393) ShuffleQueryStage
 Output [2]: [hd_demo_sk#133, hd_income_band_sk#134]
 Arguments: X
 
-(396) AQEShuffleRead
+(394) AQEShuffleRead
 Input [2]: [hd_demo_sk#133, hd_income_band_sk#134]
 Arguments: coalesced
 
-(397) InputAdapter
+(395) InputAdapter
 Input [2]: [hd_demo_sk#133, hd_income_band_sk#134]
 Arguments: [#133, #134]
 
-(398) InputAdapter
+(396) InputAdapter
 Input [2]: [#133#133, #134#134]
 
-(399) NativeSort
+(397) NativeSort
 Input [2]: [#133#133, #134#134]
 Arguments: [hd_demo_sk#133 ASC NULLS FIRST], false
 
-(400) NativeSortMergeJoin
+(398) NativeSortMergeJoin
 Left keys [1]: [ss_hdemo_sk#106]
 Right keys [1]: [hd_demo_sk#133]
 Join type: Inner
 Join condition: None
 
-(401) NativeProject
+(399) NativeProject
 Output [13]: [ss_item_sk#103, ss_addr_sk#107, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_hdemo_sk#120, c_current_addr_sk#121, d_year#125, d_year#127, hd_income_band_sk#134]
 Input [15]: [ss_item_sk#103, ss_hdemo_sk#106, ss_addr_sk#107, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_hdemo_sk#120, c_current_addr_sk#121, d_year#125, d_year#127, #133#133, #134#134]
 
-(402) NativeShuffleExchange
+(400) NativeShuffleExchange
 Input [13]: [ss_item_sk#103, ss_addr_sk#107, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_hdemo_sk#120, c_current_addr_sk#121, d_year#125, d_year#127, hd_income_band_sk#134]
 Arguments: hashpartitioning(c_current_hdemo_sk#120, 100), ENSURE_REQUIREMENTS, [plan_id=42]
 
-(403) ShuffleQueryStage
+(401) ShuffleQueryStage
 Output [13]: [ss_item_sk#103, ss_addr_sk#107, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_hdemo_sk#120, c_current_addr_sk#121, d_year#125, d_year#127, hd_income_band_sk#134]
 Arguments: X
 
-(404) AQEShuffleRead
+(402) AQEShuffleRead
 Input [13]: [ss_item_sk#103, ss_addr_sk#107, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_hdemo_sk#120, c_current_addr_sk#121, d_year#125, d_year#127, hd_income_band_sk#134]
 Arguments: coalesced
 
-(405) InputAdapter
+(403) InputAdapter
 Input [13]: [ss_item_sk#103, ss_addr_sk#107, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_hdemo_sk#120, c_current_addr_sk#121, d_year#125, d_year#127, hd_income_band_sk#134]
 
-(406) NativeSort
+(404) NativeSort
 Input [13]: [ss_item_sk#103, ss_addr_sk#107, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_hdemo_sk#120, c_current_addr_sk#121, d_year#125, d_year#127, hd_income_band_sk#134]
 Arguments: [c_current_hdemo_sk#120 ASC NULLS FIRST], false
 
-(407) ReusedExchange [Reuses operator id: 180]
+(405) ReusedExchange [Reuses operator id: 179]
 Output [2]: [hd_demo_sk#135, hd_income_band_sk#136]
 
-(408) ShuffleQueryStage
+(406) ShuffleQueryStage
 Output [2]: [hd_demo_sk#135, hd_income_band_sk#136]
 Arguments: X
 
-(409) AQEShuffleRead
+(407) AQEShuffleRead
 Input [2]: [hd_demo_sk#135, hd_income_band_sk#136]
 Arguments: coalesced
 
-(410) InputAdapter
+(408) InputAdapter
 Input [2]: [hd_demo_sk#135, hd_income_band_sk#136]
 Arguments: [#135, #136]
 
-(411) InputAdapter
+(409) InputAdapter
 Input [2]: [#135#135, #136#136]
 
-(412) NativeSort
+(410) NativeSort
 Input [2]: [#135#135, #136#136]
 Arguments: [hd_demo_sk#135 ASC NULLS FIRST], false
 
-(413) NativeSortMergeJoin
+(411) NativeSortMergeJoin
 Left keys [1]: [c_current_hdemo_sk#120]
 Right keys [1]: [hd_demo_sk#135]
 Join type: Inner
 Join condition: None
 
-(414) NativeProject
+(412) NativeProject
 Output [13]: [ss_item_sk#103, ss_addr_sk#107, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_addr_sk#121, d_year#125, d_year#127, hd_income_band_sk#134, hd_income_band_sk#136]
 Input [15]: [ss_item_sk#103, ss_addr_sk#107, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_hdemo_sk#120, c_current_addr_sk#121, d_year#125, d_year#127, hd_income_band_sk#134, #135#135, #136#136]
 
-(415) NativeShuffleExchange
+(413) NativeShuffleExchange
 Input [13]: [ss_item_sk#103, ss_addr_sk#107, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_addr_sk#121, d_year#125, d_year#127, hd_income_band_sk#134, hd_income_band_sk#136]
 Arguments: hashpartitioning(ss_addr_sk#107, 100), ENSURE_REQUIREMENTS, [plan_id=43]
 
-(416) ShuffleQueryStage
+(414) ShuffleQueryStage
 Output [13]: [ss_item_sk#103, ss_addr_sk#107, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_addr_sk#121, d_year#125, d_year#127, hd_income_band_sk#134, hd_income_band_sk#136]
 Arguments: X
 
-(417) AQEShuffleRead
+(415) AQEShuffleRead
 Input [13]: [ss_item_sk#103, ss_addr_sk#107, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_addr_sk#121, d_year#125, d_year#127, hd_income_band_sk#134, hd_income_band_sk#136]
 Arguments: coalesced
 
-(418) InputAdapter
+(416) InputAdapter
 Input [13]: [ss_item_sk#103, ss_addr_sk#107, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_addr_sk#121, d_year#125, d_year#127, hd_income_band_sk#134, hd_income_band_sk#136]
 
-(419) NativeSort
+(417) NativeSort
 Input [13]: [ss_item_sk#103, ss_addr_sk#107, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_addr_sk#121, d_year#125, d_year#127, hd_income_band_sk#134, hd_income_band_sk#136]
 Arguments: [ss_addr_sk#107 ASC NULLS FIRST], false
 
-(420) ReusedExchange [Reuses operator id: 208]
+(418) ReusedExchange [Reuses operator id: 207]
 Output [5]: [ca_address_sk#137, ca_street_number#138, ca_street_name#139, ca_city#140, ca_zip#141]
 
-(421) ShuffleQueryStage
+(419) ShuffleQueryStage
 Output [5]: [ca_address_sk#137, ca_street_number#138, ca_street_name#139, ca_city#140, ca_zip#141]
 Arguments: X
 
-(422) AQEShuffleRead
+(420) AQEShuffleRead
 Input [5]: [ca_address_sk#137, ca_street_number#138, ca_street_name#139, ca_city#140, ca_zip#141]
 Arguments: coalesced
 
-(423) InputAdapter
+(421) InputAdapter
 Input [5]: [ca_address_sk#137, ca_street_number#138, ca_street_name#139, ca_city#140, ca_zip#141]
 Arguments: [#137, #138, #139, #140, #141]
 
-(424) InputAdapter
+(422) InputAdapter
 Input [5]: [#137#137, #138#138, #139#139, #140#140, #141#141]
 
-(425) NativeSort
+(423) NativeSort
 Input [5]: [#137#137, #138#138, #139#139, #140#140, #141#141]
 Arguments: [ca_address_sk#137 ASC NULLS FIRST], false
 
-(426) NativeSortMergeJoin
+(424) NativeSortMergeJoin
 Left keys [1]: [ss_addr_sk#107]
 Right keys [1]: [ca_address_sk#137]
 Join type: Inner
 Join condition: None
 
-(427) NativeProject
+(425) NativeProject
 Output [16]: [ss_item_sk#103, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_addr_sk#121, d_year#125, d_year#127, hd_income_band_sk#134, hd_income_band_sk#136, ca_street_number#138, ca_street_name#139, ca_city#140, ca_zip#141]
 Input [18]: [ss_item_sk#103, ss_addr_sk#107, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_addr_sk#121, d_year#125, d_year#127, hd_income_band_sk#134, hd_income_band_sk#136, #137#137, #138#138, #139#139, #140#140, #141#141]
 
-(428) NativeShuffleExchange
+(426) NativeShuffleExchange
 Input [16]: [ss_item_sk#103, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_addr_sk#121, d_year#125, d_year#127, hd_income_band_sk#134, hd_income_band_sk#136, ca_street_number#138, ca_street_name#139, ca_city#140, ca_zip#141]
 Arguments: hashpartitioning(c_current_addr_sk#121, 100), ENSURE_REQUIREMENTS, [plan_id=44]
 
-(429) ShuffleQueryStage
+(427) ShuffleQueryStage
 Output [16]: [ss_item_sk#103, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_addr_sk#121, d_year#125, d_year#127, hd_income_band_sk#134, hd_income_band_sk#136, ca_street_number#138, ca_street_name#139, ca_city#140, ca_zip#141]
 Arguments: X
 
-(430) AQEShuffleRead
+(428) AQEShuffleRead
 Input [16]: [ss_item_sk#103, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_addr_sk#121, d_year#125, d_year#127, hd_income_band_sk#134, hd_income_band_sk#136, ca_street_number#138, ca_street_name#139, ca_city#140, ca_zip#141]
 Arguments: coalesced
 
-(431) InputAdapter
+(429) InputAdapter
 Input [16]: [ss_item_sk#103, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_addr_sk#121, d_year#125, d_year#127, hd_income_band_sk#134, hd_income_band_sk#136, ca_street_number#138, ca_street_name#139, ca_city#140, ca_zip#141]
 
-(432) NativeSort
+(430) NativeSort
 Input [16]: [ss_item_sk#103, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_addr_sk#121, d_year#125, d_year#127, hd_income_band_sk#134, hd_income_band_sk#136, ca_street_number#138, ca_street_name#139, ca_city#140, ca_zip#141]
 Arguments: [c_current_addr_sk#121 ASC NULLS FIRST], false
 
-(433) ReusedExchange [Reuses operator id: 208]
+(431) ReusedExchange [Reuses operator id: 207]
 Output [5]: [ca_address_sk#142, ca_street_number#143, ca_street_name#144, ca_city#145, ca_zip#146]
 
-(434) ShuffleQueryStage
+(432) ShuffleQueryStage
 Output [5]: [ca_address_sk#142, ca_street_number#143, ca_street_name#144, ca_city#145, ca_zip#146]
 Arguments: X
 
-(435) AQEShuffleRead
+(433) AQEShuffleRead
 Input [5]: [ca_address_sk#142, ca_street_number#143, ca_street_name#144, ca_city#145, ca_zip#146]
 Arguments: coalesced
 
-(436) InputAdapter
+(434) InputAdapter
 Input [5]: [ca_address_sk#142, ca_street_number#143, ca_street_name#144, ca_city#145, ca_zip#146]
 Arguments: [#142, #143, #144, #145, #146]
 
-(437) InputAdapter
+(435) InputAdapter
 Input [5]: [#142#142, #143#143, #144#144, #145#145, #146#146]
 
-(438) NativeSort
+(436) NativeSort
 Input [5]: [#142#142, #143#143, #144#144, #145#145, #146#146]
 Arguments: [ca_address_sk#142 ASC NULLS FIRST], false
 
-(439) NativeSortMergeJoin
+(437) NativeSortMergeJoin
 Left keys [1]: [c_current_addr_sk#121]
 Right keys [1]: [ca_address_sk#142]
 Join type: Inner
 Join condition: None
 
-(440) NativeProject
+(438) NativeProject
 Output [19]: [ss_item_sk#103, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, d_year#125, d_year#127, hd_income_band_sk#134, hd_income_band_sk#136, ca_street_number#138, ca_street_name#139, ca_city#140, ca_zip#141, ca_street_number#143, ca_street_name#144, ca_city#145, ca_zip#146]
 Input [21]: [ss_item_sk#103, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_addr_sk#121, d_year#125, d_year#127, hd_income_band_sk#134, hd_income_band_sk#136, ca_street_number#138, ca_street_name#139, ca_city#140, ca_zip#141, #142#142, #143#143, #144#144, #145#145, #146#146]
 
-(441) NativeShuffleExchange
+(439) NativeShuffleExchange
 Input [19]: [ss_item_sk#103, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, d_year#125, d_year#127, hd_income_band_sk#134, hd_income_band_sk#136, ca_street_number#138, ca_street_name#139, ca_city#140, ca_zip#141, ca_street_number#143, ca_street_name#144, ca_city#145, ca_zip#146]
 Arguments: hashpartitioning(hd_income_band_sk#134, 100), ENSURE_REQUIREMENTS, [plan_id=45]
 
-(442) ShuffleQueryStage
+(440) ShuffleQueryStage
 Output [19]: [ss_item_sk#103, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, d_year#125, d_year#127, hd_income_band_sk#134, hd_income_band_sk#136, ca_street_number#138, ca_street_name#139, ca_city#140, ca_zip#141, ca_street_number#143, ca_street_name#144, ca_city#145, ca_zip#146]
 Arguments: X
 
-(443) AQEShuffleRead
+(441) AQEShuffleRead
 Input [19]: [ss_item_sk#103, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, d_year#125, d_year#127, hd_income_band_sk#134, hd_income_band_sk#136, ca_street_number#138, ca_street_name#139, ca_city#140, ca_zip#141, ca_street_number#143, ca_street_name#144, ca_city#145, ca_zip#146]
 Arguments: coalesced
 
-(444) InputAdapter
+(442) InputAdapter
 Input [19]: [ss_item_sk#103, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, d_year#125, d_year#127, hd_income_band_sk#134, hd_income_band_sk#136, ca_street_number#138, ca_street_name#139, ca_city#140, ca_zip#141, ca_street_number#143, ca_street_name#144, ca_city#145, ca_zip#146]
 
-(445) NativeSort
+(443) NativeSort
 Input [19]: [ss_item_sk#103, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, d_year#125, d_year#127, hd_income_band_sk#134, hd_income_band_sk#136, ca_street_number#138, ca_street_name#139, ca_city#140, ca_zip#141, ca_street_number#143, ca_street_name#144, ca_city#145, ca_zip#146]
 Arguments: [hd_income_band_sk#134 ASC NULLS FIRST], false
 
-(446) ReusedExchange [Reuses operator id: 236]
+(444) ReusedExchange [Reuses operator id: 235]
 Output [1]: [ib_income_band_sk#147]
 
-(447) ShuffleQueryStage
+(445) ShuffleQueryStage
 Output [1]: [ib_income_band_sk#147]
 Arguments: X
 
-(448) AQEShuffleRead
+(446) AQEShuffleRead
 Input [1]: [ib_income_band_sk#147]
 Arguments: coalesced
 
-(449) InputAdapter
+(447) InputAdapter
 Input [1]: [ib_income_band_sk#147]
 Arguments: [#147]
 
-(450) InputAdapter
+(448) InputAdapter
 Input [1]: [#147#147]
 
-(451) NativeSort
+(449) NativeSort
 Input [1]: [#147#147]
 Arguments: [ib_income_band_sk#147 ASC NULLS FIRST], false
 
-(452) NativeSortMergeJoin
+(450) NativeSortMergeJoin
 Left keys [1]: [hd_income_band_sk#134]
 Right keys [1]: [ib_income_band_sk#147]
 Join type: Inner
 Join condition: None
 
-(453) NativeProject
+(451) NativeProject
 Output [18]: [ss_item_sk#103, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, d_year#125, d_year#127, hd_income_band_sk#136, ca_street_number#138, ca_street_name#139, ca_city#140, ca_zip#141, ca_street_number#143, ca_street_name#144, ca_city#145, ca_zip#146]
 Input [20]: [ss_item_sk#103, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, d_year#125, d_year#127, hd_income_band_sk#134, hd_income_band_sk#136, ca_street_number#138, ca_street_name#139, ca_city#140, ca_zip#141, ca_street_number#143, ca_street_name#144, ca_city#145, ca_zip#146, #147#147]
 
-(454) NativeShuffleExchange
+(452) NativeShuffleExchange
 Input [18]: [ss_item_sk#103, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, d_year#125, d_year#127, hd_income_band_sk#136, ca_street_number#138, ca_street_name#139, ca_city#140, ca_zip#141, ca_street_number#143, ca_street_name#144, ca_city#145, ca_zip#146]
 Arguments: hashpartitioning(hd_income_band_sk#136, 100), ENSURE_REQUIREMENTS, [plan_id=46]
 
-(455) ShuffleQueryStage
+(453) ShuffleQueryStage
 Output [18]: [ss_item_sk#103, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, d_year#125, d_year#127, hd_income_band_sk#136, ca_street_number#138, ca_street_name#139, ca_city#140, ca_zip#141, ca_street_number#143, ca_street_name#144, ca_city#145, ca_zip#146]
 Arguments: X
 
-(456) AQEShuffleRead
+(454) AQEShuffleRead
 Input [18]: [ss_item_sk#103, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, d_year#125, d_year#127, hd_income_band_sk#136, ca_street_number#138, ca_street_name#139, ca_city#140, ca_zip#141, ca_street_number#143, ca_street_name#144, ca_city#145, ca_zip#146]
 Arguments: coalesced
 
-(457) InputAdapter
+(455) InputAdapter
 Input [18]: [ss_item_sk#103, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, d_year#125, d_year#127, hd_income_band_sk#136, ca_street_number#138, ca_street_name#139, ca_city#140, ca_zip#141, ca_street_number#143, ca_street_name#144, ca_city#145, ca_zip#146]
 
-(458) NativeSort
+(456) NativeSort
 Input [18]: [ss_item_sk#103, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, d_year#125, d_year#127, hd_income_band_sk#136, ca_street_number#138, ca_street_name#139, ca_city#140, ca_zip#141, ca_street_number#143, ca_street_name#144, ca_city#145, ca_zip#146]
 Arguments: [hd_income_band_sk#136 ASC NULLS FIRST], false
 
-(459) ReusedExchange [Reuses operator id: 236]
+(457) ReusedExchange [Reuses operator id: 235]
 Output [1]: [ib_income_band_sk#148]
 
-(460) ShuffleQueryStage
+(458) ShuffleQueryStage
 Output [1]: [ib_income_band_sk#148]
 Arguments: X
 
-(461) AQEShuffleRead
+(459) AQEShuffleRead
 Input [1]: [ib_income_band_sk#148]
 Arguments: coalesced
 
-(462) InputAdapter
+(460) InputAdapter
 Input [1]: [ib_income_band_sk#148]
 Arguments: [#148]
 
-(463) InputAdapter
+(461) InputAdapter
 Input [1]: [#148#148]
 
-(464) NativeSort
+(462) NativeSort
 Input [1]: [#148#148]
 Arguments: [ib_income_band_sk#148 ASC NULLS FIRST], false
 
-(465) NativeSortMergeJoin
+(463) NativeSortMergeJoin
 Left keys [1]: [hd_income_band_sk#136]
 Right keys [1]: [ib_income_band_sk#148]
 Join type: Inner
 Join condition: None
 
-(466) NativeProject
+(464) NativeProject
 Output [17]: [ss_item_sk#103, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, d_year#125, d_year#127, ca_street_number#138, ca_street_name#139, ca_city#140, ca_zip#141, ca_street_number#143, ca_street_name#144, ca_city#145, ca_zip#146]
 Input [19]: [ss_item_sk#103, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, d_year#125, d_year#127, hd_income_band_sk#136, ca_street_number#138, ca_street_name#139, ca_city#140, ca_zip#141, ca_street_number#143, ca_street_name#144, ca_city#145, ca_zip#146, #148#148]
 
-(467) NativeShuffleExchange
+(465) NativeShuffleExchange
 Input [17]: [ss_item_sk#103, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, d_year#125, d_year#127, ca_street_number#138, ca_street_name#139, ca_city#140, ca_zip#141, ca_street_number#143, ca_street_name#144, ca_city#145, ca_zip#146]
 Arguments: hashpartitioning(ss_item_sk#103, 100), ENSURE_REQUIREMENTS, [plan_id=47]
 
-(468) ShuffleQueryStage
+(466) ShuffleQueryStage
 Output [17]: [ss_item_sk#103, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, d_year#125, d_year#127, ca_street_number#138, ca_street_name#139, ca_city#140, ca_zip#141, ca_street_number#143, ca_street_name#144, ca_city#145, ca_zip#146]
 Arguments: X
 
-(469) AQEShuffleRead
+(467) AQEShuffleRead
 Input [17]: [ss_item_sk#103, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, d_year#125, d_year#127, ca_street_number#138, ca_street_name#139, ca_city#140, ca_zip#141, ca_street_number#143, ca_street_name#144, ca_city#145, ca_zip#146]
 Arguments: coalesced
 
-(470) InputAdapter
+(468) InputAdapter
 Input [17]: [ss_item_sk#103, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, d_year#125, d_year#127, ca_street_number#138, ca_street_name#139, ca_city#140, ca_zip#141, ca_street_number#143, ca_street_name#144, ca_city#145, ca_zip#146]
 
-(471) NativeSort
+(469) NativeSort
 Input [17]: [ss_item_sk#103, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, d_year#125, d_year#127, ca_street_number#138, ca_street_name#139, ca_city#140, ca_zip#141, ca_street_number#143, ca_street_name#144, ca_city#145, ca_zip#146]
 Arguments: [ss_item_sk#103 ASC NULLS FIRST], false
 
-(472) ReusedExchange [Reuses operator id: 265]
+(470) ReusedExchange [Reuses operator id: 264]
 Output [2]: [i_item_sk#149, i_product_name#150]
 
-(473) ShuffleQueryStage
+(471) ShuffleQueryStage
 Output [2]: [i_item_sk#149, i_product_name#150]
 Arguments: X
 
-(474) AQEShuffleRead
+(472) AQEShuffleRead
 Input [2]: [i_item_sk#149, i_product_name#150]
 Arguments: coalesced
 
-(475) InputAdapter
+(473) InputAdapter
 Input [2]: [i_item_sk#149, i_product_name#150]
 Arguments: [#149, #150]
 
-(476) InputAdapter
+(474) InputAdapter
 Input [2]: [#149#149, #150#150]
 
-(477) NativeSort
+(475) NativeSort
 Input [2]: [#149#149, #150#150]
 Arguments: [i_item_sk#149 ASC NULLS FIRST], false
 
-(478) NativeSortMergeJoin
+(476) NativeSortMergeJoin
 Left keys [1]: [ss_item_sk#103]
 Right keys [1]: [i_item_sk#149]
 Join type: Inner
 Join condition: None
 
-(479) NativeProject
+(477) NativeProject
 Output [18]: [ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, d_year#125, d_year#127, s_store_name#116, s_zip#117, ca_street_number#138, ca_street_name#139, ca_city#140, ca_zip#141, ca_street_number#143, ca_street_name#144, ca_city#145, ca_zip#146, i_item_sk#149, i_product_name#150]
 Input [19]: [ss_item_sk#103, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, d_year#125, d_year#127, ca_street_number#138, ca_street_name#139, ca_city#140, ca_zip#141, ca_street_number#143, ca_street_name#144, ca_city#145, ca_zip#146, #149#149, #150#150]
 
-(480) NativeProject
+(478) NativeProject
 Output [18]: [i_product_name#150 AS i_product_name#150, i_item_sk#149 AS i_item_sk#149, s_store_name#116 AS s_store_name#116, s_zip#117 AS s_zip#117, ca_street_number#138 AS ca_street_number#138, ca_street_name#139 AS ca_street_name#139, ca_city#140 AS ca_city#140, ca_zip#141 AS ca_zip#141, ca_street_number#143 AS ca_street_number#143, ca_street_name#144 AS ca_street_name#144, ca_city#145 AS ca_city#145, ca_zip#146 AS ca_zip#146, d_year#114 AS d_year#114, d_year#125 AS d_year#125, d_year#127 AS d_year#127, UnscaledValue(ss_wholesale_cost#110) AS _c15#151, UnscaledValue(ss_list_price#111) AS _c16#152, UnscaledValue(ss_coupon_amt#112) AS _c17#153]
 Input [18]: [ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, d_year#125, d_year#127, s_store_name#116, s_zip#117, ca_street_number#138, ca_street_name#139, ca_city#140, ca_zip#141, ca_street_number#143, ca_street_name#144, ca_city#145, ca_zip#146, i_item_sk#149, i_product_name#150]
 
-(481) NativeHashAggregate
+(479) NativeHashAggregate
 Input [18]: [i_product_name#150, i_item_sk#149, s_store_name#116, s_zip#117, ca_street_number#138, ca_street_name#139, ca_city#140, ca_zip#141, ca_street_number#143, ca_street_name#144, ca_city#145, ca_zip#146, d_year#114, d_year#125, d_year#127, _c15#151, _c16#152, _c17#153]
 Keys [15]: [i_product_name#150, i_item_sk#149, s_store_name#116, s_zip#117, ca_street_number#138, ca_street_name#139, ca_city#140, ca_zip#141, ca_street_number#143, ca_street_name#144, ca_city#145, ca_zip#146, d_year#114, d_year#125, d_year#127]
 Functions [4]: [partial_count(1), partial_sum(_c15#151), partial_sum(_c16#152), partial_sum(_c17#153)]
 Aggregate Attributes [4]: [count#77, sum#154, sum#155, sum#156]
 Results [19]: [i_product_name#150, i_item_sk#149, s_store_name#116, s_zip#117, ca_street_number#138, ca_street_name#139, ca_city#140, ca_zip#141, ca_street_number#143, ca_street_name#144, ca_city#145, ca_zip#146, d_year#114, d_year#125, d_year#127, #28, #28, #28, #28]
 
-(482) NativeHashAggregate
+(480) NativeHashAggregate
 Input [19]: [i_product_name#150, i_item_sk#149, s_store_name#116, s_zip#117, ca_street_number#138, ca_street_name#139, ca_city#140, ca_zip#141, ca_street_number#143, ca_street_name#144, ca_city#145, ca_zip#146, d_year#114, d_year#125, d_year#127, #28, #28, #28, #28]
 Keys [15]: [i_product_name#150, i_item_sk#149, s_store_name#116, s_zip#117, ca_street_number#138, ca_street_name#139, ca_city#140, ca_zip#141, ca_street_number#143, ca_street_name#144, ca_city#145, ca_zip#146, d_year#114, d_year#125, d_year#127]
 Functions [4]: [count(1), sum(UnscaledValue(ss_wholesale_cost#110)), sum(UnscaledValue(ss_list_price#111)), sum(UnscaledValue(ss_coupon_amt#112))]
 Aggregate Attributes [4]: [count(1)#81, sum(UnscaledValue(ss_wholesale_cost#110))#82, sum(UnscaledValue(ss_list_price#111))#83, sum(UnscaledValue(ss_coupon_amt#112))#84]
 Results [19]: [i_product_name#150, i_item_sk#149, s_store_name#116, s_zip#117, ca_street_number#138, ca_street_name#139, ca_city#140, ca_zip#141, ca_street_number#143, ca_street_name#144, ca_city#145, ca_zip#146, d_year#114, d_year#125, d_year#127, count(1)#81, sum(UnscaledValue(ss_wholesale_cost#110))#82, sum(UnscaledValue(ss_list_price#111))#83, sum(UnscaledValue(ss_coupon_amt#112))#84]
 
-(483) NativeProject
+(481) NativeProject
 Output [8]: [i_item_sk#149 AS item_sk#157, s_store_name#116 AS store_name#158, s_zip#117 AS store_zip#159, d_year#114 AS syear#160, count(1)#81 AS cnt#161, MakeDecimal(sum(UnscaledValue(ss_wholesale_cost#110))#82,17,2) AS s1#162, MakeDecimal(sum(UnscaledValue(ss_list_price#111))#83,17,2) AS s2#163, MakeDecimal(sum(UnscaledValue(ss_coupon_amt#112))#84,17,2) AS s3#164]
 Input [19]: [i_product_name#150, i_item_sk#149, s_store_name#116, s_zip#117, ca_street_number#138, ca_street_name#139, ca_city#140, ca_zip#141, ca_street_number#143, ca_street_name#144, ca_city#145, ca_zip#146, d_year#114, d_year#125, d_year#127, count(1)#81, sum(UnscaledValue(ss_wholesale_cost#110))#82, sum(UnscaledValue(ss_list_price#111))#83, sum(UnscaledValue(ss_coupon_amt#112))#84]
 
-(484) NativeShuffleExchange
+(482) NativeShuffleExchange
 Input [8]: [item_sk#157, store_name#158, store_zip#159, syear#160, cnt#161, s1#162, s2#163, s3#164]
 Arguments: hashpartitioning(item_sk#157, store_name#158, store_zip#159, 100), ENSURE_REQUIREMENTS, [plan_id=48]
 
-(485) ShuffleQueryStage
+(483) ShuffleQueryStage
 Output [8]: [item_sk#157, store_name#158, store_zip#159, syear#160, cnt#161, s1#162, s2#163, s3#164]
 Arguments: X
 
-(486) AQEShuffleRead
+(484) AQEShuffleRead
 Input [8]: [item_sk#157, store_name#158, store_zip#159, syear#160, cnt#161, s1#162, s2#163, s3#164]
 Arguments: coalesced
 
-(487) InputAdapter
+(485) InputAdapter
 Input [8]: [item_sk#157, store_name#158, store_zip#159, syear#160, cnt#161, s1#162, s2#163, s3#164]
 
-(488) NativeSort
+(486) NativeSort
 Input [8]: [item_sk#157, store_name#158, store_zip#159, syear#160, cnt#161, s1#162, s2#163, s3#164]
 Arguments: [item_sk#157 ASC NULLS FIRST, store_name#158 ASC NULLS FIRST, store_zip#159 ASC NULLS FIRST], false
 
-(489) SortMergeJoin [codegen id : X]
+(487) NativeSortMergeJoin
 Left keys [3]: [item_sk#86, store_name#87, store_zip#88]
 Right keys [3]: [item_sk#157, store_name#158, store_zip#159]
 Join type: Inner
 Join condition: (cnt#161 <= cnt#98)
 
-(490) Project [codegen id : X]
+(488) NativeProject
 Output [21]: [product_name#85, store_name#87, store_zip#88, b_street_number#89, b_streen_name#90, b_city#91, b_zip#92, c_street_number#93, c_street_name#94, c_city#95, c_zip#96, syear#97, cnt#98, s1#99, s2#100, s3#101, s1#162, s2#163, s3#164, syear#160, cnt#161]
 Input [25]: [product_name#85, item_sk#86, store_name#87, store_zip#88, b_street_number#89, b_streen_name#90, b_city#91, b_zip#92, c_street_number#93, c_street_name#94, c_city#95, c_zip#96, syear#97, cnt#98, s1#99, s2#100, s3#101, item_sk#157, store_name#158, store_zip#159, syear#160, cnt#161, s1#162, s2#163, s3#164]
 
-(491) ConvertToNative
-Input [21]: [product_name#85, store_name#87, store_zip#88, b_street_number#89, b_streen_name#90, b_city#91, b_zip#92, c_street_number#93, c_street_name#94, c_city#95, c_zip#96, syear#97, cnt#98, s1#99, s2#100, s3#101, s1#162, s2#163, s3#164, syear#160, cnt#161]
-
-(492) NativeShuffleExchange
+(489) NativeShuffleExchange
 Input [21]: [product_name#85, store_name#87, store_zip#88, b_street_number#89, b_streen_name#90, b_city#91, b_zip#92, c_street_number#93, c_street_name#94, c_city#95, c_zip#96, syear#97, cnt#98, s1#99, s2#100, s3#101, s1#162, s2#163, s3#164, syear#160, cnt#161]
 Arguments: rangepartitioning(product_name#85 ASC NULLS FIRST, store_name#87 ASC NULLS FIRST, cnt#161 ASC NULLS FIRST, s1#99 ASC NULLS FIRST, s1#162 ASC NULLS FIRST, 100), ENSURE_REQUIREMENTS, [plan_id=49]
 
-(493) ShuffleQueryStage
+(490) ShuffleQueryStage
 Output [21]: [product_name#85, store_name#87, store_zip#88, b_street_number#89, b_streen_name#90, b_city#91, b_zip#92, c_street_number#93, c_street_name#94, c_city#95, c_zip#96, syear#97, cnt#98, s1#99, s2#100, s3#101, s1#162, s2#163, s3#164, syear#160, cnt#161]
 Arguments: X
 
-(494) AQEShuffleRead
+(491) AQEShuffleRead
 Input [21]: [product_name#85, store_name#87, store_zip#88, b_street_number#89, b_streen_name#90, b_city#91, b_zip#92, c_street_number#93, c_street_name#94, c_city#95, c_zip#96, syear#97, cnt#98, s1#99, s2#100, s3#101, s1#162, s2#163, s3#164, syear#160, cnt#161]
 Arguments: coalesced
 
-(495) InputAdapter
+(492) InputAdapter
 Input [21]: [product_name#85, store_name#87, store_zip#88, b_street_number#89, b_streen_name#90, b_city#91, b_zip#92, c_street_number#93, c_street_name#94, c_city#95, c_zip#96, syear#97, cnt#98, s1#99, s2#100, s3#101, s1#162, s2#163, s3#164, syear#160, cnt#161]
 
-(496) NativeSort
+(493) NativeSort
 Input [21]: [product_name#85, store_name#87, store_zip#88, b_street_number#89, b_streen_name#90, b_city#91, b_zip#92, c_street_number#93, c_street_name#94, c_city#95, c_zip#96, syear#97, cnt#98, s1#99, s2#100, s3#101, s1#162, s2#163, s3#164, syear#160, cnt#161]
 Arguments: [product_name#85 ASC NULLS FIRST, store_name#87 ASC NULLS FIRST, cnt#161 ASC NULLS FIRST, s1#99 ASC NULLS FIRST, s1#162 ASC NULLS FIRST], true
 
-(497) Scan parquet
+(494) Scan parquet
 Output [12]: [ss_sold_date_sk#1, ss_item_sk#2, ss_customer_sk#3, ss_cdemo_sk#4, ss_hdemo_sk#5, ss_addr_sk#6, ss_store_sk#7, ss_promo_sk#8, ss_ticket_number#9, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(ss_item_sk), IsNotNull(ss_ticket_number), IsNotNull(ss_sold_date_sk), IsNotNull(ss_store_sk), IsNotNull(ss_customer_sk), IsNotNull(ss_cdemo_sk), IsNotNull(ss_promo_sk), IsNotNull(ss_hdemo_sk), IsNotNull(ss_addr_sk)]
 ReadSchema: struct<ss_sold_date_sk:int,ss_item_sk:int,ss_customer_sk:int,ss_cdemo_sk:int,ss_hdemo_sk:int,ss_addr_sk:int,ss_store_sk:int,ss_promo_sk:int,ss_ticket_number:int,ss_wholesale_cost:decimal(7,2),ss_list_price:decimal(7,2),ss_coupon_amt:decimal(7,2)>
 
-(498) Filter
+(495) Filter
 Input [12]: [ss_sold_date_sk#1, ss_item_sk#2, ss_customer_sk#3, ss_cdemo_sk#4, ss_hdemo_sk#5, ss_addr_sk#6, ss_store_sk#7, ss_promo_sk#8, ss_ticket_number#9, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12]
 Condition : ((((((((isnotnull(ss_item_sk#2) AND isnotnull(ss_ticket_number#9)) AND isnotnull(ss_sold_date_sk#1)) AND isnotnull(ss_store_sk#7)) AND isnotnull(ss_customer_sk#3)) AND isnotnull(ss_cdemo_sk#4)) AND isnotnull(ss_promo_sk#8)) AND isnotnull(ss_hdemo_sk#5)) AND isnotnull(ss_addr_sk#6))
 
-(499) Exchange
+(496) Exchange
 Input [12]: [ss_sold_date_sk#1, ss_item_sk#2, ss_customer_sk#3, ss_cdemo_sk#4, ss_hdemo_sk#5, ss_addr_sk#6, ss_store_sk#7, ss_promo_sk#8, ss_ticket_number#9, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12]
 Arguments: hashpartitioning(ss_item_sk#2, ss_ticket_number#9, 100), ENSURE_REQUIREMENTS, [plan_id=50]
 
-(500) Sort
+(497) Sort
 Input [12]: [ss_sold_date_sk#1, ss_item_sk#2, ss_customer_sk#3, ss_cdemo_sk#4, ss_hdemo_sk#5, ss_addr_sk#6, ss_store_sk#7, ss_promo_sk#8, ss_ticket_number#9, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12]
 Arguments: [ss_item_sk#2 ASC NULLS FIRST, ss_ticket_number#9 ASC NULLS FIRST], false, 0
 
-(501) Scan parquet
+(498) Scan parquet
 Output [2]: [sr_item_sk#13, sr_ticket_number#14]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(sr_item_sk), IsNotNull(sr_ticket_number)]
 ReadSchema: struct<sr_item_sk:int,sr_ticket_number:int>
 
-(502) Filter
+(499) Filter
 Input [2]: [sr_item_sk#13, sr_ticket_number#14]
 Condition : (isnotnull(sr_item_sk#13) AND isnotnull(sr_ticket_number#14))
 
-(503) Exchange
+(500) Exchange
 Input [2]: [sr_item_sk#13, sr_ticket_number#14]
 Arguments: hashpartitioning(sr_item_sk#13, sr_ticket_number#14, 100), ENSURE_REQUIREMENTS, [plan_id=51]
 
-(504) Sort
+(501) Sort
 Input [2]: [sr_item_sk#13, sr_ticket_number#14]
 Arguments: [sr_item_sk#13 ASC NULLS FIRST, sr_ticket_number#14 ASC NULLS FIRST], false, 0
 
-(505) SortMergeJoin
+(502) SortMergeJoin
 Left keys [2]: [ss_item_sk#2, ss_ticket_number#9]
 Right keys [2]: [sr_item_sk#13, sr_ticket_number#14]
 Join type: Inner
 Join condition: None
 
-(506) Project
+(503) Project
 Output [11]: [ss_sold_date_sk#1, ss_item_sk#2, ss_customer_sk#3, ss_cdemo_sk#4, ss_hdemo_sk#5, ss_addr_sk#6, ss_store_sk#7, ss_promo_sk#8, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12]
 Input [14]: [ss_sold_date_sk#1, ss_item_sk#2, ss_customer_sk#3, ss_cdemo_sk#4, ss_hdemo_sk#5, ss_addr_sk#6, ss_store_sk#7, ss_promo_sk#8, ss_ticket_number#9, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, sr_item_sk#13, sr_ticket_number#14]
 
-(507) Exchange
+(504) Exchange
 Input [11]: [ss_sold_date_sk#1, ss_item_sk#2, ss_customer_sk#3, ss_cdemo_sk#4, ss_hdemo_sk#5, ss_addr_sk#6, ss_store_sk#7, ss_promo_sk#8, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12]
 Arguments: hashpartitioning(ss_item_sk#2, 100), ENSURE_REQUIREMENTS, [plan_id=52]
 
-(508) Sort
+(505) Sort
 Input [11]: [ss_sold_date_sk#1, ss_item_sk#2, ss_customer_sk#3, ss_cdemo_sk#4, ss_hdemo_sk#5, ss_addr_sk#6, ss_store_sk#7, ss_promo_sk#8, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12]
 Arguments: [ss_item_sk#2 ASC NULLS FIRST], false, 0
 
-(509) Scan parquet
+(506) Scan parquet
 Output [3]: [cs_item_sk#15, cs_order_number#16, cs_ext_list_price#17]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(cs_item_sk), IsNotNull(cs_order_number)]
 ReadSchema: struct<cs_item_sk:int,cs_order_number:int,cs_ext_list_price:decimal(7,2)>
 
-(510) Filter
+(507) Filter
 Input [3]: [cs_item_sk#15, cs_order_number#16, cs_ext_list_price#17]
 Condition : (isnotnull(cs_item_sk#15) AND isnotnull(cs_order_number#16))
 
-(511) Exchange
+(508) Exchange
 Input [3]: [cs_item_sk#15, cs_order_number#16, cs_ext_list_price#17]
 Arguments: hashpartitioning(cs_item_sk#15, cs_order_number#16, 100), ENSURE_REQUIREMENTS, [plan_id=53]
 
-(512) Sort
+(509) Sort
 Input [3]: [cs_item_sk#15, cs_order_number#16, cs_ext_list_price#17]
 Arguments: [cs_item_sk#15 ASC NULLS FIRST, cs_order_number#16 ASC NULLS FIRST], false, 0
 
-(513) Scan parquet
+(510) Scan parquet
 Output [5]: [cr_item_sk#18, cr_order_number#19, cr_refunded_cash#20, cr_reversed_charge#21, cr_store_credit#22]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(cr_item_sk), IsNotNull(cr_order_number)]
 ReadSchema: struct<cr_item_sk:int,cr_order_number:int,cr_refunded_cash:decimal(7,2),cr_reversed_charge:decimal(7,2),cr_store_credit:decimal(7,2)>
 
-(514) Filter
+(511) Filter
 Input [5]: [cr_item_sk#18, cr_order_number#19, cr_refunded_cash#20, cr_reversed_charge#21, cr_store_credit#22]
 Condition : (isnotnull(cr_item_sk#18) AND isnotnull(cr_order_number#19))
 
-(515) Exchange
+(512) Exchange
 Input [5]: [cr_item_sk#18, cr_order_number#19, cr_refunded_cash#20, cr_reversed_charge#21, cr_store_credit#22]
 Arguments: hashpartitioning(cr_item_sk#18, cr_order_number#19, 100), ENSURE_REQUIREMENTS, [plan_id=54]
 
-(516) Sort
+(513) Sort
 Input [5]: [cr_item_sk#18, cr_order_number#19, cr_refunded_cash#20, cr_reversed_charge#21, cr_store_credit#22]
 Arguments: [cr_item_sk#18 ASC NULLS FIRST, cr_order_number#19 ASC NULLS FIRST], false, 0
 
-(517) SortMergeJoin
+(514) SortMergeJoin
 Left keys [2]: [cs_item_sk#15, cs_order_number#16]
 Right keys [2]: [cr_item_sk#18, cr_order_number#19]
 Join type: Inner
 Join condition: None
 
-(518) Project
+(515) Project
 Output [5]: [cs_item_sk#15, cs_ext_list_price#17, cr_refunded_cash#20, cr_reversed_charge#21, cr_store_credit#22]
 Input [8]: [cs_item_sk#15, cs_order_number#16, cs_ext_list_price#17, cr_item_sk#18, cr_order_number#19, cr_refunded_cash#20, cr_reversed_charge#21, cr_store_credit#22]
 
-(519) HashAggregate
+(516) HashAggregate
 Input [5]: [cs_item_sk#15, cs_ext_list_price#17, cr_refunded_cash#20, cr_reversed_charge#21, cr_store_credit#22]
 Keys [1]: [cs_item_sk#15]
 Functions [2]: [partial_sum(UnscaledValue(cs_ext_list_price#17)), partial_sum(((cr_refunded_cash#20 + cr_reversed_charge#21) + cr_store_credit#22))]
 Aggregate Attributes [3]: [sum#25, sum#26, isEmpty#27]
 Results [4]: [cs_item_sk#15, sum#165, sum#166, isEmpty#167]
 
-(520) Exchange
+(517) Exchange
 Input [4]: [cs_item_sk#15, sum#165, sum#166, isEmpty#167]
 Arguments: hashpartitioning(cs_item_sk#15, 100), ENSURE_REQUIREMENTS, [plan_id=55]
 
-(521) HashAggregate
+(518) HashAggregate
 Input [4]: [cs_item_sk#15, sum#165, sum#166, isEmpty#167]
 Keys [1]: [cs_item_sk#15]
 Functions [2]: [sum(UnscaledValue(cs_ext_list_price#17)), sum(((cr_refunded_cash#20 + cr_reversed_charge#21) + cr_store_credit#22))]
 Aggregate Attributes [2]: [sum(UnscaledValue(cs_ext_list_price#17))#30, sum(((cr_refunded_cash#20 + cr_reversed_charge#21) + cr_store_credit#22))#31]
 Results [3]: [cs_item_sk#15, MakeDecimal(sum(UnscaledValue(cs_ext_list_price#17))#30,17,2) AS sale#32, sum(((cr_refunded_cash#20 + cr_reversed_charge#21) + cr_store_credit#22))#31 AS refund#33]
 
-(522) Filter
+(519) Filter
 Input [3]: [cs_item_sk#15, sale#32, refund#33]
 Condition : ((isnotnull(sale#32) AND isnotnull(refund#33)) AND (cast(sale#32 as decimal(21,2)) > (2 * refund#33)))
 
-(523) Project
+(520) Project
 Output [1]: [cs_item_sk#15]
 Input [3]: [cs_item_sk#15, sale#32, refund#33]
 
-(524) Sort
+(521) Sort
 Input [1]: [cs_item_sk#15]
 Arguments: [cs_item_sk#15 ASC NULLS FIRST], false, 0
 
-(525) SortMergeJoin
+(522) SortMergeJoin
 Left keys [1]: [ss_item_sk#2]
 Right keys [1]: [cs_item_sk#15]
 Join type: Inner
 Join condition: None
 
-(526) Project
+(523) Project
 Output [11]: [ss_sold_date_sk#1, ss_item_sk#2, ss_customer_sk#3, ss_cdemo_sk#4, ss_hdemo_sk#5, ss_addr_sk#6, ss_store_sk#7, ss_promo_sk#8, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12]
 Input [12]: [ss_sold_date_sk#1, ss_item_sk#2, ss_customer_sk#3, ss_cdemo_sk#4, ss_hdemo_sk#5, ss_addr_sk#6, ss_store_sk#7, ss_promo_sk#8, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, cs_item_sk#15]
 
-(527) Exchange
+(524) Exchange
 Input [11]: [ss_sold_date_sk#1, ss_item_sk#2, ss_customer_sk#3, ss_cdemo_sk#4, ss_hdemo_sk#5, ss_addr_sk#6, ss_store_sk#7, ss_promo_sk#8, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12]
 Arguments: hashpartitioning(ss_sold_date_sk#1, 100), ENSURE_REQUIREMENTS, [plan_id=56]
 
-(528) Sort
+(525) Sort
 Input [11]: [ss_sold_date_sk#1, ss_item_sk#2, ss_customer_sk#3, ss_cdemo_sk#4, ss_hdemo_sk#5, ss_addr_sk#6, ss_store_sk#7, ss_promo_sk#8, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12]
 Arguments: [ss_sold_date_sk#1 ASC NULLS FIRST], false, 0
 
-(529) Scan parquet
+(526) Scan parquet
 Output [2]: [d_date_sk#34, d_year#35]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,1999), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
-(530) Filter
+(527) Filter
 Input [2]: [d_date_sk#34, d_year#35]
 Condition : ((isnotnull(d_year#35) AND (d_year#35 = 1999)) AND isnotnull(d_date_sk#34))
 
-(531) Exchange
+(528) Exchange
 Input [2]: [d_date_sk#34, d_year#35]
 Arguments: hashpartitioning(d_date_sk#34, 100), ENSURE_REQUIREMENTS, [plan_id=57]
 
-(532) Sort
+(529) Sort
 Input [2]: [d_date_sk#34, d_year#35]
 Arguments: [d_date_sk#34 ASC NULLS FIRST], false, 0
 
-(533) SortMergeJoin
+(530) SortMergeJoin
 Left keys [1]: [ss_sold_date_sk#1]
 Right keys [1]: [d_date_sk#34]
 Join type: Inner
 Join condition: None
 
-(534) Project
+(531) Project
 Output [11]: [ss_item_sk#2, ss_customer_sk#3, ss_cdemo_sk#4, ss_hdemo_sk#5, ss_addr_sk#6, ss_store_sk#7, ss_promo_sk#8, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35]
 Input [13]: [ss_sold_date_sk#1, ss_item_sk#2, ss_customer_sk#3, ss_cdemo_sk#4, ss_hdemo_sk#5, ss_addr_sk#6, ss_store_sk#7, ss_promo_sk#8, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_date_sk#34, d_year#35]
 
-(535) Exchange
+(532) Exchange
 Input [11]: [ss_item_sk#2, ss_customer_sk#3, ss_cdemo_sk#4, ss_hdemo_sk#5, ss_addr_sk#6, ss_store_sk#7, ss_promo_sk#8, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35]
 Arguments: hashpartitioning(ss_store_sk#7, 100), ENSURE_REQUIREMENTS, [plan_id=58]
 
-(536) Sort
+(533) Sort
 Input [11]: [ss_item_sk#2, ss_customer_sk#3, ss_cdemo_sk#4, ss_hdemo_sk#5, ss_addr_sk#6, ss_store_sk#7, ss_promo_sk#8, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35]
 Arguments: [ss_store_sk#7 ASC NULLS FIRST], false, 0
 
-(537) Scan parquet
+(534) Scan parquet
 Output [3]: [s_store_sk#36, s_store_name#37, s_zip#38]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(s_store_sk), IsNotNull(s_store_name), IsNotNull(s_zip)]
 ReadSchema: struct<s_store_sk:int,s_store_name:string,s_zip:string>
 
-(538) Filter
+(535) Filter
 Input [3]: [s_store_sk#36, s_store_name#37, s_zip#38]
 Condition : ((isnotnull(s_store_sk#36) AND isnotnull(s_store_name#37)) AND isnotnull(s_zip#38))
 
-(539) Exchange
+(536) Exchange
 Input [3]: [s_store_sk#36, s_store_name#37, s_zip#38]
 Arguments: hashpartitioning(s_store_sk#36, 100), ENSURE_REQUIREMENTS, [plan_id=59]
 
-(540) Sort
+(537) Sort
 Input [3]: [s_store_sk#36, s_store_name#37, s_zip#38]
 Arguments: [s_store_sk#36 ASC NULLS FIRST], false, 0
 
-(541) SortMergeJoin
+(538) SortMergeJoin
 Left keys [1]: [ss_store_sk#7]
 Right keys [1]: [s_store_sk#36]
 Join type: Inner
 Join condition: None
 
-(542) Project
+(539) Project
 Output [12]: [ss_item_sk#2, ss_customer_sk#3, ss_cdemo_sk#4, ss_hdemo_sk#5, ss_addr_sk#6, ss_promo_sk#8, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38]
 Input [14]: [ss_item_sk#2, ss_customer_sk#3, ss_cdemo_sk#4, ss_hdemo_sk#5, ss_addr_sk#6, ss_store_sk#7, ss_promo_sk#8, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_sk#36, s_store_name#37, s_zip#38]
 
-(543) Exchange
+(540) Exchange
 Input [12]: [ss_item_sk#2, ss_customer_sk#3, ss_cdemo_sk#4, ss_hdemo_sk#5, ss_addr_sk#6, ss_promo_sk#8, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38]
 Arguments: hashpartitioning(ss_customer_sk#3, 100), ENSURE_REQUIREMENTS, [plan_id=60]
 
-(544) Sort
+(541) Sort
 Input [12]: [ss_item_sk#2, ss_customer_sk#3, ss_cdemo_sk#4, ss_hdemo_sk#5, ss_addr_sk#6, ss_promo_sk#8, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38]
 Arguments: [ss_customer_sk#3 ASC NULLS FIRST], false, 0
 
-(545) Scan parquet
+(542) Scan parquet
 Output [6]: [c_customer_sk#39, c_current_cdemo_sk#40, c_current_hdemo_sk#41, c_current_addr_sk#42, c_first_shipto_date_sk#43, c_first_sales_date_sk#44]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_first_sales_date_sk), IsNotNull(c_first_shipto_date_sk), IsNotNull(c_current_cdemo_sk), IsNotNull(c_current_hdemo_sk), IsNotNull(c_current_addr_sk)]
 ReadSchema: struct<c_customer_sk:int,c_current_cdemo_sk:int,c_current_hdemo_sk:int,c_current_addr_sk:int,c_first_shipto_date_sk:int,c_first_sales_date_sk:int>
 
-(546) Filter
+(543) Filter
 Input [6]: [c_customer_sk#39, c_current_cdemo_sk#40, c_current_hdemo_sk#41, c_current_addr_sk#42, c_first_shipto_date_sk#43, c_first_sales_date_sk#44]
 Condition : (((((isnotnull(c_customer_sk#39) AND isnotnull(c_first_sales_date_sk#44)) AND isnotnull(c_first_shipto_date_sk#43)) AND isnotnull(c_current_cdemo_sk#40)) AND isnotnull(c_current_hdemo_sk#41)) AND isnotnull(c_current_addr_sk#42))
 
-(547) Exchange
+(544) Exchange
 Input [6]: [c_customer_sk#39, c_current_cdemo_sk#40, c_current_hdemo_sk#41, c_current_addr_sk#42, c_first_shipto_date_sk#43, c_first_sales_date_sk#44]
 Arguments: hashpartitioning(c_customer_sk#39, 100), ENSURE_REQUIREMENTS, [plan_id=61]
 
-(548) Sort
+(545) Sort
 Input [6]: [c_customer_sk#39, c_current_cdemo_sk#40, c_current_hdemo_sk#41, c_current_addr_sk#42, c_first_shipto_date_sk#43, c_first_sales_date_sk#44]
 Arguments: [c_customer_sk#39 ASC NULLS FIRST], false, 0
 
-(549) SortMergeJoin
+(546) SortMergeJoin
 Left keys [1]: [ss_customer_sk#3]
 Right keys [1]: [c_customer_sk#39]
 Join type: Inner
 Join condition: None
 
-(550) Project
+(547) Project
 Output [16]: [ss_item_sk#2, ss_cdemo_sk#4, ss_hdemo_sk#5, ss_addr_sk#6, ss_promo_sk#8, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, c_current_cdemo_sk#40, c_current_hdemo_sk#41, c_current_addr_sk#42, c_first_shipto_date_sk#43, c_first_sales_date_sk#44]
 Input [18]: [ss_item_sk#2, ss_customer_sk#3, ss_cdemo_sk#4, ss_hdemo_sk#5, ss_addr_sk#6, ss_promo_sk#8, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, c_customer_sk#39, c_current_cdemo_sk#40, c_current_hdemo_sk#41, c_current_addr_sk#42, c_first_shipto_date_sk#43, c_first_sales_date_sk#44]
 
-(551) Exchange
+(548) Exchange
 Input [16]: [ss_item_sk#2, ss_cdemo_sk#4, ss_hdemo_sk#5, ss_addr_sk#6, ss_promo_sk#8, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, c_current_cdemo_sk#40, c_current_hdemo_sk#41, c_current_addr_sk#42, c_first_shipto_date_sk#43, c_first_sales_date_sk#44]
 Arguments: hashpartitioning(c_first_sales_date_sk#44, 100), ENSURE_REQUIREMENTS, [plan_id=62]
 
-(552) Sort
+(549) Sort
 Input [16]: [ss_item_sk#2, ss_cdemo_sk#4, ss_hdemo_sk#5, ss_addr_sk#6, ss_promo_sk#8, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, c_current_cdemo_sk#40, c_current_hdemo_sk#41, c_current_addr_sk#42, c_first_shipto_date_sk#43, c_first_sales_date_sk#44]
 Arguments: [c_first_sales_date_sk#44 ASC NULLS FIRST], false, 0
 
-(553) Scan parquet
+(550) Scan parquet
 Output [2]: [d_date_sk#45, d_year#46]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
-(554) Filter
+(551) Filter
 Input [2]: [d_date_sk#45, d_year#46]
 Condition : isnotnull(d_date_sk#45)
 
-(555) Exchange
+(552) Exchange
 Input [2]: [d_date_sk#45, d_year#46]
 Arguments: hashpartitioning(d_date_sk#45, 100), ENSURE_REQUIREMENTS, [plan_id=63]
 
-(556) Sort
+(553) Sort
 Input [2]: [d_date_sk#45, d_year#46]
 Arguments: [d_date_sk#45 ASC NULLS FIRST], false, 0
 
-(557) SortMergeJoin
+(554) SortMergeJoin
 Left keys [1]: [c_first_sales_date_sk#44]
 Right keys [1]: [d_date_sk#45]
 Join type: Inner
 Join condition: None
 
-(558) Project
+(555) Project
 Output [16]: [ss_item_sk#2, ss_cdemo_sk#4, ss_hdemo_sk#5, ss_addr_sk#6, ss_promo_sk#8, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, c_current_cdemo_sk#40, c_current_hdemo_sk#41, c_current_addr_sk#42, c_first_shipto_date_sk#43, d_year#46]
 Input [18]: [ss_item_sk#2, ss_cdemo_sk#4, ss_hdemo_sk#5, ss_addr_sk#6, ss_promo_sk#8, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, c_current_cdemo_sk#40, c_current_hdemo_sk#41, c_current_addr_sk#42, c_first_shipto_date_sk#43, c_first_sales_date_sk#44, d_date_sk#45, d_year#46]
 
-(559) Exchange
+(556) Exchange
 Input [16]: [ss_item_sk#2, ss_cdemo_sk#4, ss_hdemo_sk#5, ss_addr_sk#6, ss_promo_sk#8, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, c_current_cdemo_sk#40, c_current_hdemo_sk#41, c_current_addr_sk#42, c_first_shipto_date_sk#43, d_year#46]
 Arguments: hashpartitioning(c_first_shipto_date_sk#43, 100), ENSURE_REQUIREMENTS, [plan_id=64]
 
-(560) Sort
+(557) Sort
 Input [16]: [ss_item_sk#2, ss_cdemo_sk#4, ss_hdemo_sk#5, ss_addr_sk#6, ss_promo_sk#8, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, c_current_cdemo_sk#40, c_current_hdemo_sk#41, c_current_addr_sk#42, c_first_shipto_date_sk#43, d_year#46]
 Arguments: [c_first_shipto_date_sk#43 ASC NULLS FIRST], false, 0
 
-(561) Scan parquet
+(558) Scan parquet
 Output [2]: [d_date_sk#47, d_year#48]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
-(562) Filter
+(559) Filter
 Input [2]: [d_date_sk#47, d_year#48]
 Condition : isnotnull(d_date_sk#47)
 
-(563) Exchange
+(560) Exchange
 Input [2]: [d_date_sk#47, d_year#48]
 Arguments: hashpartitioning(d_date_sk#47, 100), ENSURE_REQUIREMENTS, [plan_id=65]
 
-(564) Sort
+(561) Sort
 Input [2]: [d_date_sk#47, d_year#48]
 Arguments: [d_date_sk#47 ASC NULLS FIRST], false, 0
 
-(565) SortMergeJoin
+(562) SortMergeJoin
 Left keys [1]: [c_first_shipto_date_sk#43]
 Right keys [1]: [d_date_sk#47]
 Join type: Inner
 Join condition: None
 
-(566) Project
+(563) Project
 Output [16]: [ss_item_sk#2, ss_cdemo_sk#4, ss_hdemo_sk#5, ss_addr_sk#6, ss_promo_sk#8, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, c_current_cdemo_sk#40, c_current_hdemo_sk#41, c_current_addr_sk#42, d_year#46, d_year#48]
 Input [18]: [ss_item_sk#2, ss_cdemo_sk#4, ss_hdemo_sk#5, ss_addr_sk#6, ss_promo_sk#8, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, c_current_cdemo_sk#40, c_current_hdemo_sk#41, c_current_addr_sk#42, c_first_shipto_date_sk#43, d_year#46, d_date_sk#47, d_year#48]
 
-(567) Exchange
+(564) Exchange
 Input [16]: [ss_item_sk#2, ss_cdemo_sk#4, ss_hdemo_sk#5, ss_addr_sk#6, ss_promo_sk#8, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, c_current_cdemo_sk#40, c_current_hdemo_sk#41, c_current_addr_sk#42, d_year#46, d_year#48]
 Arguments: hashpartitioning(ss_cdemo_sk#4, 100), ENSURE_REQUIREMENTS, [plan_id=66]
 
-(568) Sort
+(565) Sort
 Input [16]: [ss_item_sk#2, ss_cdemo_sk#4, ss_hdemo_sk#5, ss_addr_sk#6, ss_promo_sk#8, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, c_current_cdemo_sk#40, c_current_hdemo_sk#41, c_current_addr_sk#42, d_year#46, d_year#48]
 Arguments: [ss_cdemo_sk#4 ASC NULLS FIRST], false, 0
 
-(569) Scan parquet
+(566) Scan parquet
 Output [2]: [cd_demo_sk#49, cd_marital_status#50]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(cd_demo_sk), IsNotNull(cd_marital_status)]
 ReadSchema: struct<cd_demo_sk:int,cd_marital_status:string>
 
-(570) Filter
+(567) Filter
 Input [2]: [cd_demo_sk#49, cd_marital_status#50]
 Condition : (isnotnull(cd_demo_sk#49) AND isnotnull(cd_marital_status#50))
 
-(571) Exchange
+(568) Exchange
 Input [2]: [cd_demo_sk#49, cd_marital_status#50]
 Arguments: hashpartitioning(cd_demo_sk#49, 100), ENSURE_REQUIREMENTS, [plan_id=67]
 
-(572) Sort
+(569) Sort
 Input [2]: [cd_demo_sk#49, cd_marital_status#50]
 Arguments: [cd_demo_sk#49 ASC NULLS FIRST], false, 0
 
-(573) SortMergeJoin
+(570) SortMergeJoin
 Left keys [1]: [ss_cdemo_sk#4]
 Right keys [1]: [cd_demo_sk#49]
 Join type: Inner
 Join condition: None
 
-(574) Project
+(571) Project
 Output [16]: [ss_item_sk#2, ss_hdemo_sk#5, ss_addr_sk#6, ss_promo_sk#8, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, c_current_cdemo_sk#40, c_current_hdemo_sk#41, c_current_addr_sk#42, d_year#46, d_year#48, cd_marital_status#50]
 Input [18]: [ss_item_sk#2, ss_cdemo_sk#4, ss_hdemo_sk#5, ss_addr_sk#6, ss_promo_sk#8, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, c_current_cdemo_sk#40, c_current_hdemo_sk#41, c_current_addr_sk#42, d_year#46, d_year#48, cd_demo_sk#49, cd_marital_status#50]
 
-(575) Exchange
+(572) Exchange
 Input [16]: [ss_item_sk#2, ss_hdemo_sk#5, ss_addr_sk#6, ss_promo_sk#8, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, c_current_cdemo_sk#40, c_current_hdemo_sk#41, c_current_addr_sk#42, d_year#46, d_year#48, cd_marital_status#50]
 Arguments: hashpartitioning(c_current_cdemo_sk#40, 100), ENSURE_REQUIREMENTS, [plan_id=68]
 
-(576) Sort
+(573) Sort
 Input [16]: [ss_item_sk#2, ss_hdemo_sk#5, ss_addr_sk#6, ss_promo_sk#8, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, c_current_cdemo_sk#40, c_current_hdemo_sk#41, c_current_addr_sk#42, d_year#46, d_year#48, cd_marital_status#50]
 Arguments: [c_current_cdemo_sk#40 ASC NULLS FIRST], false, 0
 
-(577) Scan parquet
+(574) Scan parquet
 Output [2]: [cd_demo_sk#51, cd_marital_status#52]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(cd_demo_sk), IsNotNull(cd_marital_status)]
 ReadSchema: struct<cd_demo_sk:int,cd_marital_status:string>
 
-(578) Filter
+(575) Filter
 Input [2]: [cd_demo_sk#51, cd_marital_status#52]
 Condition : (isnotnull(cd_demo_sk#51) AND isnotnull(cd_marital_status#52))
 
-(579) Exchange
+(576) Exchange
 Input [2]: [cd_demo_sk#51, cd_marital_status#52]
 Arguments: hashpartitioning(cd_demo_sk#51, 100), ENSURE_REQUIREMENTS, [plan_id=69]
 
-(580) Sort
+(577) Sort
 Input [2]: [cd_demo_sk#51, cd_marital_status#52]
 Arguments: [cd_demo_sk#51 ASC NULLS FIRST], false, 0
 
-(581) SortMergeJoin
+(578) SortMergeJoin
 Left keys [1]: [c_current_cdemo_sk#40]
 Right keys [1]: [cd_demo_sk#51]
 Join type: Inner
 Join condition: NOT (cd_marital_status#50 = cd_marital_status#52)
 
-(582) Project
+(579) Project
 Output [14]: [ss_item_sk#2, ss_hdemo_sk#5, ss_addr_sk#6, ss_promo_sk#8, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, c_current_hdemo_sk#41, c_current_addr_sk#42, d_year#46, d_year#48]
 Input [18]: [ss_item_sk#2, ss_hdemo_sk#5, ss_addr_sk#6, ss_promo_sk#8, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, c_current_cdemo_sk#40, c_current_hdemo_sk#41, c_current_addr_sk#42, d_year#46, d_year#48, cd_marital_status#50, cd_demo_sk#51, cd_marital_status#52]
 
-(583) Exchange
+(580) Exchange
 Input [14]: [ss_item_sk#2, ss_hdemo_sk#5, ss_addr_sk#6, ss_promo_sk#8, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, c_current_hdemo_sk#41, c_current_addr_sk#42, d_year#46, d_year#48]
 Arguments: hashpartitioning(ss_promo_sk#8, 100), ENSURE_REQUIREMENTS, [plan_id=70]
 
-(584) Sort
+(581) Sort
 Input [14]: [ss_item_sk#2, ss_hdemo_sk#5, ss_addr_sk#6, ss_promo_sk#8, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, c_current_hdemo_sk#41, c_current_addr_sk#42, d_year#46, d_year#48]
 Arguments: [ss_promo_sk#8 ASC NULLS FIRST], false, 0
 
-(585) Scan parquet
+(582) Scan parquet
 Output [1]: [p_promo_sk#53]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(p_promo_sk)]
 ReadSchema: struct<p_promo_sk:int>
 
-(586) Filter
+(583) Filter
 Input [1]: [p_promo_sk#53]
 Condition : isnotnull(p_promo_sk#53)
 
-(587) Exchange
+(584) Exchange
 Input [1]: [p_promo_sk#53]
 Arguments: hashpartitioning(p_promo_sk#53, 100), ENSURE_REQUIREMENTS, [plan_id=71]
 
-(588) Sort
+(585) Sort
 Input [1]: [p_promo_sk#53]
 Arguments: [p_promo_sk#53 ASC NULLS FIRST], false, 0
 
-(589) SortMergeJoin
+(586) SortMergeJoin
 Left keys [1]: [ss_promo_sk#8]
 Right keys [1]: [p_promo_sk#53]
 Join type: Inner
 Join condition: None
 
-(590) Project
+(587) Project
 Output [13]: [ss_item_sk#2, ss_hdemo_sk#5, ss_addr_sk#6, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, c_current_hdemo_sk#41, c_current_addr_sk#42, d_year#46, d_year#48]
 Input [15]: [ss_item_sk#2, ss_hdemo_sk#5, ss_addr_sk#6, ss_promo_sk#8, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, c_current_hdemo_sk#41, c_current_addr_sk#42, d_year#46, d_year#48, p_promo_sk#53]
 
-(591) Exchange
+(588) Exchange
 Input [13]: [ss_item_sk#2, ss_hdemo_sk#5, ss_addr_sk#6, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, c_current_hdemo_sk#41, c_current_addr_sk#42, d_year#46, d_year#48]
 Arguments: hashpartitioning(ss_hdemo_sk#5, 100), ENSURE_REQUIREMENTS, [plan_id=72]
 
-(592) Sort
+(589) Sort
 Input [13]: [ss_item_sk#2, ss_hdemo_sk#5, ss_addr_sk#6, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, c_current_hdemo_sk#41, c_current_addr_sk#42, d_year#46, d_year#48]
 Arguments: [ss_hdemo_sk#5 ASC NULLS FIRST], false, 0
 
-(593) Scan parquet
+(590) Scan parquet
 Output [2]: [hd_demo_sk#54, hd_income_band_sk#55]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(hd_demo_sk), IsNotNull(hd_income_band_sk)]
 ReadSchema: struct<hd_demo_sk:int,hd_income_band_sk:int>
 
-(594) Filter
+(591) Filter
 Input [2]: [hd_demo_sk#54, hd_income_band_sk#55]
 Condition : (isnotnull(hd_demo_sk#54) AND isnotnull(hd_income_band_sk#55))
 
-(595) Exchange
+(592) Exchange
 Input [2]: [hd_demo_sk#54, hd_income_band_sk#55]
 Arguments: hashpartitioning(hd_demo_sk#54, 100), ENSURE_REQUIREMENTS, [plan_id=73]
 
-(596) Sort
+(593) Sort
 Input [2]: [hd_demo_sk#54, hd_income_band_sk#55]
 Arguments: [hd_demo_sk#54 ASC NULLS FIRST], false, 0
 
-(597) SortMergeJoin
+(594) SortMergeJoin
 Left keys [1]: [ss_hdemo_sk#5]
 Right keys [1]: [hd_demo_sk#54]
 Join type: Inner
 Join condition: None
 
-(598) Project
+(595) Project
 Output [13]: [ss_item_sk#2, ss_addr_sk#6, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, c_current_hdemo_sk#41, c_current_addr_sk#42, d_year#46, d_year#48, hd_income_band_sk#55]
 Input [15]: [ss_item_sk#2, ss_hdemo_sk#5, ss_addr_sk#6, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, c_current_hdemo_sk#41, c_current_addr_sk#42, d_year#46, d_year#48, hd_demo_sk#54, hd_income_band_sk#55]
 
-(599) Exchange
+(596) Exchange
 Input [13]: [ss_item_sk#2, ss_addr_sk#6, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, c_current_hdemo_sk#41, c_current_addr_sk#42, d_year#46, d_year#48, hd_income_band_sk#55]
 Arguments: hashpartitioning(c_current_hdemo_sk#41, 100), ENSURE_REQUIREMENTS, [plan_id=74]
 
-(600) Sort
+(597) Sort
 Input [13]: [ss_item_sk#2, ss_addr_sk#6, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, c_current_hdemo_sk#41, c_current_addr_sk#42, d_year#46, d_year#48, hd_income_band_sk#55]
 Arguments: [c_current_hdemo_sk#41 ASC NULLS FIRST], false, 0
 
-(601) Scan parquet
+(598) Scan parquet
 Output [2]: [hd_demo_sk#56, hd_income_band_sk#57]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(hd_demo_sk), IsNotNull(hd_income_band_sk)]
 ReadSchema: struct<hd_demo_sk:int,hd_income_band_sk:int>
 
-(602) Filter
+(599) Filter
 Input [2]: [hd_demo_sk#56, hd_income_band_sk#57]
 Condition : (isnotnull(hd_demo_sk#56) AND isnotnull(hd_income_band_sk#57))
 
-(603) Exchange
+(600) Exchange
 Input [2]: [hd_demo_sk#56, hd_income_band_sk#57]
 Arguments: hashpartitioning(hd_demo_sk#56, 100), ENSURE_REQUIREMENTS, [plan_id=75]
 
-(604) Sort
+(601) Sort
 Input [2]: [hd_demo_sk#56, hd_income_band_sk#57]
 Arguments: [hd_demo_sk#56 ASC NULLS FIRST], false, 0
 
-(605) SortMergeJoin
+(602) SortMergeJoin
 Left keys [1]: [c_current_hdemo_sk#41]
 Right keys [1]: [hd_demo_sk#56]
 Join type: Inner
 Join condition: None
 
-(606) Project
+(603) Project
 Output [13]: [ss_item_sk#2, ss_addr_sk#6, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, c_current_addr_sk#42, d_year#46, d_year#48, hd_income_band_sk#55, hd_income_band_sk#57]
 Input [15]: [ss_item_sk#2, ss_addr_sk#6, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, c_current_hdemo_sk#41, c_current_addr_sk#42, d_year#46, d_year#48, hd_income_band_sk#55, hd_demo_sk#56, hd_income_band_sk#57]
 
-(607) Exchange
+(604) Exchange
 Input [13]: [ss_item_sk#2, ss_addr_sk#6, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, c_current_addr_sk#42, d_year#46, d_year#48, hd_income_band_sk#55, hd_income_band_sk#57]
 Arguments: hashpartitioning(ss_addr_sk#6, 100), ENSURE_REQUIREMENTS, [plan_id=76]
 
-(608) Sort
+(605) Sort
 Input [13]: [ss_item_sk#2, ss_addr_sk#6, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, c_current_addr_sk#42, d_year#46, d_year#48, hd_income_band_sk#55, hd_income_band_sk#57]
 Arguments: [ss_addr_sk#6 ASC NULLS FIRST], false, 0
 
-(609) Scan parquet
+(606) Scan parquet
 Output [5]: [ca_address_sk#58, ca_street_number#59, ca_street_name#60, ca_city#61, ca_zip#62]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(ca_address_sk)]
 ReadSchema: struct<ca_address_sk:int,ca_street_number:string,ca_street_name:string,ca_city:string,ca_zip:string>
 
-(610) Filter
+(607) Filter
 Input [5]: [ca_address_sk#58, ca_street_number#59, ca_street_name#60, ca_city#61, ca_zip#62]
 Condition : isnotnull(ca_address_sk#58)
 
-(611) Exchange
+(608) Exchange
 Input [5]: [ca_address_sk#58, ca_street_number#59, ca_street_name#60, ca_city#61, ca_zip#62]
 Arguments: hashpartitioning(ca_address_sk#58, 100), ENSURE_REQUIREMENTS, [plan_id=77]
 
-(612) Sort
+(609) Sort
 Input [5]: [ca_address_sk#58, ca_street_number#59, ca_street_name#60, ca_city#61, ca_zip#62]
 Arguments: [ca_address_sk#58 ASC NULLS FIRST], false, 0
 
-(613) SortMergeJoin
+(610) SortMergeJoin
 Left keys [1]: [ss_addr_sk#6]
 Right keys [1]: [ca_address_sk#58]
 Join type: Inner
 Join condition: None
 
-(614) Project
+(611) Project
 Output [16]: [ss_item_sk#2, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, c_current_addr_sk#42, d_year#46, d_year#48, hd_income_band_sk#55, hd_income_band_sk#57, ca_street_number#59, ca_street_name#60, ca_city#61, ca_zip#62]
 Input [18]: [ss_item_sk#2, ss_addr_sk#6, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, c_current_addr_sk#42, d_year#46, d_year#48, hd_income_band_sk#55, hd_income_band_sk#57, ca_address_sk#58, ca_street_number#59, ca_street_name#60, ca_city#61, ca_zip#62]
 
-(615) Exchange
+(612) Exchange
 Input [16]: [ss_item_sk#2, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, c_current_addr_sk#42, d_year#46, d_year#48, hd_income_band_sk#55, hd_income_band_sk#57, ca_street_number#59, ca_street_name#60, ca_city#61, ca_zip#62]
 Arguments: hashpartitioning(c_current_addr_sk#42, 100), ENSURE_REQUIREMENTS, [plan_id=78]
 
-(616) Sort
+(613) Sort
 Input [16]: [ss_item_sk#2, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, c_current_addr_sk#42, d_year#46, d_year#48, hd_income_band_sk#55, hd_income_band_sk#57, ca_street_number#59, ca_street_name#60, ca_city#61, ca_zip#62]
 Arguments: [c_current_addr_sk#42 ASC NULLS FIRST], false, 0
 
-(617) Scan parquet
+(614) Scan parquet
 Output [5]: [ca_address_sk#63, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(ca_address_sk)]
 ReadSchema: struct<ca_address_sk:int,ca_street_number:string,ca_street_name:string,ca_city:string,ca_zip:string>
 
-(618) Filter
+(615) Filter
 Input [5]: [ca_address_sk#63, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67]
 Condition : isnotnull(ca_address_sk#63)
 
-(619) Exchange
+(616) Exchange
 Input [5]: [ca_address_sk#63, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67]
 Arguments: hashpartitioning(ca_address_sk#63, 100), ENSURE_REQUIREMENTS, [plan_id=79]
 
-(620) Sort
+(617) Sort
 Input [5]: [ca_address_sk#63, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67]
 Arguments: [ca_address_sk#63 ASC NULLS FIRST], false, 0
 
-(621) SortMergeJoin
+(618) SortMergeJoin
 Left keys [1]: [c_current_addr_sk#42]
 Right keys [1]: [ca_address_sk#63]
 Join type: Inner
 Join condition: None
 
-(622) Project
+(619) Project
 Output [19]: [ss_item_sk#2, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, d_year#46, d_year#48, hd_income_band_sk#55, hd_income_band_sk#57, ca_street_number#59, ca_street_name#60, ca_city#61, ca_zip#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67]
 Input [21]: [ss_item_sk#2, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, c_current_addr_sk#42, d_year#46, d_year#48, hd_income_band_sk#55, hd_income_band_sk#57, ca_street_number#59, ca_street_name#60, ca_city#61, ca_zip#62, ca_address_sk#63, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67]
 
-(623) Exchange
+(620) Exchange
 Input [19]: [ss_item_sk#2, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, d_year#46, d_year#48, hd_income_band_sk#55, hd_income_band_sk#57, ca_street_number#59, ca_street_name#60, ca_city#61, ca_zip#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67]
 Arguments: hashpartitioning(hd_income_band_sk#55, 100), ENSURE_REQUIREMENTS, [plan_id=80]
 
-(624) Sort
+(621) Sort
 Input [19]: [ss_item_sk#2, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, d_year#46, d_year#48, hd_income_band_sk#55, hd_income_band_sk#57, ca_street_number#59, ca_street_name#60, ca_city#61, ca_zip#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67]
 Arguments: [hd_income_band_sk#55 ASC NULLS FIRST], false, 0
 
-(625) Scan parquet
+(622) Scan parquet
 Output [1]: [ib_income_band_sk#68]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(ib_income_band_sk)]
 ReadSchema: struct<ib_income_band_sk:int>
 
-(626) Filter
+(623) Filter
 Input [1]: [ib_income_band_sk#68]
 Condition : isnotnull(ib_income_band_sk#68)
 
-(627) Exchange
+(624) Exchange
 Input [1]: [ib_income_band_sk#68]
 Arguments: hashpartitioning(ib_income_band_sk#68, 100), ENSURE_REQUIREMENTS, [plan_id=81]
 
-(628) Sort
+(625) Sort
 Input [1]: [ib_income_band_sk#68]
 Arguments: [ib_income_band_sk#68 ASC NULLS FIRST], false, 0
 
-(629) SortMergeJoin
+(626) SortMergeJoin
 Left keys [1]: [hd_income_band_sk#55]
 Right keys [1]: [ib_income_band_sk#68]
 Join type: Inner
 Join condition: None
 
-(630) Project
+(627) Project
 Output [18]: [ss_item_sk#2, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, d_year#46, d_year#48, hd_income_band_sk#57, ca_street_number#59, ca_street_name#60, ca_city#61, ca_zip#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67]
 Input [20]: [ss_item_sk#2, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, d_year#46, d_year#48, hd_income_band_sk#55, hd_income_band_sk#57, ca_street_number#59, ca_street_name#60, ca_city#61, ca_zip#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, ib_income_band_sk#68]
 
-(631) Exchange
+(628) Exchange
 Input [18]: [ss_item_sk#2, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, d_year#46, d_year#48, hd_income_band_sk#57, ca_street_number#59, ca_street_name#60, ca_city#61, ca_zip#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67]
 Arguments: hashpartitioning(hd_income_band_sk#57, 100), ENSURE_REQUIREMENTS, [plan_id=82]
 
-(632) Sort
+(629) Sort
 Input [18]: [ss_item_sk#2, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, d_year#46, d_year#48, hd_income_band_sk#57, ca_street_number#59, ca_street_name#60, ca_city#61, ca_zip#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67]
 Arguments: [hd_income_band_sk#57 ASC NULLS FIRST], false, 0
 
-(633) Scan parquet
+(630) Scan parquet
 Output [1]: [ib_income_band_sk#69]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(ib_income_band_sk)]
 ReadSchema: struct<ib_income_band_sk:int>
 
-(634) Filter
+(631) Filter
 Input [1]: [ib_income_band_sk#69]
 Condition : isnotnull(ib_income_band_sk#69)
 
-(635) Exchange
+(632) Exchange
 Input [1]: [ib_income_band_sk#69]
 Arguments: hashpartitioning(ib_income_band_sk#69, 100), ENSURE_REQUIREMENTS, [plan_id=83]
 
-(636) Sort
+(633) Sort
 Input [1]: [ib_income_band_sk#69]
 Arguments: [ib_income_band_sk#69 ASC NULLS FIRST], false, 0
 
-(637) SortMergeJoin
+(634) SortMergeJoin
 Left keys [1]: [hd_income_band_sk#57]
 Right keys [1]: [ib_income_band_sk#69]
 Join type: Inner
 Join condition: None
 
-(638) Project
+(635) Project
 Output [17]: [ss_item_sk#2, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, d_year#46, d_year#48, ca_street_number#59, ca_street_name#60, ca_city#61, ca_zip#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67]
 Input [19]: [ss_item_sk#2, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, d_year#46, d_year#48, hd_income_band_sk#57, ca_street_number#59, ca_street_name#60, ca_city#61, ca_zip#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, ib_income_band_sk#69]
 
-(639) Exchange
+(636) Exchange
 Input [17]: [ss_item_sk#2, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, d_year#46, d_year#48, ca_street_number#59, ca_street_name#60, ca_city#61, ca_zip#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67]
 Arguments: hashpartitioning(ss_item_sk#2, 100), ENSURE_REQUIREMENTS, [plan_id=84]
 
-(640) Sort
+(637) Sort
 Input [17]: [ss_item_sk#2, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, d_year#46, d_year#48, ca_street_number#59, ca_street_name#60, ca_city#61, ca_zip#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67]
 Arguments: [ss_item_sk#2 ASC NULLS FIRST], false, 0
 
-(641) Scan parquet
+(638) Scan parquet
 Output [4]: [i_item_sk#70, i_current_price#71, i_color#72, i_product_name#73]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(i_current_price), In(i_color, [burlywood,floral,indian,medium,purple,spring]), GreaterThanOrEqual(i_current_price,64.00), LessThanOrEqual(i_current_price,74.00), GreaterThanOrEqual(i_current_price,65.00), LessThanOrEqual(i_current_price,79.00), IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_current_price:decimal(7,2),i_color:string,i_product_name:string>
 
-(642) Filter
+(639) Filter
 Input [4]: [i_item_sk#70, i_current_price#71, i_color#72, i_product_name#73]
 Condition : ((((((isnotnull(i_current_price#71) AND i_color#72 IN (purple,burlywood,indian,spring,floral,medium)) AND (i_current_price#71 >= 64.00)) AND (i_current_price#71 <= 74.00)) AND (i_current_price#71 >= 65.00)) AND (i_current_price#71 <= 79.00)) AND isnotnull(i_item_sk#70))
 
-(643) Project
+(640) Project
 Output [2]: [i_item_sk#70, i_product_name#73]
 Input [4]: [i_item_sk#70, i_current_price#71, i_color#72, i_product_name#73]
 
-(644) Exchange
+(641) Exchange
 Input [2]: [i_item_sk#70, i_product_name#73]
 Arguments: hashpartitioning(i_item_sk#70, 100), ENSURE_REQUIREMENTS, [plan_id=85]
 
-(645) Sort
+(642) Sort
 Input [2]: [i_item_sk#70, i_product_name#73]
 Arguments: [i_item_sk#70 ASC NULLS FIRST], false, 0
 
-(646) SortMergeJoin
+(643) SortMergeJoin
 Left keys [1]: [ss_item_sk#2]
 Right keys [1]: [i_item_sk#70]
 Join type: Inner
 Join condition: None
 
-(647) Project
+(644) Project
 Output [18]: [ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, d_year#46, d_year#48, s_store_name#37, s_zip#38, ca_street_number#59, ca_street_name#60, ca_city#61, ca_zip#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, i_item_sk#70, i_product_name#73]
 Input [19]: [ss_item_sk#2, ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, s_store_name#37, s_zip#38, d_year#46, d_year#48, ca_street_number#59, ca_street_name#60, ca_city#61, ca_zip#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, i_item_sk#70, i_product_name#73]
 
-(648) HashAggregate
+(645) HashAggregate
 Input [18]: [ss_wholesale_cost#10, ss_list_price#11, ss_coupon_amt#12, d_year#35, d_year#46, d_year#48, s_store_name#37, s_zip#38, ca_street_number#59, ca_street_name#60, ca_city#61, ca_zip#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, i_item_sk#70, i_product_name#73]
 Keys [15]: [i_product_name#73, i_item_sk#70, s_store_name#37, s_zip#38, ca_street_number#59, ca_street_name#60, ca_city#61, ca_zip#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, d_year#35, d_year#46, d_year#48]
 Functions [4]: [partial_count(1), partial_sum(UnscaledValue(ss_wholesale_cost#10)), partial_sum(UnscaledValue(ss_list_price#11)), partial_sum(UnscaledValue(ss_coupon_amt#12))]
 Aggregate Attributes [4]: [count#77, sum#78, sum#79, sum#80]
 Results [19]: [i_product_name#73, i_item_sk#70, s_store_name#37, s_zip#38, ca_street_number#59, ca_street_name#60, ca_city#61, ca_zip#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, d_year#35, d_year#46, d_year#48, count#168, sum#169, sum#170, sum#171]
 
-(649) HashAggregate
+(646) HashAggregate
 Input [19]: [i_product_name#73, i_item_sk#70, s_store_name#37, s_zip#38, ca_street_number#59, ca_street_name#60, ca_city#61, ca_zip#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, d_year#35, d_year#46, d_year#48, count#168, sum#169, sum#170, sum#171]
 Keys [15]: [i_product_name#73, i_item_sk#70, s_store_name#37, s_zip#38, ca_street_number#59, ca_street_name#60, ca_city#61, ca_zip#62, ca_street_number#64, ca_street_name#65, ca_city#66, ca_zip#67, d_year#35, d_year#46, d_year#48]
 Functions [4]: [count(1), sum(UnscaledValue(ss_wholesale_cost#10)), sum(UnscaledValue(ss_list_price#11)), sum(UnscaledValue(ss_coupon_amt#12))]
 Aggregate Attributes [4]: [count(1)#81, sum(UnscaledValue(ss_wholesale_cost#10))#82, sum(UnscaledValue(ss_list_price#11))#83, sum(UnscaledValue(ss_coupon_amt#12))#84]
 Results [17]: [i_product_name#73 AS product_name#85, i_item_sk#70 AS item_sk#86, s_store_name#37 AS store_name#87, s_zip#38 AS store_zip#88, ca_street_number#59 AS b_street_number#89, ca_street_name#60 AS b_streen_name#90, ca_city#61 AS b_city#91, ca_zip#62 AS b_zip#92, ca_street_number#64 AS c_street_number#93, ca_street_name#65 AS c_street_name#94, ca_city#66 AS c_city#95, ca_zip#67 AS c_zip#96, d_year#35 AS syear#97, count(1)#81 AS cnt#98, MakeDecimal(sum(UnscaledValue(ss_wholesale_cost#10))#82,17,2) AS s1#99, MakeDecimal(sum(UnscaledValue(ss_list_price#11))#83,17,2) AS s2#100, MakeDecimal(sum(UnscaledValue(ss_coupon_amt#12))#84,17,2) AS s3#101]
 
-(650) Exchange
+(647) Exchange
 Input [17]: [product_name#85, item_sk#86, store_name#87, store_zip#88, b_street_number#89, b_streen_name#90, b_city#91, b_zip#92, c_street_number#93, c_street_name#94, c_city#95, c_zip#96, syear#97, cnt#98, s1#99, s2#100, s3#101]
 Arguments: hashpartitioning(item_sk#86, store_name#87, store_zip#88, 100), ENSURE_REQUIREMENTS, [plan_id=86]
 
-(651) Sort
+(648) Sort
 Input [17]: [product_name#85, item_sk#86, store_name#87, store_zip#88, b_street_number#89, b_streen_name#90, b_city#91, b_zip#92, c_street_number#93, c_street_name#94, c_city#95, c_zip#96, syear#97, cnt#98, s1#99, s2#100, s3#101]
 Arguments: [item_sk#86 ASC NULLS FIRST, store_name#87 ASC NULLS FIRST, store_zip#88 ASC NULLS FIRST], false, 0
 
-(652) Scan parquet
+(649) Scan parquet
 Output [12]: [ss_sold_date_sk#102, ss_item_sk#103, ss_customer_sk#104, ss_cdemo_sk#105, ss_hdemo_sk#106, ss_addr_sk#107, ss_store_sk#108, ss_promo_sk#109, ss_ticket_number#172, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(ss_item_sk), IsNotNull(ss_ticket_number), IsNotNull(ss_sold_date_sk), IsNotNull(ss_store_sk), IsNotNull(ss_customer_sk), IsNotNull(ss_cdemo_sk), IsNotNull(ss_promo_sk), IsNotNull(ss_hdemo_sk), IsNotNull(ss_addr_sk)]
 ReadSchema: struct<ss_sold_date_sk:int,ss_item_sk:int,ss_customer_sk:int,ss_cdemo_sk:int,ss_hdemo_sk:int,ss_addr_sk:int,ss_store_sk:int,ss_promo_sk:int,ss_ticket_number:int,ss_wholesale_cost:decimal(7,2),ss_list_price:decimal(7,2),ss_coupon_amt:decimal(7,2)>
 
-(653) Filter
+(650) Filter
 Input [12]: [ss_sold_date_sk#102, ss_item_sk#103, ss_customer_sk#104, ss_cdemo_sk#105, ss_hdemo_sk#106, ss_addr_sk#107, ss_store_sk#108, ss_promo_sk#109, ss_ticket_number#172, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112]
 Condition : ((((((((isnotnull(ss_item_sk#103) AND isnotnull(ss_ticket_number#172)) AND isnotnull(ss_sold_date_sk#102)) AND isnotnull(ss_store_sk#108)) AND isnotnull(ss_customer_sk#104)) AND isnotnull(ss_cdemo_sk#105)) AND isnotnull(ss_promo_sk#109)) AND isnotnull(ss_hdemo_sk#106)) AND isnotnull(ss_addr_sk#107))
 
-(654) Exchange
+(651) Exchange
 Input [12]: [ss_sold_date_sk#102, ss_item_sk#103, ss_customer_sk#104, ss_cdemo_sk#105, ss_hdemo_sk#106, ss_addr_sk#107, ss_store_sk#108, ss_promo_sk#109, ss_ticket_number#172, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112]
 Arguments: hashpartitioning(ss_item_sk#103, ss_ticket_number#172, 100), ENSURE_REQUIREMENTS, [plan_id=87]
 
-(655) Sort
+(652) Sort
 Input [12]: [ss_sold_date_sk#102, ss_item_sk#103, ss_customer_sk#104, ss_cdemo_sk#105, ss_hdemo_sk#106, ss_addr_sk#107, ss_store_sk#108, ss_promo_sk#109, ss_ticket_number#172, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112]
 Arguments: [ss_item_sk#103 ASC NULLS FIRST, ss_ticket_number#172 ASC NULLS FIRST], false, 0
 
-(656) Scan parquet
+(653) Scan parquet
 Output [2]: [sr_item_sk#173, sr_ticket_number#174]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(sr_item_sk), IsNotNull(sr_ticket_number)]
 ReadSchema: struct<sr_item_sk:int,sr_ticket_number:int>
 
-(657) Filter
+(654) Filter
 Input [2]: [sr_item_sk#173, sr_ticket_number#174]
 Condition : (isnotnull(sr_item_sk#173) AND isnotnull(sr_ticket_number#174))
 
-(658) Exchange
+(655) Exchange
 Input [2]: [sr_item_sk#173, sr_ticket_number#174]
 Arguments: hashpartitioning(sr_item_sk#173, sr_ticket_number#174, 100), ENSURE_REQUIREMENTS, [plan_id=88]
 
-(659) Sort
+(656) Sort
 Input [2]: [sr_item_sk#173, sr_ticket_number#174]
 Arguments: [sr_item_sk#173 ASC NULLS FIRST, sr_ticket_number#174 ASC NULLS FIRST], false, 0
 
-(660) SortMergeJoin
+(657) SortMergeJoin
 Left keys [2]: [ss_item_sk#103, ss_ticket_number#172]
 Right keys [2]: [sr_item_sk#173, sr_ticket_number#174]
 Join type: Inner
 Join condition: None
 
-(661) Project
+(658) Project
 Output [11]: [ss_sold_date_sk#102, ss_item_sk#103, ss_customer_sk#104, ss_cdemo_sk#105, ss_hdemo_sk#106, ss_addr_sk#107, ss_store_sk#108, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112]
 Input [14]: [ss_sold_date_sk#102, ss_item_sk#103, ss_customer_sk#104, ss_cdemo_sk#105, ss_hdemo_sk#106, ss_addr_sk#107, ss_store_sk#108, ss_promo_sk#109, ss_ticket_number#172, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, sr_item_sk#173, sr_ticket_number#174]
 
-(662) Exchange
+(659) Exchange
 Input [11]: [ss_sold_date_sk#102, ss_item_sk#103, ss_customer_sk#104, ss_cdemo_sk#105, ss_hdemo_sk#106, ss_addr_sk#107, ss_store_sk#108, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112]
 Arguments: hashpartitioning(ss_item_sk#103, 100), ENSURE_REQUIREMENTS, [plan_id=89]
 
-(663) Sort
+(660) Sort
 Input [11]: [ss_sold_date_sk#102, ss_item_sk#103, ss_customer_sk#104, ss_cdemo_sk#105, ss_hdemo_sk#106, ss_addr_sk#107, ss_store_sk#108, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112]
 Arguments: [ss_item_sk#103 ASC NULLS FIRST], false, 0
 
-(664) Scan parquet
+(661) Scan parquet
 Output [3]: [cs_item_sk#175, cs_order_number#176, cs_ext_list_price#177]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(cs_item_sk), IsNotNull(cs_order_number)]
 ReadSchema: struct<cs_item_sk:int,cs_order_number:int,cs_ext_list_price:decimal(7,2)>
 
-(665) Filter
+(662) Filter
 Input [3]: [cs_item_sk#175, cs_order_number#176, cs_ext_list_price#177]
 Condition : (isnotnull(cs_item_sk#175) AND isnotnull(cs_order_number#176))
 
-(666) Exchange
+(663) Exchange
 Input [3]: [cs_item_sk#175, cs_order_number#176, cs_ext_list_price#177]
 Arguments: hashpartitioning(cs_item_sk#175, cs_order_number#176, 100), ENSURE_REQUIREMENTS, [plan_id=90]
 
-(667) Sort
+(664) Sort
 Input [3]: [cs_item_sk#175, cs_order_number#176, cs_ext_list_price#177]
 Arguments: [cs_item_sk#175 ASC NULLS FIRST, cs_order_number#176 ASC NULLS FIRST], false, 0
 
-(668) Scan parquet
+(665) Scan parquet
 Output [5]: [cr_item_sk#178, cr_order_number#179, cr_refunded_cash#180, cr_reversed_charge#181, cr_store_credit#182]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(cr_item_sk), IsNotNull(cr_order_number)]
 ReadSchema: struct<cr_item_sk:int,cr_order_number:int,cr_refunded_cash:decimal(7,2),cr_reversed_charge:decimal(7,2),cr_store_credit:decimal(7,2)>
 
-(669) Filter
+(666) Filter
 Input [5]: [cr_item_sk#178, cr_order_number#179, cr_refunded_cash#180, cr_reversed_charge#181, cr_store_credit#182]
 Condition : (isnotnull(cr_item_sk#178) AND isnotnull(cr_order_number#179))
 
-(670) Exchange
+(667) Exchange
 Input [5]: [cr_item_sk#178, cr_order_number#179, cr_refunded_cash#180, cr_reversed_charge#181, cr_store_credit#182]
 Arguments: hashpartitioning(cr_item_sk#178, cr_order_number#179, 100), ENSURE_REQUIREMENTS, [plan_id=91]
 
-(671) Sort
+(668) Sort
 Input [5]: [cr_item_sk#178, cr_order_number#179, cr_refunded_cash#180, cr_reversed_charge#181, cr_store_credit#182]
 Arguments: [cr_item_sk#178 ASC NULLS FIRST, cr_order_number#179 ASC NULLS FIRST], false, 0
 
-(672) SortMergeJoin
+(669) SortMergeJoin
 Left keys [2]: [cs_item_sk#175, cs_order_number#176]
 Right keys [2]: [cr_item_sk#178, cr_order_number#179]
 Join type: Inner
 Join condition: None
 
-(673) Project
+(670) Project
 Output [5]: [cs_item_sk#175, cs_ext_list_price#177, cr_refunded_cash#180, cr_reversed_charge#181, cr_store_credit#182]
 Input [8]: [cs_item_sk#175, cs_order_number#176, cs_ext_list_price#177, cr_item_sk#178, cr_order_number#179, cr_refunded_cash#180, cr_reversed_charge#181, cr_store_credit#182]
 
-(674) HashAggregate
+(671) HashAggregate
 Input [5]: [cs_item_sk#175, cs_ext_list_price#177, cr_refunded_cash#180, cr_reversed_charge#181, cr_store_credit#182]
 Keys [1]: [cs_item_sk#175]
 Functions [2]: [partial_sum(UnscaledValue(cs_ext_list_price#177)), partial_sum(((cr_refunded_cash#180 + cr_reversed_charge#181) + cr_store_credit#182))]
 Aggregate Attributes [3]: [sum#183, sum#184, isEmpty#185]
 Results [4]: [cs_item_sk#175, sum#186, sum#187, isEmpty#188]
 
-(675) Exchange
+(672) Exchange
 Input [4]: [cs_item_sk#175, sum#186, sum#187, isEmpty#188]
 Arguments: hashpartitioning(cs_item_sk#175, 100), ENSURE_REQUIREMENTS, [plan_id=92]
 
-(676) HashAggregate
+(673) HashAggregate
 Input [4]: [cs_item_sk#175, sum#186, sum#187, isEmpty#188]
 Keys [1]: [cs_item_sk#175]
 Functions [2]: [sum(UnscaledValue(cs_ext_list_price#177)), sum(((cr_refunded_cash#180 + cr_reversed_charge#181) + cr_store_credit#182))]
 Aggregate Attributes [2]: [sum(UnscaledValue(cs_ext_list_price#177))#30, sum(((cr_refunded_cash#180 + cr_reversed_charge#181) + cr_store_credit#182))#31]
 Results [3]: [cs_item_sk#175, MakeDecimal(sum(UnscaledValue(cs_ext_list_price#177))#30,17,2) AS sale#32, sum(((cr_refunded_cash#180 + cr_reversed_charge#181) + cr_store_credit#182))#31 AS refund#33]
 
-(677) Filter
+(674) Filter
 Input [3]: [cs_item_sk#175, sale#32, refund#33]
 Condition : ((isnotnull(sale#32) AND isnotnull(refund#33)) AND (cast(sale#32 as decimal(21,2)) > (2 * refund#33)))
 
-(678) Project
+(675) Project
 Output [1]: [cs_item_sk#175]
 Input [3]: [cs_item_sk#175, sale#32, refund#33]
 
-(679) Sort
+(676) Sort
 Input [1]: [cs_item_sk#175]
 Arguments: [cs_item_sk#175 ASC NULLS FIRST], false, 0
 
-(680) SortMergeJoin
+(677) SortMergeJoin
 Left keys [1]: [ss_item_sk#103]
 Right keys [1]: [cs_item_sk#175]
 Join type: Inner
 Join condition: None
 
-(681) Project
+(678) Project
 Output [11]: [ss_sold_date_sk#102, ss_item_sk#103, ss_customer_sk#104, ss_cdemo_sk#105, ss_hdemo_sk#106, ss_addr_sk#107, ss_store_sk#108, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112]
 Input [12]: [ss_sold_date_sk#102, ss_item_sk#103, ss_customer_sk#104, ss_cdemo_sk#105, ss_hdemo_sk#106, ss_addr_sk#107, ss_store_sk#108, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, cs_item_sk#175]
 
-(682) Exchange
+(679) Exchange
 Input [11]: [ss_sold_date_sk#102, ss_item_sk#103, ss_customer_sk#104, ss_cdemo_sk#105, ss_hdemo_sk#106, ss_addr_sk#107, ss_store_sk#108, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112]
 Arguments: hashpartitioning(ss_sold_date_sk#102, 100), ENSURE_REQUIREMENTS, [plan_id=93]
 
-(683) Sort
+(680) Sort
 Input [11]: [ss_sold_date_sk#102, ss_item_sk#103, ss_customer_sk#104, ss_cdemo_sk#105, ss_hdemo_sk#106, ss_addr_sk#107, ss_store_sk#108, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112]
 Arguments: [ss_sold_date_sk#102 ASC NULLS FIRST], false, 0
 
-(684) Scan parquet
+(681) Scan parquet
 Output [2]: [d_date_sk#113, d_year#114]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2000), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
-(685) Filter
+(682) Filter
 Input [2]: [d_date_sk#113, d_year#114]
 Condition : ((isnotnull(d_year#114) AND (d_year#114 = 2000)) AND isnotnull(d_date_sk#113))
 
-(686) Exchange
+(683) Exchange
 Input [2]: [d_date_sk#113, d_year#114]
 Arguments: hashpartitioning(d_date_sk#113, 100), ENSURE_REQUIREMENTS, [plan_id=94]
 
-(687) Sort
+(684) Sort
 Input [2]: [d_date_sk#113, d_year#114]
 Arguments: [d_date_sk#113 ASC NULLS FIRST], false, 0
 
-(688) SortMergeJoin
+(685) SortMergeJoin
 Left keys [1]: [ss_sold_date_sk#102]
 Right keys [1]: [d_date_sk#113]
 Join type: Inner
 Join condition: None
 
-(689) Project
+(686) Project
 Output [11]: [ss_item_sk#103, ss_customer_sk#104, ss_cdemo_sk#105, ss_hdemo_sk#106, ss_addr_sk#107, ss_store_sk#108, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114]
 Input [13]: [ss_sold_date_sk#102, ss_item_sk#103, ss_customer_sk#104, ss_cdemo_sk#105, ss_hdemo_sk#106, ss_addr_sk#107, ss_store_sk#108, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_date_sk#113, d_year#114]
 
-(690) Exchange
+(687) Exchange
 Input [11]: [ss_item_sk#103, ss_customer_sk#104, ss_cdemo_sk#105, ss_hdemo_sk#106, ss_addr_sk#107, ss_store_sk#108, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114]
 Arguments: hashpartitioning(ss_store_sk#108, 100), ENSURE_REQUIREMENTS, [plan_id=95]
 
-(691) Sort
+(688) Sort
 Input [11]: [ss_item_sk#103, ss_customer_sk#104, ss_cdemo_sk#105, ss_hdemo_sk#106, ss_addr_sk#107, ss_store_sk#108, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114]
 Arguments: [ss_store_sk#108 ASC NULLS FIRST], false, 0
 
-(692) Scan parquet
+(689) Scan parquet
 Output [3]: [s_store_sk#115, s_store_name#116, s_zip#117]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(s_store_sk), IsNotNull(s_store_name), IsNotNull(s_zip)]
 ReadSchema: struct<s_store_sk:int,s_store_name:string,s_zip:string>
 
-(693) Filter
+(690) Filter
 Input [3]: [s_store_sk#115, s_store_name#116, s_zip#117]
 Condition : ((isnotnull(s_store_sk#115) AND isnotnull(s_store_name#116)) AND isnotnull(s_zip#117))
 
-(694) Exchange
+(691) Exchange
 Input [3]: [s_store_sk#115, s_store_name#116, s_zip#117]
 Arguments: hashpartitioning(s_store_sk#115, 100), ENSURE_REQUIREMENTS, [plan_id=96]
 
-(695) Sort
+(692) Sort
 Input [3]: [s_store_sk#115, s_store_name#116, s_zip#117]
 Arguments: [s_store_sk#115 ASC NULLS FIRST], false, 0
 
-(696) SortMergeJoin
+(693) SortMergeJoin
 Left keys [1]: [ss_store_sk#108]
 Right keys [1]: [s_store_sk#115]
 Join type: Inner
 Join condition: None
 
-(697) Project
+(694) Project
 Output [12]: [ss_item_sk#103, ss_customer_sk#104, ss_cdemo_sk#105, ss_hdemo_sk#106, ss_addr_sk#107, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117]
 Input [14]: [ss_item_sk#103, ss_customer_sk#104, ss_cdemo_sk#105, ss_hdemo_sk#106, ss_addr_sk#107, ss_store_sk#108, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_sk#115, s_store_name#116, s_zip#117]
 
-(698) Exchange
+(695) Exchange
 Input [12]: [ss_item_sk#103, ss_customer_sk#104, ss_cdemo_sk#105, ss_hdemo_sk#106, ss_addr_sk#107, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117]
 Arguments: hashpartitioning(ss_customer_sk#104, 100), ENSURE_REQUIREMENTS, [plan_id=97]
 
-(699) Sort
+(696) Sort
 Input [12]: [ss_item_sk#103, ss_customer_sk#104, ss_cdemo_sk#105, ss_hdemo_sk#106, ss_addr_sk#107, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117]
 Arguments: [ss_customer_sk#104 ASC NULLS FIRST], false, 0
 
-(700) Scan parquet
+(697) Scan parquet
 Output [6]: [c_customer_sk#118, c_current_cdemo_sk#119, c_current_hdemo_sk#120, c_current_addr_sk#121, c_first_shipto_date_sk#122, c_first_sales_date_sk#123]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_first_sales_date_sk), IsNotNull(c_first_shipto_date_sk), IsNotNull(c_current_cdemo_sk), IsNotNull(c_current_hdemo_sk), IsNotNull(c_current_addr_sk)]
 ReadSchema: struct<c_customer_sk:int,c_current_cdemo_sk:int,c_current_hdemo_sk:int,c_current_addr_sk:int,c_first_shipto_date_sk:int,c_first_sales_date_sk:int>
 
-(701) Filter
+(698) Filter
 Input [6]: [c_customer_sk#118, c_current_cdemo_sk#119, c_current_hdemo_sk#120, c_current_addr_sk#121, c_first_shipto_date_sk#122, c_first_sales_date_sk#123]
 Condition : (((((isnotnull(c_customer_sk#118) AND isnotnull(c_first_sales_date_sk#123)) AND isnotnull(c_first_shipto_date_sk#122)) AND isnotnull(c_current_cdemo_sk#119)) AND isnotnull(c_current_hdemo_sk#120)) AND isnotnull(c_current_addr_sk#121))
 
-(702) Exchange
+(699) Exchange
 Input [6]: [c_customer_sk#118, c_current_cdemo_sk#119, c_current_hdemo_sk#120, c_current_addr_sk#121, c_first_shipto_date_sk#122, c_first_sales_date_sk#123]
 Arguments: hashpartitioning(c_customer_sk#118, 100), ENSURE_REQUIREMENTS, [plan_id=98]
 
-(703) Sort
+(700) Sort
 Input [6]: [c_customer_sk#118, c_current_cdemo_sk#119, c_current_hdemo_sk#120, c_current_addr_sk#121, c_first_shipto_date_sk#122, c_first_sales_date_sk#123]
 Arguments: [c_customer_sk#118 ASC NULLS FIRST], false, 0
 
-(704) SortMergeJoin
+(701) SortMergeJoin
 Left keys [1]: [ss_customer_sk#104]
 Right keys [1]: [c_customer_sk#118]
 Join type: Inner
 Join condition: None
 
-(705) Project
+(702) Project
 Output [16]: [ss_item_sk#103, ss_cdemo_sk#105, ss_hdemo_sk#106, ss_addr_sk#107, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_cdemo_sk#119, c_current_hdemo_sk#120, c_current_addr_sk#121, c_first_shipto_date_sk#122, c_first_sales_date_sk#123]
 Input [18]: [ss_item_sk#103, ss_customer_sk#104, ss_cdemo_sk#105, ss_hdemo_sk#106, ss_addr_sk#107, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_customer_sk#118, c_current_cdemo_sk#119, c_current_hdemo_sk#120, c_current_addr_sk#121, c_first_shipto_date_sk#122, c_first_sales_date_sk#123]
 
-(706) Exchange
+(703) Exchange
 Input [16]: [ss_item_sk#103, ss_cdemo_sk#105, ss_hdemo_sk#106, ss_addr_sk#107, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_cdemo_sk#119, c_current_hdemo_sk#120, c_current_addr_sk#121, c_first_shipto_date_sk#122, c_first_sales_date_sk#123]
 Arguments: hashpartitioning(c_first_sales_date_sk#123, 100), ENSURE_REQUIREMENTS, [plan_id=99]
 
-(707) Sort
+(704) Sort
 Input [16]: [ss_item_sk#103, ss_cdemo_sk#105, ss_hdemo_sk#106, ss_addr_sk#107, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_cdemo_sk#119, c_current_hdemo_sk#120, c_current_addr_sk#121, c_first_shipto_date_sk#122, c_first_sales_date_sk#123]
 Arguments: [c_first_sales_date_sk#123 ASC NULLS FIRST], false, 0
 
-(708) Scan parquet
+(705) Scan parquet
 Output [2]: [d_date_sk#124, d_year#125]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
-(709) Filter
+(706) Filter
 Input [2]: [d_date_sk#124, d_year#125]
 Condition : isnotnull(d_date_sk#124)
 
-(710) Exchange
+(707) Exchange
 Input [2]: [d_date_sk#124, d_year#125]
 Arguments: hashpartitioning(d_date_sk#124, 100), ENSURE_REQUIREMENTS, [plan_id=100]
 
-(711) Sort
+(708) Sort
 Input [2]: [d_date_sk#124, d_year#125]
 Arguments: [d_date_sk#124 ASC NULLS FIRST], false, 0
 
-(712) SortMergeJoin
+(709) SortMergeJoin
 Left keys [1]: [c_first_sales_date_sk#123]
 Right keys [1]: [d_date_sk#124]
 Join type: Inner
 Join condition: None
 
-(713) Project
+(710) Project
 Output [16]: [ss_item_sk#103, ss_cdemo_sk#105, ss_hdemo_sk#106, ss_addr_sk#107, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_cdemo_sk#119, c_current_hdemo_sk#120, c_current_addr_sk#121, c_first_shipto_date_sk#122, d_year#125]
 Input [18]: [ss_item_sk#103, ss_cdemo_sk#105, ss_hdemo_sk#106, ss_addr_sk#107, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_cdemo_sk#119, c_current_hdemo_sk#120, c_current_addr_sk#121, c_first_shipto_date_sk#122, c_first_sales_date_sk#123, d_date_sk#124, d_year#125]
 
-(714) Exchange
+(711) Exchange
 Input [16]: [ss_item_sk#103, ss_cdemo_sk#105, ss_hdemo_sk#106, ss_addr_sk#107, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_cdemo_sk#119, c_current_hdemo_sk#120, c_current_addr_sk#121, c_first_shipto_date_sk#122, d_year#125]
 Arguments: hashpartitioning(c_first_shipto_date_sk#122, 100), ENSURE_REQUIREMENTS, [plan_id=101]
 
-(715) Sort
+(712) Sort
 Input [16]: [ss_item_sk#103, ss_cdemo_sk#105, ss_hdemo_sk#106, ss_addr_sk#107, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_cdemo_sk#119, c_current_hdemo_sk#120, c_current_addr_sk#121, c_first_shipto_date_sk#122, d_year#125]
 Arguments: [c_first_shipto_date_sk#122 ASC NULLS FIRST], false, 0
 
-(716) Scan parquet
+(713) Scan parquet
 Output [2]: [d_date_sk#126, d_year#127]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
-(717) Filter
+(714) Filter
 Input [2]: [d_date_sk#126, d_year#127]
 Condition : isnotnull(d_date_sk#126)
 
-(718) Exchange
+(715) Exchange
 Input [2]: [d_date_sk#126, d_year#127]
 Arguments: hashpartitioning(d_date_sk#126, 100), ENSURE_REQUIREMENTS, [plan_id=102]
 
-(719) Sort
+(716) Sort
 Input [2]: [d_date_sk#126, d_year#127]
 Arguments: [d_date_sk#126 ASC NULLS FIRST], false, 0
 
-(720) SortMergeJoin
+(717) SortMergeJoin
 Left keys [1]: [c_first_shipto_date_sk#122]
 Right keys [1]: [d_date_sk#126]
 Join type: Inner
 Join condition: None
 
-(721) Project
+(718) Project
 Output [16]: [ss_item_sk#103, ss_cdemo_sk#105, ss_hdemo_sk#106, ss_addr_sk#107, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_cdemo_sk#119, c_current_hdemo_sk#120, c_current_addr_sk#121, d_year#125, d_year#127]
 Input [18]: [ss_item_sk#103, ss_cdemo_sk#105, ss_hdemo_sk#106, ss_addr_sk#107, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_cdemo_sk#119, c_current_hdemo_sk#120, c_current_addr_sk#121, c_first_shipto_date_sk#122, d_year#125, d_date_sk#126, d_year#127]
 
-(722) Exchange
+(719) Exchange
 Input [16]: [ss_item_sk#103, ss_cdemo_sk#105, ss_hdemo_sk#106, ss_addr_sk#107, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_cdemo_sk#119, c_current_hdemo_sk#120, c_current_addr_sk#121, d_year#125, d_year#127]
 Arguments: hashpartitioning(ss_cdemo_sk#105, 100), ENSURE_REQUIREMENTS, [plan_id=103]
 
-(723) Sort
+(720) Sort
 Input [16]: [ss_item_sk#103, ss_cdemo_sk#105, ss_hdemo_sk#106, ss_addr_sk#107, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_cdemo_sk#119, c_current_hdemo_sk#120, c_current_addr_sk#121, d_year#125, d_year#127]
 Arguments: [ss_cdemo_sk#105 ASC NULLS FIRST], false, 0
 
-(724) Scan parquet
+(721) Scan parquet
 Output [2]: [cd_demo_sk#128, cd_marital_status#129]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(cd_demo_sk), IsNotNull(cd_marital_status)]
 ReadSchema: struct<cd_demo_sk:int,cd_marital_status:string>
 
-(725) Filter
+(722) Filter
 Input [2]: [cd_demo_sk#128, cd_marital_status#129]
 Condition : (isnotnull(cd_demo_sk#128) AND isnotnull(cd_marital_status#129))
 
-(726) Exchange
+(723) Exchange
 Input [2]: [cd_demo_sk#128, cd_marital_status#129]
 Arguments: hashpartitioning(cd_demo_sk#128, 100), ENSURE_REQUIREMENTS, [plan_id=104]
 
-(727) Sort
+(724) Sort
 Input [2]: [cd_demo_sk#128, cd_marital_status#129]
 Arguments: [cd_demo_sk#128 ASC NULLS FIRST], false, 0
 
-(728) SortMergeJoin
+(725) SortMergeJoin
 Left keys [1]: [ss_cdemo_sk#105]
 Right keys [1]: [cd_demo_sk#128]
 Join type: Inner
 Join condition: None
 
-(729) Project
+(726) Project
 Output [16]: [ss_item_sk#103, ss_hdemo_sk#106, ss_addr_sk#107, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_cdemo_sk#119, c_current_hdemo_sk#120, c_current_addr_sk#121, d_year#125, d_year#127, cd_marital_status#129]
 Input [18]: [ss_item_sk#103, ss_cdemo_sk#105, ss_hdemo_sk#106, ss_addr_sk#107, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_cdemo_sk#119, c_current_hdemo_sk#120, c_current_addr_sk#121, d_year#125, d_year#127, cd_demo_sk#128, cd_marital_status#129]
 
-(730) Exchange
+(727) Exchange
 Input [16]: [ss_item_sk#103, ss_hdemo_sk#106, ss_addr_sk#107, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_cdemo_sk#119, c_current_hdemo_sk#120, c_current_addr_sk#121, d_year#125, d_year#127, cd_marital_status#129]
 Arguments: hashpartitioning(c_current_cdemo_sk#119, 100), ENSURE_REQUIREMENTS, [plan_id=105]
 
-(731) Sort
+(728) Sort
 Input [16]: [ss_item_sk#103, ss_hdemo_sk#106, ss_addr_sk#107, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_cdemo_sk#119, c_current_hdemo_sk#120, c_current_addr_sk#121, d_year#125, d_year#127, cd_marital_status#129]
 Arguments: [c_current_cdemo_sk#119 ASC NULLS FIRST], false, 0
 
-(732) Scan parquet
+(729) Scan parquet
 Output [2]: [cd_demo_sk#130, cd_marital_status#131]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(cd_demo_sk), IsNotNull(cd_marital_status)]
 ReadSchema: struct<cd_demo_sk:int,cd_marital_status:string>
 
-(733) Filter
+(730) Filter
 Input [2]: [cd_demo_sk#130, cd_marital_status#131]
 Condition : (isnotnull(cd_demo_sk#130) AND isnotnull(cd_marital_status#131))
 
-(734) Exchange
+(731) Exchange
 Input [2]: [cd_demo_sk#130, cd_marital_status#131]
 Arguments: hashpartitioning(cd_demo_sk#130, 100), ENSURE_REQUIREMENTS, [plan_id=106]
 
-(735) Sort
+(732) Sort
 Input [2]: [cd_demo_sk#130, cd_marital_status#131]
 Arguments: [cd_demo_sk#130 ASC NULLS FIRST], false, 0
 
-(736) SortMergeJoin
+(733) SortMergeJoin
 Left keys [1]: [c_current_cdemo_sk#119]
 Right keys [1]: [cd_demo_sk#130]
 Join type: Inner
 Join condition: NOT (cd_marital_status#129 = cd_marital_status#131)
 
-(737) Project
+(734) Project
 Output [14]: [ss_item_sk#103, ss_hdemo_sk#106, ss_addr_sk#107, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_hdemo_sk#120, c_current_addr_sk#121, d_year#125, d_year#127]
 Input [18]: [ss_item_sk#103, ss_hdemo_sk#106, ss_addr_sk#107, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_cdemo_sk#119, c_current_hdemo_sk#120, c_current_addr_sk#121, d_year#125, d_year#127, cd_marital_status#129, cd_demo_sk#130, cd_marital_status#131]
 
-(738) Exchange
+(735) Exchange
 Input [14]: [ss_item_sk#103, ss_hdemo_sk#106, ss_addr_sk#107, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_hdemo_sk#120, c_current_addr_sk#121, d_year#125, d_year#127]
 Arguments: hashpartitioning(ss_promo_sk#109, 100), ENSURE_REQUIREMENTS, [plan_id=107]
 
-(739) Sort
+(736) Sort
 Input [14]: [ss_item_sk#103, ss_hdemo_sk#106, ss_addr_sk#107, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_hdemo_sk#120, c_current_addr_sk#121, d_year#125, d_year#127]
 Arguments: [ss_promo_sk#109 ASC NULLS FIRST], false, 0
 
-(740) Scan parquet
+(737) Scan parquet
 Output [1]: [p_promo_sk#132]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(p_promo_sk)]
 ReadSchema: struct<p_promo_sk:int>
 
-(741) Filter
+(738) Filter
 Input [1]: [p_promo_sk#132]
 Condition : isnotnull(p_promo_sk#132)
 
-(742) Exchange
+(739) Exchange
 Input [1]: [p_promo_sk#132]
 Arguments: hashpartitioning(p_promo_sk#132, 100), ENSURE_REQUIREMENTS, [plan_id=108]
 
-(743) Sort
+(740) Sort
 Input [1]: [p_promo_sk#132]
 Arguments: [p_promo_sk#132 ASC NULLS FIRST], false, 0
 
-(744) SortMergeJoin
+(741) SortMergeJoin
 Left keys [1]: [ss_promo_sk#109]
 Right keys [1]: [p_promo_sk#132]
 Join type: Inner
 Join condition: None
 
-(745) Project
+(742) Project
 Output [13]: [ss_item_sk#103, ss_hdemo_sk#106, ss_addr_sk#107, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_hdemo_sk#120, c_current_addr_sk#121, d_year#125, d_year#127]
 Input [15]: [ss_item_sk#103, ss_hdemo_sk#106, ss_addr_sk#107, ss_promo_sk#109, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_hdemo_sk#120, c_current_addr_sk#121, d_year#125, d_year#127, p_promo_sk#132]
 
-(746) Exchange
+(743) Exchange
 Input [13]: [ss_item_sk#103, ss_hdemo_sk#106, ss_addr_sk#107, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_hdemo_sk#120, c_current_addr_sk#121, d_year#125, d_year#127]
 Arguments: hashpartitioning(ss_hdemo_sk#106, 100), ENSURE_REQUIREMENTS, [plan_id=109]
 
-(747) Sort
+(744) Sort
 Input [13]: [ss_item_sk#103, ss_hdemo_sk#106, ss_addr_sk#107, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_hdemo_sk#120, c_current_addr_sk#121, d_year#125, d_year#127]
 Arguments: [ss_hdemo_sk#106 ASC NULLS FIRST], false, 0
 
-(748) Scan parquet
+(745) Scan parquet
 Output [2]: [hd_demo_sk#133, hd_income_band_sk#134]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(hd_demo_sk), IsNotNull(hd_income_band_sk)]
 ReadSchema: struct<hd_demo_sk:int,hd_income_band_sk:int>
 
-(749) Filter
+(746) Filter
 Input [2]: [hd_demo_sk#133, hd_income_band_sk#134]
 Condition : (isnotnull(hd_demo_sk#133) AND isnotnull(hd_income_band_sk#134))
 
-(750) Exchange
+(747) Exchange
 Input [2]: [hd_demo_sk#133, hd_income_band_sk#134]
 Arguments: hashpartitioning(hd_demo_sk#133, 100), ENSURE_REQUIREMENTS, [plan_id=110]
 
-(751) Sort
+(748) Sort
 Input [2]: [hd_demo_sk#133, hd_income_band_sk#134]
 Arguments: [hd_demo_sk#133 ASC NULLS FIRST], false, 0
 
-(752) SortMergeJoin
+(749) SortMergeJoin
 Left keys [1]: [ss_hdemo_sk#106]
 Right keys [1]: [hd_demo_sk#133]
 Join type: Inner
 Join condition: None
 
-(753) Project
+(750) Project
 Output [13]: [ss_item_sk#103, ss_addr_sk#107, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_hdemo_sk#120, c_current_addr_sk#121, d_year#125, d_year#127, hd_income_band_sk#134]
 Input [15]: [ss_item_sk#103, ss_hdemo_sk#106, ss_addr_sk#107, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_hdemo_sk#120, c_current_addr_sk#121, d_year#125, d_year#127, hd_demo_sk#133, hd_income_band_sk#134]
 
-(754) Exchange
+(751) Exchange
 Input [13]: [ss_item_sk#103, ss_addr_sk#107, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_hdemo_sk#120, c_current_addr_sk#121, d_year#125, d_year#127, hd_income_band_sk#134]
 Arguments: hashpartitioning(c_current_hdemo_sk#120, 100), ENSURE_REQUIREMENTS, [plan_id=111]
 
-(755) Sort
+(752) Sort
 Input [13]: [ss_item_sk#103, ss_addr_sk#107, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_hdemo_sk#120, c_current_addr_sk#121, d_year#125, d_year#127, hd_income_band_sk#134]
 Arguments: [c_current_hdemo_sk#120 ASC NULLS FIRST], false, 0
 
-(756) Scan parquet
+(753) Scan parquet
 Output [2]: [hd_demo_sk#135, hd_income_band_sk#136]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(hd_demo_sk), IsNotNull(hd_income_band_sk)]
 ReadSchema: struct<hd_demo_sk:int,hd_income_band_sk:int>
 
-(757) Filter
+(754) Filter
 Input [2]: [hd_demo_sk#135, hd_income_band_sk#136]
 Condition : (isnotnull(hd_demo_sk#135) AND isnotnull(hd_income_band_sk#136))
 
-(758) Exchange
+(755) Exchange
 Input [2]: [hd_demo_sk#135, hd_income_band_sk#136]
 Arguments: hashpartitioning(hd_demo_sk#135, 100), ENSURE_REQUIREMENTS, [plan_id=112]
 
-(759) Sort
+(756) Sort
 Input [2]: [hd_demo_sk#135, hd_income_band_sk#136]
 Arguments: [hd_demo_sk#135 ASC NULLS FIRST], false, 0
 
-(760) SortMergeJoin
+(757) SortMergeJoin
 Left keys [1]: [c_current_hdemo_sk#120]
 Right keys [1]: [hd_demo_sk#135]
 Join type: Inner
 Join condition: None
 
-(761) Project
+(758) Project
 Output [13]: [ss_item_sk#103, ss_addr_sk#107, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_addr_sk#121, d_year#125, d_year#127, hd_income_band_sk#134, hd_income_band_sk#136]
 Input [15]: [ss_item_sk#103, ss_addr_sk#107, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_hdemo_sk#120, c_current_addr_sk#121, d_year#125, d_year#127, hd_income_band_sk#134, hd_demo_sk#135, hd_income_band_sk#136]
 
-(762) Exchange
+(759) Exchange
 Input [13]: [ss_item_sk#103, ss_addr_sk#107, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_addr_sk#121, d_year#125, d_year#127, hd_income_band_sk#134, hd_income_band_sk#136]
 Arguments: hashpartitioning(ss_addr_sk#107, 100), ENSURE_REQUIREMENTS, [plan_id=113]
 
-(763) Sort
+(760) Sort
 Input [13]: [ss_item_sk#103, ss_addr_sk#107, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_addr_sk#121, d_year#125, d_year#127, hd_income_band_sk#134, hd_income_band_sk#136]
 Arguments: [ss_addr_sk#107 ASC NULLS FIRST], false, 0
 
-(764) Scan parquet
+(761) Scan parquet
 Output [5]: [ca_address_sk#137, ca_street_number#138, ca_street_name#139, ca_city#140, ca_zip#141]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(ca_address_sk)]
 ReadSchema: struct<ca_address_sk:int,ca_street_number:string,ca_street_name:string,ca_city:string,ca_zip:string>
 
-(765) Filter
+(762) Filter
 Input [5]: [ca_address_sk#137, ca_street_number#138, ca_street_name#139, ca_city#140, ca_zip#141]
 Condition : isnotnull(ca_address_sk#137)
 
-(766) Exchange
+(763) Exchange
 Input [5]: [ca_address_sk#137, ca_street_number#138, ca_street_name#139, ca_city#140, ca_zip#141]
 Arguments: hashpartitioning(ca_address_sk#137, 100), ENSURE_REQUIREMENTS, [plan_id=114]
 
-(767) Sort
+(764) Sort
 Input [5]: [ca_address_sk#137, ca_street_number#138, ca_street_name#139, ca_city#140, ca_zip#141]
 Arguments: [ca_address_sk#137 ASC NULLS FIRST], false, 0
 
-(768) SortMergeJoin
+(765) SortMergeJoin
 Left keys [1]: [ss_addr_sk#107]
 Right keys [1]: [ca_address_sk#137]
 Join type: Inner
 Join condition: None
 
-(769) Project
+(766) Project
 Output [16]: [ss_item_sk#103, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_addr_sk#121, d_year#125, d_year#127, hd_income_band_sk#134, hd_income_band_sk#136, ca_street_number#138, ca_street_name#139, ca_city#140, ca_zip#141]
 Input [18]: [ss_item_sk#103, ss_addr_sk#107, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_addr_sk#121, d_year#125, d_year#127, hd_income_band_sk#134, hd_income_band_sk#136, ca_address_sk#137, ca_street_number#138, ca_street_name#139, ca_city#140, ca_zip#141]
 
-(770) Exchange
+(767) Exchange
 Input [16]: [ss_item_sk#103, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_addr_sk#121, d_year#125, d_year#127, hd_income_band_sk#134, hd_income_band_sk#136, ca_street_number#138, ca_street_name#139, ca_city#140, ca_zip#141]
 Arguments: hashpartitioning(c_current_addr_sk#121, 100), ENSURE_REQUIREMENTS, [plan_id=115]
 
-(771) Sort
+(768) Sort
 Input [16]: [ss_item_sk#103, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_addr_sk#121, d_year#125, d_year#127, hd_income_band_sk#134, hd_income_band_sk#136, ca_street_number#138, ca_street_name#139, ca_city#140, ca_zip#141]
 Arguments: [c_current_addr_sk#121 ASC NULLS FIRST], false, 0
 
-(772) Scan parquet
+(769) Scan parquet
 Output [5]: [ca_address_sk#142, ca_street_number#143, ca_street_name#144, ca_city#145, ca_zip#146]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(ca_address_sk)]
 ReadSchema: struct<ca_address_sk:int,ca_street_number:string,ca_street_name:string,ca_city:string,ca_zip:string>
 
-(773) Filter
+(770) Filter
 Input [5]: [ca_address_sk#142, ca_street_number#143, ca_street_name#144, ca_city#145, ca_zip#146]
 Condition : isnotnull(ca_address_sk#142)
 
-(774) Exchange
+(771) Exchange
 Input [5]: [ca_address_sk#142, ca_street_number#143, ca_street_name#144, ca_city#145, ca_zip#146]
 Arguments: hashpartitioning(ca_address_sk#142, 100), ENSURE_REQUIREMENTS, [plan_id=116]
 
-(775) Sort
+(772) Sort
 Input [5]: [ca_address_sk#142, ca_street_number#143, ca_street_name#144, ca_city#145, ca_zip#146]
 Arguments: [ca_address_sk#142 ASC NULLS FIRST], false, 0
 
-(776) SortMergeJoin
+(773) SortMergeJoin
 Left keys [1]: [c_current_addr_sk#121]
 Right keys [1]: [ca_address_sk#142]
 Join type: Inner
 Join condition: None
 
-(777) Project
+(774) Project
 Output [19]: [ss_item_sk#103, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, d_year#125, d_year#127, hd_income_band_sk#134, hd_income_band_sk#136, ca_street_number#138, ca_street_name#139, ca_city#140, ca_zip#141, ca_street_number#143, ca_street_name#144, ca_city#145, ca_zip#146]
 Input [21]: [ss_item_sk#103, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, c_current_addr_sk#121, d_year#125, d_year#127, hd_income_band_sk#134, hd_income_band_sk#136, ca_street_number#138, ca_street_name#139, ca_city#140, ca_zip#141, ca_address_sk#142, ca_street_number#143, ca_street_name#144, ca_city#145, ca_zip#146]
 
-(778) Exchange
+(775) Exchange
 Input [19]: [ss_item_sk#103, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, d_year#125, d_year#127, hd_income_band_sk#134, hd_income_band_sk#136, ca_street_number#138, ca_street_name#139, ca_city#140, ca_zip#141, ca_street_number#143, ca_street_name#144, ca_city#145, ca_zip#146]
 Arguments: hashpartitioning(hd_income_band_sk#134, 100), ENSURE_REQUIREMENTS, [plan_id=117]
 
-(779) Sort
+(776) Sort
 Input [19]: [ss_item_sk#103, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, d_year#125, d_year#127, hd_income_band_sk#134, hd_income_band_sk#136, ca_street_number#138, ca_street_name#139, ca_city#140, ca_zip#141, ca_street_number#143, ca_street_name#144, ca_city#145, ca_zip#146]
 Arguments: [hd_income_band_sk#134 ASC NULLS FIRST], false, 0
 
-(780) Scan parquet
+(777) Scan parquet
 Output [1]: [ib_income_band_sk#147]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(ib_income_band_sk)]
 ReadSchema: struct<ib_income_band_sk:int>
 
-(781) Filter
+(778) Filter
 Input [1]: [ib_income_band_sk#147]
 Condition : isnotnull(ib_income_band_sk#147)
 
-(782) Exchange
+(779) Exchange
 Input [1]: [ib_income_band_sk#147]
 Arguments: hashpartitioning(ib_income_band_sk#147, 100), ENSURE_REQUIREMENTS, [plan_id=118]
 
-(783) Sort
+(780) Sort
 Input [1]: [ib_income_band_sk#147]
 Arguments: [ib_income_band_sk#147 ASC NULLS FIRST], false, 0
 
-(784) SortMergeJoin
+(781) SortMergeJoin
 Left keys [1]: [hd_income_band_sk#134]
 Right keys [1]: [ib_income_band_sk#147]
 Join type: Inner
 Join condition: None
 
-(785) Project
+(782) Project
 Output [18]: [ss_item_sk#103, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, d_year#125, d_year#127, hd_income_band_sk#136, ca_street_number#138, ca_street_name#139, ca_city#140, ca_zip#141, ca_street_number#143, ca_street_name#144, ca_city#145, ca_zip#146]
 Input [20]: [ss_item_sk#103, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, d_year#125, d_year#127, hd_income_band_sk#134, hd_income_band_sk#136, ca_street_number#138, ca_street_name#139, ca_city#140, ca_zip#141, ca_street_number#143, ca_street_name#144, ca_city#145, ca_zip#146, ib_income_band_sk#147]
 
-(786) Exchange
+(783) Exchange
 Input [18]: [ss_item_sk#103, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, d_year#125, d_year#127, hd_income_band_sk#136, ca_street_number#138, ca_street_name#139, ca_city#140, ca_zip#141, ca_street_number#143, ca_street_name#144, ca_city#145, ca_zip#146]
 Arguments: hashpartitioning(hd_income_band_sk#136, 100), ENSURE_REQUIREMENTS, [plan_id=119]
 
-(787) Sort
+(784) Sort
 Input [18]: [ss_item_sk#103, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, d_year#125, d_year#127, hd_income_band_sk#136, ca_street_number#138, ca_street_name#139, ca_city#140, ca_zip#141, ca_street_number#143, ca_street_name#144, ca_city#145, ca_zip#146]
 Arguments: [hd_income_band_sk#136 ASC NULLS FIRST], false, 0
 
-(788) Scan parquet
+(785) Scan parquet
 Output [1]: [ib_income_band_sk#148]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(ib_income_band_sk)]
 ReadSchema: struct<ib_income_band_sk:int>
 
-(789) Filter
+(786) Filter
 Input [1]: [ib_income_band_sk#148]
 Condition : isnotnull(ib_income_band_sk#148)
 
-(790) Exchange
+(787) Exchange
 Input [1]: [ib_income_band_sk#148]
 Arguments: hashpartitioning(ib_income_band_sk#148, 100), ENSURE_REQUIREMENTS, [plan_id=120]
 
-(791) Sort
+(788) Sort
 Input [1]: [ib_income_band_sk#148]
 Arguments: [ib_income_band_sk#148 ASC NULLS FIRST], false, 0
 
-(792) SortMergeJoin
+(789) SortMergeJoin
 Left keys [1]: [hd_income_band_sk#136]
 Right keys [1]: [ib_income_band_sk#148]
 Join type: Inner
 Join condition: None
 
-(793) Project
+(790) Project
 Output [17]: [ss_item_sk#103, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, d_year#125, d_year#127, ca_street_number#138, ca_street_name#139, ca_city#140, ca_zip#141, ca_street_number#143, ca_street_name#144, ca_city#145, ca_zip#146]
 Input [19]: [ss_item_sk#103, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, d_year#125, d_year#127, hd_income_band_sk#136, ca_street_number#138, ca_street_name#139, ca_city#140, ca_zip#141, ca_street_number#143, ca_street_name#144, ca_city#145, ca_zip#146, ib_income_band_sk#148]
 
-(794) Exchange
+(791) Exchange
 Input [17]: [ss_item_sk#103, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, d_year#125, d_year#127, ca_street_number#138, ca_street_name#139, ca_city#140, ca_zip#141, ca_street_number#143, ca_street_name#144, ca_city#145, ca_zip#146]
 Arguments: hashpartitioning(ss_item_sk#103, 100), ENSURE_REQUIREMENTS, [plan_id=121]
 
-(795) Sort
+(792) Sort
 Input [17]: [ss_item_sk#103, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, d_year#125, d_year#127, ca_street_number#138, ca_street_name#139, ca_city#140, ca_zip#141, ca_street_number#143, ca_street_name#144, ca_city#145, ca_zip#146]
 Arguments: [ss_item_sk#103 ASC NULLS FIRST], false, 0
 
-(796) Scan parquet
+(793) Scan parquet
 Output [4]: [i_item_sk#149, i_current_price#189, i_color#190, i_product_name#150]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(i_current_price), In(i_color, [burlywood,floral,indian,medium,purple,spring]), GreaterThanOrEqual(i_current_price,64.00), LessThanOrEqual(i_current_price,74.00), GreaterThanOrEqual(i_current_price,65.00), LessThanOrEqual(i_current_price,79.00), IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_current_price:decimal(7,2),i_color:string,i_product_name:string>
 
-(797) Filter
+(794) Filter
 Input [4]: [i_item_sk#149, i_current_price#189, i_color#190, i_product_name#150]
 Condition : ((((((isnotnull(i_current_price#189) AND i_color#190 IN (purple,burlywood,indian,spring,floral,medium)) AND (i_current_price#189 >= 64.00)) AND (i_current_price#189 <= 74.00)) AND (i_current_price#189 >= 65.00)) AND (i_current_price#189 <= 79.00)) AND isnotnull(i_item_sk#149))
 
-(798) Project
+(795) Project
 Output [2]: [i_item_sk#149, i_product_name#150]
 Input [4]: [i_item_sk#149, i_current_price#189, i_color#190, i_product_name#150]
 
-(799) Exchange
+(796) Exchange
 Input [2]: [i_item_sk#149, i_product_name#150]
 Arguments: hashpartitioning(i_item_sk#149, 100), ENSURE_REQUIREMENTS, [plan_id=122]
 
-(800) Sort
+(797) Sort
 Input [2]: [i_item_sk#149, i_product_name#150]
 Arguments: [i_item_sk#149 ASC NULLS FIRST], false, 0
 
-(801) SortMergeJoin
+(798) SortMergeJoin
 Left keys [1]: [ss_item_sk#103]
 Right keys [1]: [i_item_sk#149]
 Join type: Inner
 Join condition: None
 
-(802) Project
+(799) Project
 Output [18]: [ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, d_year#125, d_year#127, s_store_name#116, s_zip#117, ca_street_number#138, ca_street_name#139, ca_city#140, ca_zip#141, ca_street_number#143, ca_street_name#144, ca_city#145, ca_zip#146, i_item_sk#149, i_product_name#150]
 Input [19]: [ss_item_sk#103, ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, s_store_name#116, s_zip#117, d_year#125, d_year#127, ca_street_number#138, ca_street_name#139, ca_city#140, ca_zip#141, ca_street_number#143, ca_street_name#144, ca_city#145, ca_zip#146, i_item_sk#149, i_product_name#150]
 
-(803) HashAggregate
+(800) HashAggregate
 Input [18]: [ss_wholesale_cost#110, ss_list_price#111, ss_coupon_amt#112, d_year#114, d_year#125, d_year#127, s_store_name#116, s_zip#117, ca_street_number#138, ca_street_name#139, ca_city#140, ca_zip#141, ca_street_number#143, ca_street_name#144, ca_city#145, ca_zip#146, i_item_sk#149, i_product_name#150]
 Keys [15]: [i_product_name#150, i_item_sk#149, s_store_name#116, s_zip#117, ca_street_number#138, ca_street_name#139, ca_city#140, ca_zip#141, ca_street_number#143, ca_street_name#144, ca_city#145, ca_zip#146, d_year#114, d_year#125, d_year#127]
 Functions [4]: [partial_count(1), partial_sum(UnscaledValue(ss_wholesale_cost#110)), partial_sum(UnscaledValue(ss_list_price#111)), partial_sum(UnscaledValue(ss_coupon_amt#112))]
 Aggregate Attributes [4]: [count#77, sum#154, sum#155, sum#156]
 Results [19]: [i_product_name#150, i_item_sk#149, s_store_name#116, s_zip#117, ca_street_number#138, ca_street_name#139, ca_city#140, ca_zip#141, ca_street_number#143, ca_street_name#144, ca_city#145, ca_zip#146, d_year#114, d_year#125, d_year#127, count#168, sum#191, sum#192, sum#193]
 
-(804) HashAggregate
+(801) HashAggregate
 Input [19]: [i_product_name#150, i_item_sk#149, s_store_name#116, s_zip#117, ca_street_number#138, ca_street_name#139, ca_city#140, ca_zip#141, ca_street_number#143, ca_street_name#144, ca_city#145, ca_zip#146, d_year#114, d_year#125, d_year#127, count#168, sum#191, sum#192, sum#193]
 Keys [15]: [i_product_name#150, i_item_sk#149, s_store_name#116, s_zip#117, ca_street_number#138, ca_street_name#139, ca_city#140, ca_zip#141, ca_street_number#143, ca_street_name#144, ca_city#145, ca_zip#146, d_year#114, d_year#125, d_year#127]
 Functions [4]: [count(1), sum(UnscaledValue(ss_wholesale_cost#110)), sum(UnscaledValue(ss_list_price#111)), sum(UnscaledValue(ss_coupon_amt#112))]
 Aggregate Attributes [4]: [count(1)#81, sum(UnscaledValue(ss_wholesale_cost#110))#82, sum(UnscaledValue(ss_list_price#111))#83, sum(UnscaledValue(ss_coupon_amt#112))#84]
 Results [8]: [i_item_sk#149 AS item_sk#157, s_store_name#116 AS store_name#158, s_zip#117 AS store_zip#159, d_year#114 AS syear#160, count(1)#81 AS cnt#161, MakeDecimal(sum(UnscaledValue(ss_wholesale_cost#110))#82,17,2) AS s1#162, MakeDecimal(sum(UnscaledValue(ss_list_price#111))#83,17,2) AS s2#163, MakeDecimal(sum(UnscaledValue(ss_coupon_amt#112))#84,17,2) AS s3#164]
 
-(805) Exchange
+(802) Exchange
 Input [8]: [item_sk#157, store_name#158, store_zip#159, syear#160, cnt#161, s1#162, s2#163, s3#164]
 Arguments: hashpartitioning(item_sk#157, store_name#158, store_zip#159, 100), ENSURE_REQUIREMENTS, [plan_id=123]
 
-(806) Sort
+(803) Sort
 Input [8]: [item_sk#157, store_name#158, store_zip#159, syear#160, cnt#161, s1#162, s2#163, s3#164]
 Arguments: [item_sk#157 ASC NULLS FIRST, store_name#158 ASC NULLS FIRST, store_zip#159 ASC NULLS FIRST], false, 0
 
-(807) SortMergeJoin
+(804) SortMergeJoin
 Left keys [3]: [item_sk#86, store_name#87, store_zip#88]
 Right keys [3]: [item_sk#157, store_name#158, store_zip#159]
 Join type: Inner
 Join condition: (cnt#161 <= cnt#98)
 
-(808) Project
+(805) Project
 Output [21]: [product_name#85, store_name#87, store_zip#88, b_street_number#89, b_streen_name#90, b_city#91, b_zip#92, c_street_number#93, c_street_name#94, c_city#95, c_zip#96, syear#97, cnt#98, s1#99, s2#100, s3#101, s1#162, s2#163, s3#164, syear#160, cnt#161]
 Input [25]: [product_name#85, item_sk#86, store_name#87, store_zip#88, b_street_number#89, b_streen_name#90, b_city#91, b_zip#92, c_street_number#93, c_street_name#94, c_city#95, c_zip#96, syear#97, cnt#98, s1#99, s2#100, s3#101, item_sk#157, store_name#158, store_zip#159, syear#160, cnt#161, s1#162, s2#163, s3#164]
 
-(809) Exchange
+(806) Exchange
 Input [21]: [product_name#85, store_name#87, store_zip#88, b_street_number#89, b_streen_name#90, b_city#91, b_zip#92, c_street_number#93, c_street_name#94, c_city#95, c_zip#96, syear#97, cnt#98, s1#99, s2#100, s3#101, s1#162, s2#163, s3#164, syear#160, cnt#161]
 Arguments: rangepartitioning(product_name#85 ASC NULLS FIRST, store_name#87 ASC NULLS FIRST, cnt#161 ASC NULLS FIRST, s1#99 ASC NULLS FIRST, s1#162 ASC NULLS FIRST, 100), ENSURE_REQUIREMENTS, [plan_id=124]
 
-(810) Sort
+(807) Sort
 Input [21]: [product_name#85, store_name#87, store_zip#88, b_street_number#89, b_streen_name#90, b_city#91, b_zip#92, c_street_number#93, c_street_name#94, c_city#95, c_zip#96, syear#97, cnt#98, s1#99, s2#100, s3#101, s1#162, s2#163, s3#164, syear#160, cnt#161]
 Arguments: [product_name#85 ASC NULLS FIRST, store_name#87 ASC NULLS FIRST, cnt#161 ASC NULLS FIRST, s1#99 ASC NULLS FIRST, s1#162 ASC NULLS FIRST], true, 0
 
-(811) AdaptiveSparkPlan
+(808) AdaptiveSparkPlan
 Output [21]: [product_name#85, store_name#87, store_zip#88, b_street_number#89, b_streen_name#90, b_city#91, b_zip#92, c_street_number#93, c_street_name#94, c_city#95, c_zip#96, syear#97, cnt#98, s1#99, s2#100, s3#101, s1#162, s2#163, s3#164, syear#160, cnt#161]
 Arguments: isFinalPlan=true
 

--- a/dev/auron-it/src/main/resources/tpcds-plan-stability/spark-3.5/q65.txt
+++ b/dev/auron-it/src/main/resources/tpcds-plan-stability/spark-3.5/q65.txt
@@ -1,9 +1,9 @@
 == Physical Plan ==
 AdaptiveSparkPlan (155)
 +- == Final Plan ==
-   TakeOrderedAndProject (99)
-   +- * Project (98)
-      +- * SortMergeJoin Inner (97)
+   NativeTakeOrdered (99)
+   +- NativeProject (98)
+      +- NativeSortMergeJoin Inner (97)
          :- NativeSort (63)
          :  +- InputAdapter (62)
          :     +- AQEShuffleRead (61)
@@ -570,19 +570,19 @@ Condition : isnotnull(ave#32)
 Input [2]: [ss_store_sk#21, ave#32]
 Arguments: [ss_store_sk#21 ASC NULLS FIRST], false
 
-(97) SortMergeJoin [codegen id : X]
+(97) NativeSortMergeJoin
 Left keys [1]: [ss_store_sk#5]
 Right keys [1]: [ss_store_sk#21]
 Join type: Inner
 Join condition: (cast(revenue#13 as decimal(23,7)) <= (0.1 * ave#32))
 
-(98) Project [codegen id : X]
+(98) NativeProject
 Output [6]: [s_store_name#2, i_item_desc#15, revenue#13, i_current_price#16, i_wholesale_cost#17, i_brand#18]
 Input [9]: [s_store_name#2, ss_store_sk#5, revenue#13, i_item_desc#15, i_current_price#16, i_wholesale_cost#17, i_brand#18, ss_store_sk#21, ave#32]
 
-(99) TakeOrderedAndProject
+(99) NativeTakeOrdered
 Input [6]: [s_store_name#2, i_item_desc#15, revenue#13, i_current_price#16, i_wholesale_cost#17, i_brand#18]
-Arguments: X, [s_store_name#2 ASC NULLS FIRST, i_item_desc#15 ASC NULLS FIRST], [s_store_name#2, i_item_desc#15, revenue#13, i_current_price#16, i_wholesale_cost#17, i_brand#18]
+Arguments: X, X, [s_store_name#2 ASC NULLS FIRST, i_item_desc#15 ASC NULLS FIRST]
 
 (100) Scan parquet
 Output [2]: [s_store_sk#1, s_store_name#2]

--- a/dev/auron-it/src/main/resources/tpcds-plan-stability/spark-3.5/q68.txt
+++ b/dev/auron-it/src/main/resources/tpcds-plan-stability/spark-3.5/q68.txt
@@ -1,9 +1,9 @@
 == Physical Plan ==
 AdaptiveSparkPlan (156)
 +- == Final Plan ==
-   TakeOrderedAndProject (99)
-   +- * Project (98)
-      +- * SortMergeJoin Inner (97)
+   NativeTakeOrdered (99)
+   +- NativeProject (98)
+      +- NativeSortMergeJoin Inner (97)
          :- NativeSort (90)
          :  +- InputAdapter (89)
          :     +- AQEShuffleRead (88)
@@ -564,19 +564,19 @@ Input [2]: [#38#38, #39#39]
 Input [2]: [#38#38, #39#39]
 Arguments: [ca_address_sk#38 ASC NULLS FIRST], false
 
-(97) SortMergeJoin [codegen id : X]
+(97) NativeSortMergeJoin
 Left keys [1]: [c_current_addr_sk#35]
 Right keys [1]: [ca_address_sk#38]
 Join type: Inner
 Join condition: NOT (ca_city#39 = bought_city#30)
 
-(98) Project [codegen id : X]
+(98) NativeProject
 Output [8]: [c_last_name#37, c_first_name#36, ca_city#39, bought_city#30, ss_ticket_number#6, extended_price#31, extended_tax#33, list_price#32]
 Input [10]: [ss_ticket_number#6, bought_city#30, extended_price#31, list_price#32, extended_tax#33, c_current_addr_sk#35, c_first_name#36, c_last_name#37, #38#38, #39#39]
 
-(99) TakeOrderedAndProject
+(99) NativeTakeOrdered
 Input [8]: [c_last_name#37, c_first_name#36, ca_city#39, bought_city#30, ss_ticket_number#6, extended_price#31, extended_tax#33, list_price#32]
-Arguments: X, [c_last_name#37 ASC NULLS FIRST, ss_ticket_number#6 ASC NULLS FIRST], [c_last_name#37, c_first_name#36, ca_city#39, bought_city#30, ss_ticket_number#6, extended_price#31, extended_tax#33, list_price#32]
+Arguments: X, X, [c_last_name#37 ASC NULLS FIRST, ss_ticket_number#6 ASC NULLS FIRST]
 
 (100) Scan parquet
 Output [9]: [ss_sold_date_sk#1, ss_customer_sk#2, ss_hdemo_sk#3, ss_addr_sk#4, ss_store_sk#5, ss_ticket_number#6, ss_ext_sales_price#7, ss_ext_list_price#8, ss_ext_tax#9]

--- a/dev/auron-it/src/main/resources/tpcds-plan-stability/spark-3.5/q72.txt
+++ b/dev/auron-it/src/main/resources/tpcds-plan-stability/spark-3.5/q72.txt
@@ -1,265 +1,263 @@
 == Physical Plan ==
-AdaptiveSparkPlan (256)
+AdaptiveSparkPlan (254)
 +- == Final Plan ==
-   NativeTakeOrdered (166)
-   +- NativeProject (165)
-      +- NativeHashAggregate (164)
-         +- InputAdapter (163)
-            +- AQEShuffleRead (162)
-               +- ShuffleQueryStage (161), Statistics(X)
-                  +- NativeShuffleExchange (160)
-                     +- NativeHashAggregate (159)
-                        +- NativeProject (158)
-                           +- NativeSortMergeJoin LeftOuter (157)
-                              :- NativeSort (148)
-                              :  +- InputAdapter (147)
-                              :     +- AQEShuffleRead (146)
-                              :        +- ShuffleQueryStage (145), Statistics(X)
-                              :           +- NativeShuffleExchange (144)
-                              :              +- NativeProject (143)
-                              :                 +- NativeSortMergeJoin LeftOuter (142)
-                              :                    :- NativeSort (133)
-                              :                    :  +- InputAdapter (132)
-                              :                    :     +- AQEShuffleRead (131)
-                              :                    :        +- ShuffleQueryStage (130), Statistics(X)
-                              :                    :           +- NativeShuffleExchange (129)
-                              :                    :              +- ConvertToNative (128)
-                              :                    :                 +- * Project (127)
-                              :                    :                    +- * SortMergeJoin Inner (126)
-                              :                    :                       :- NativeSort (117)
-                              :                    :                       :  +- InputAdapter (116)
-                              :                    :                       :     +- AQEShuffleRead (115)
-                              :                    :                       :        +- ShuffleQueryStage (114), Statistics(X)
-                              :                    :                       :           +- NativeShuffleExchange (113)
-                              :                    :                       :              +- NativeProject (112)
-                              :                    :                       :                 +- NativeSortMergeJoin Inner (111)
-                              :                    :                       :                    :- NativeSort (102)
-                              :                    :                       :                    :  +- InputAdapter (101)
-                              :                    :                       :                    :     +- AQEShuffleRead (100)
-                              :                    :                       :                    :        +- ShuffleQueryStage (99), Statistics(X)
-                              :                    :                       :                    :           +- NativeShuffleExchange (98)
-                              :                    :                       :                    :              +- NativeProject (97)
-                              :                    :                       :                    :                 +- NativeSortMergeJoin Inner (96)
-                              :                    :                       :                    :                    :- NativeSort (86)
-                              :                    :                       :                    :                    :  +- InputAdapter (85)
-                              :                    :                       :                    :                    :     +- AQEShuffleRead (84)
-                              :                    :                       :                    :                    :        +- ShuffleQueryStage (83), Statistics(X)
-                              :                    :                       :                    :                    :           +- NativeShuffleExchange (82)
-                              :                    :                       :                    :                    :              +- NativeProject (81)
-                              :                    :                       :                    :                    :                 +- NativeSortMergeJoin Inner (80)
-                              :                    :                       :                    :                    :                    :- NativeSort (70)
-                              :                    :                       :                    :                    :                    :  +- InputAdapter (69)
-                              :                    :                       :                    :                    :                    :     +- AQEShuffleRead (68)
-                              :                    :                       :                    :                    :                    :        +- ShuffleQueryStage (67), Statistics(X)
-                              :                    :                       :                    :                    :                    :           +- NativeShuffleExchange (66)
-                              :                    :                       :                    :                    :                    :              +- NativeProject (65)
-                              :                    :                       :                    :                    :                    :                 +- NativeSortMergeJoin Inner (64)
-                              :                    :                       :                    :                    :                    :                    :- NativeSort (54)
-                              :                    :                       :                    :                    :                    :                    :  +- InputAdapter (53)
-                              :                    :                       :                    :                    :                    :                    :     +- AQEShuffleRead (52)
-                              :                    :                       :                    :                    :                    :                    :        +- ShuffleQueryStage (51), Statistics(X)
-                              :                    :                       :                    :                    :                    :                    :           +- NativeShuffleExchange (50)
-                              :                    :                       :                    :                    :                    :                    :              +- NativeProject (49)
-                              :                    :                       :                    :                    :                    :                    :                 +- NativeSortMergeJoin Inner (48)
-                              :                    :                       :                    :                    :                    :                    :                    :- NativeSort (39)
-                              :                    :                       :                    :                    :                    :                    :                    :  +- InputAdapter (38)
-                              :                    :                       :                    :                    :                    :                    :                    :     +- AQEShuffleRead (37)
-                              :                    :                       :                    :                    :                    :                    :                    :        +- ShuffleQueryStage (36), Statistics(X)
-                              :                    :                       :                    :                    :                    :                    :                    :           +- NativeShuffleExchange (35)
-                              :                    :                       :                    :                    :                    :                    :                    :              +- NativeProject (34)
-                              :                    :                       :                    :                    :                    :                    :                    :                 +- NativeSortMergeJoin Inner (33)
-                              :                    :                       :                    :                    :                    :                    :                    :                    :- NativeSort (24)
-                              :                    :                       :                    :                    :                    :                    :                    :                    :  +- InputAdapter (23)
-                              :                    :                       :                    :                    :                    :                    :                    :                    :     +- AQEShuffleRead (22)
-                              :                    :                       :                    :                    :                    :                    :                    :                    :        +- ShuffleQueryStage (21), Statistics(X)
-                              :                    :                       :                    :                    :                    :                    :                    :                    :           +- NativeShuffleExchange (20)
-                              :                    :                       :                    :                    :                    :                    :                    :                    :              +- ConvertToNative (19)
-                              :                    :                       :                    :                    :                    :                    :                    :                    :                 +- * Project (18)
-                              :                    :                       :                    :                    :                    :                    :                    :                    :                    +- * SortMergeJoin Inner (17)
-                              :                    :                       :                    :                    :                    :                    :                    :                    :                       :- NativeSort (8)
-                              :                    :                       :                    :                    :                    :                    :                    :                    :                       :  +- InputAdapter (7)
-                              :                    :                       :                    :                    :                    :                    :                    :                    :                       :     +- AQEShuffleRead (6)
-                              :                    :                       :                    :                    :                    :                    :                    :                    :                       :        +- ShuffleQueryStage (5), Statistics(X)
-                              :                    :                       :                    :                    :                    :                    :                    :                    :                       :           +- NativeShuffleExchange (4)
-                              :                    :                       :                    :                    :                    :                    :                    :                    :                       :              +- NativeFilter (3)
-                              :                    :                       :                    :                    :                    :                    :                    :                    :                       :                 +- InputAdapter (2)
-                              :                    :                       :                    :                    :                    :                    :                    :                    :                       :                    +- NativeParquetScan  (1)
-                              :                    :                       :                    :                    :                    :                    :                    :                    :                       +- NativeSort (16)
-                              :                    :                       :                    :                    :                    :                    :                    :                    :                          +- InputAdapter (15)
-                              :                    :                       :                    :                    :                    :                    :                    :                    :                             +- AQEShuffleRead (14)
-                              :                    :                       :                    :                    :                    :                    :                    :                    :                                +- ShuffleQueryStage (13), Statistics(X)
-                              :                    :                       :                    :                    :                    :                    :                    :                    :                                   +- NativeShuffleExchange (12)
-                              :                    :                       :                    :                    :                    :                    :                    :                    :                                      +- NativeFilter (11)
-                              :                    :                       :                    :                    :                    :                    :                    :                    :                                         +- InputAdapter (10)
-                              :                    :                       :                    :                    :                    :                    :                    :                    :                                            +- NativeParquetScan  (9)
-                              :                    :                       :                    :                    :                    :                    :                    :                    +- NativeSort (32)
-                              :                    :                       :                    :                    :                    :                    :                    :                       +- InputAdapter (31)
-                              :                    :                       :                    :                    :                    :                    :                    :                          +- AQEShuffleRead (30)
-                              :                    :                       :                    :                    :                    :                    :                    :                             +- ShuffleQueryStage (29), Statistics(X)
-                              :                    :                       :                    :                    :                    :                    :                    :                                +- NativeShuffleExchange (28)
-                              :                    :                       :                    :                    :                    :                    :                    :                                   +- NativeFilter (27)
-                              :                    :                       :                    :                    :                    :                    :                    :                                      +- InputAdapter (26)
-                              :                    :                       :                    :                    :                    :                    :                    :                                         +- NativeParquetScan  (25)
-                              :                    :                       :                    :                    :                    :                    :                    +- NativeSort (47)
-                              :                    :                       :                    :                    :                    :                    :                       +- InputAdapter (46)
-                              :                    :                       :                    :                    :                    :                    :                          +- AQEShuffleRead (45)
-                              :                    :                       :                    :                    :                    :                    :                             +- ShuffleQueryStage (44), Statistics(X)
-                              :                    :                       :                    :                    :                    :                    :                                +- NativeShuffleExchange (43)
-                              :                    :                       :                    :                    :                    :                    :                                   +- NativeFilter (42)
-                              :                    :                       :                    :                    :                    :                    :                                      +- InputAdapter (41)
-                              :                    :                       :                    :                    :                    :                    :                                         +- NativeParquetScan  (40)
-                              :                    :                       :                    :                    :                    :                    +- NativeSort (63)
-                              :                    :                       :                    :                    :                    :                       +- InputAdapter (62)
-                              :                    :                       :                    :                    :                    :                          +- AQEShuffleRead (61)
-                              :                    :                       :                    :                    :                    :                             +- ShuffleQueryStage (60), Statistics(X)
-                              :                    :                       :                    :                    :                    :                                +- NativeShuffleExchange (59)
-                              :                    :                       :                    :                    :                    :                                   +- NativeProject (58)
-                              :                    :                       :                    :                    :                    :                                      +- NativeFilter (57)
-                              :                    :                       :                    :                    :                    :                                         +- InputAdapter (56)
-                              :                    :                       :                    :                    :                    :                                            +- NativeParquetScan  (55)
-                              :                    :                       :                    :                    :                    +- NativeSort (79)
-                              :                    :                       :                    :                    :                       +- InputAdapter (78)
-                              :                    :                       :                    :                    :                          +- AQEShuffleRead (77)
-                              :                    :                       :                    :                    :                             +- ShuffleQueryStage (76), Statistics(X)
-                              :                    :                       :                    :                    :                                +- NativeShuffleExchange (75)
-                              :                    :                       :                    :                    :                                   +- NativeProject (74)
-                              :                    :                       :                    :                    :                                      +- NativeFilter (73)
-                              :                    :                       :                    :                    :                                         +- InputAdapter (72)
-                              :                    :                       :                    :                    :                                            +- NativeParquetScan  (71)
-                              :                    :                       :                    :                    +- NativeSort (95)
-                              :                    :                       :                    :                       +- InputAdapter (94)
-                              :                    :                       :                    :                          +- AQEShuffleRead (93)
-                              :                    :                       :                    :                             +- ShuffleQueryStage (92), Statistics(X)
-                              :                    :                       :                    :                                +- NativeShuffleExchange (91)
-                              :                    :                       :                    :                                   +- NativeProject (90)
-                              :                    :                       :                    :                                      +- NativeFilter (89)
-                              :                    :                       :                    :                                         +- InputAdapter (88)
-                              :                    :                       :                    :                                            +- NativeParquetScan  (87)
-                              :                    :                       :                    +- NativeSort (110)
-                              :                    :                       :                       +- InputAdapter (109)
-                              :                    :                       :                          +- AQEShuffleRead (108)
-                              :                    :                       :                             +- ShuffleQueryStage (107), Statistics(X)
-                              :                    :                       :                                +- NativeShuffleExchange (106)
-                              :                    :                       :                                   +- NativeFilter (105)
-                              :                    :                       :                                      +- InputAdapter (104)
-                              :                    :                       :                                         +- NativeParquetScan  (103)
-                              :                    :                       +- NativeSort (125)
-                              :                    :                          +- InputAdapter (124)
-                              :                    :                             +- AQEShuffleRead (123)
-                              :                    :                                +- ShuffleQueryStage (122), Statistics(X)
-                              :                    :                                   +- NativeShuffleExchange (121)
-                              :                    :                                      +- NativeFilter (120)
-                              :                    :                                         +- InputAdapter (119)
-                              :                    :                                            +- NativeParquetScan  (118)
-                              :                    +- NativeSort (141)
-                              :                       +- InputAdapter (140)
-                              :                          +- AQEShuffleRead (139)
-                              :                             +- ShuffleQueryStage (138), Statistics(X)
-                              :                                +- NativeShuffleExchange (137)
-                              :                                   +- NativeFilter (136)
-                              :                                      +- InputAdapter (135)
-                              :                                         +- NativeParquetScan  (134)
-                              +- NativeSort (156)
-                                 +- InputAdapter (155)
-                                    +- AQEShuffleRead (154)
-                                       +- ShuffleQueryStage (153), Statistics(X)
-                                          +- NativeShuffleExchange (152)
-                                             +- NativeFilter (151)
-                                                +- InputAdapter (150)
-                                                   +- NativeParquetScan  (149)
+   NativeTakeOrdered (164)
+   +- NativeProject (163)
+      +- NativeHashAggregate (162)
+         +- InputAdapter (161)
+            +- AQEShuffleRead (160)
+               +- ShuffleQueryStage (159), Statistics(X)
+                  +- NativeShuffleExchange (158)
+                     +- NativeHashAggregate (157)
+                        +- NativeProject (156)
+                           +- NativeSortMergeJoin LeftOuter (155)
+                              :- NativeSort (146)
+                              :  +- InputAdapter (145)
+                              :     +- AQEShuffleRead (144)
+                              :        +- ShuffleQueryStage (143), Statistics(X)
+                              :           +- NativeShuffleExchange (142)
+                              :              +- NativeProject (141)
+                              :                 +- NativeSortMergeJoin LeftOuter (140)
+                              :                    :- NativeSort (131)
+                              :                    :  +- InputAdapter (130)
+                              :                    :     +- AQEShuffleRead (129)
+                              :                    :        +- ShuffleQueryStage (128), Statistics(X)
+                              :                    :           +- NativeShuffleExchange (127)
+                              :                    :              +- NativeProject (126)
+                              :                    :                 +- NativeSortMergeJoin Inner (125)
+                              :                    :                    :- NativeSort (116)
+                              :                    :                    :  +- InputAdapter (115)
+                              :                    :                    :     +- AQEShuffleRead (114)
+                              :                    :                    :        +- ShuffleQueryStage (113), Statistics(X)
+                              :                    :                    :           +- NativeShuffleExchange (112)
+                              :                    :                    :              +- NativeProject (111)
+                              :                    :                    :                 +- NativeSortMergeJoin Inner (110)
+                              :                    :                    :                    :- NativeSort (101)
+                              :                    :                    :                    :  +- InputAdapter (100)
+                              :                    :                    :                    :     +- AQEShuffleRead (99)
+                              :                    :                    :                    :        +- ShuffleQueryStage (98), Statistics(X)
+                              :                    :                    :                    :           +- NativeShuffleExchange (97)
+                              :                    :                    :                    :              +- NativeProject (96)
+                              :                    :                    :                    :                 +- NativeSortMergeJoin Inner (95)
+                              :                    :                    :                    :                    :- NativeSort (85)
+                              :                    :                    :                    :                    :  +- InputAdapter (84)
+                              :                    :                    :                    :                    :     +- AQEShuffleRead (83)
+                              :                    :                    :                    :                    :        +- ShuffleQueryStage (82), Statistics(X)
+                              :                    :                    :                    :                    :           +- NativeShuffleExchange (81)
+                              :                    :                    :                    :                    :              +- NativeProject (80)
+                              :                    :                    :                    :                    :                 +- NativeSortMergeJoin Inner (79)
+                              :                    :                    :                    :                    :                    :- NativeSort (69)
+                              :                    :                    :                    :                    :                    :  +- InputAdapter (68)
+                              :                    :                    :                    :                    :                    :     +- AQEShuffleRead (67)
+                              :                    :                    :                    :                    :                    :        +- ShuffleQueryStage (66), Statistics(X)
+                              :                    :                    :                    :                    :                    :           +- NativeShuffleExchange (65)
+                              :                    :                    :                    :                    :                    :              +- NativeProject (64)
+                              :                    :                    :                    :                    :                    :                 +- NativeSortMergeJoin Inner (63)
+                              :                    :                    :                    :                    :                    :                    :- NativeSort (53)
+                              :                    :                    :                    :                    :                    :                    :  +- InputAdapter (52)
+                              :                    :                    :                    :                    :                    :                    :     +- AQEShuffleRead (51)
+                              :                    :                    :                    :                    :                    :                    :        +- ShuffleQueryStage (50), Statistics(X)
+                              :                    :                    :                    :                    :                    :                    :           +- NativeShuffleExchange (49)
+                              :                    :                    :                    :                    :                    :                    :              +- NativeProject (48)
+                              :                    :                    :                    :                    :                    :                    :                 +- NativeSortMergeJoin Inner (47)
+                              :                    :                    :                    :                    :                    :                    :                    :- NativeSort (38)
+                              :                    :                    :                    :                    :                    :                    :                    :  +- InputAdapter (37)
+                              :                    :                    :                    :                    :                    :                    :                    :     +- AQEShuffleRead (36)
+                              :                    :                    :                    :                    :                    :                    :                    :        +- ShuffleQueryStage (35), Statistics(X)
+                              :                    :                    :                    :                    :                    :                    :                    :           +- NativeShuffleExchange (34)
+                              :                    :                    :                    :                    :                    :                    :                    :              +- NativeProject (33)
+                              :                    :                    :                    :                    :                    :                    :                    :                 +- NativeSortMergeJoin Inner (32)
+                              :                    :                    :                    :                    :                    :                    :                    :                    :- NativeSort (23)
+                              :                    :                    :                    :                    :                    :                    :                    :                    :  +- InputAdapter (22)
+                              :                    :                    :                    :                    :                    :                    :                    :                    :     +- AQEShuffleRead (21)
+                              :                    :                    :                    :                    :                    :                    :                    :                    :        +- ShuffleQueryStage (20), Statistics(X)
+                              :                    :                    :                    :                    :                    :                    :                    :                    :           +- NativeShuffleExchange (19)
+                              :                    :                    :                    :                    :                    :                    :                    :                    :              +- NativeProject (18)
+                              :                    :                    :                    :                    :                    :                    :                    :                    :                 +- NativeSortMergeJoin Inner (17)
+                              :                    :                    :                    :                    :                    :                    :                    :                    :                    :- NativeSort (8)
+                              :                    :                    :                    :                    :                    :                    :                    :                    :                    :  +- InputAdapter (7)
+                              :                    :                    :                    :                    :                    :                    :                    :                    :                    :     +- AQEShuffleRead (6)
+                              :                    :                    :                    :                    :                    :                    :                    :                    :                    :        +- ShuffleQueryStage (5), Statistics(X)
+                              :                    :                    :                    :                    :                    :                    :                    :                    :                    :           +- NativeShuffleExchange (4)
+                              :                    :                    :                    :                    :                    :                    :                    :                    :                    :              +- NativeFilter (3)
+                              :                    :                    :                    :                    :                    :                    :                    :                    :                    :                 +- InputAdapter (2)
+                              :                    :                    :                    :                    :                    :                    :                    :                    :                    :                    +- NativeParquetScan  (1)
+                              :                    :                    :                    :                    :                    :                    :                    :                    :                    +- NativeSort (16)
+                              :                    :                    :                    :                    :                    :                    :                    :                    :                       +- InputAdapter (15)
+                              :                    :                    :                    :                    :                    :                    :                    :                    :                          +- AQEShuffleRead (14)
+                              :                    :                    :                    :                    :                    :                    :                    :                    :                             +- ShuffleQueryStage (13), Statistics(X)
+                              :                    :                    :                    :                    :                    :                    :                    :                    :                                +- NativeShuffleExchange (12)
+                              :                    :                    :                    :                    :                    :                    :                    :                    :                                   +- NativeFilter (11)
+                              :                    :                    :                    :                    :                    :                    :                    :                    :                                      +- InputAdapter (10)
+                              :                    :                    :                    :                    :                    :                    :                    :                    :                                         +- NativeParquetScan  (9)
+                              :                    :                    :                    :                    :                    :                    :                    :                    +- NativeSort (31)
+                              :                    :                    :                    :                    :                    :                    :                    :                       +- InputAdapter (30)
+                              :                    :                    :                    :                    :                    :                    :                    :                          +- AQEShuffleRead (29)
+                              :                    :                    :                    :                    :                    :                    :                    :                             +- ShuffleQueryStage (28), Statistics(X)
+                              :                    :                    :                    :                    :                    :                    :                    :                                +- NativeShuffleExchange (27)
+                              :                    :                    :                    :                    :                    :                    :                    :                                   +- NativeFilter (26)
+                              :                    :                    :                    :                    :                    :                    :                    :                                      +- InputAdapter (25)
+                              :                    :                    :                    :                    :                    :                    :                    :                                         +- NativeParquetScan  (24)
+                              :                    :                    :                    :                    :                    :                    :                    +- NativeSort (46)
+                              :                    :                    :                    :                    :                    :                    :                       +- InputAdapter (45)
+                              :                    :                    :                    :                    :                    :                    :                          +- AQEShuffleRead (44)
+                              :                    :                    :                    :                    :                    :                    :                             +- ShuffleQueryStage (43), Statistics(X)
+                              :                    :                    :                    :                    :                    :                    :                                +- NativeShuffleExchange (42)
+                              :                    :                    :                    :                    :                    :                    :                                   +- NativeFilter (41)
+                              :                    :                    :                    :                    :                    :                    :                                      +- InputAdapter (40)
+                              :                    :                    :                    :                    :                    :                    :                                         +- NativeParquetScan  (39)
+                              :                    :                    :                    :                    :                    :                    +- NativeSort (62)
+                              :                    :                    :                    :                    :                    :                       +- InputAdapter (61)
+                              :                    :                    :                    :                    :                    :                          +- AQEShuffleRead (60)
+                              :                    :                    :                    :                    :                    :                             +- ShuffleQueryStage (59), Statistics(X)
+                              :                    :                    :                    :                    :                    :                                +- NativeShuffleExchange (58)
+                              :                    :                    :                    :                    :                    :                                   +- NativeProject (57)
+                              :                    :                    :                    :                    :                    :                                      +- NativeFilter (56)
+                              :                    :                    :                    :                    :                    :                                         +- InputAdapter (55)
+                              :                    :                    :                    :                    :                    :                                            +- NativeParquetScan  (54)
+                              :                    :                    :                    :                    :                    +- NativeSort (78)
+                              :                    :                    :                    :                    :                       +- InputAdapter (77)
+                              :                    :                    :                    :                    :                          +- AQEShuffleRead (76)
+                              :                    :                    :                    :                    :                             +- ShuffleQueryStage (75), Statistics(X)
+                              :                    :                    :                    :                    :                                +- NativeShuffleExchange (74)
+                              :                    :                    :                    :                    :                                   +- NativeProject (73)
+                              :                    :                    :                    :                    :                                      +- NativeFilter (72)
+                              :                    :                    :                    :                    :                                         +- InputAdapter (71)
+                              :                    :                    :                    :                    :                                            +- NativeParquetScan  (70)
+                              :                    :                    :                    :                    +- NativeSort (94)
+                              :                    :                    :                    :                       +- InputAdapter (93)
+                              :                    :                    :                    :                          +- AQEShuffleRead (92)
+                              :                    :                    :                    :                             +- ShuffleQueryStage (91), Statistics(X)
+                              :                    :                    :                    :                                +- NativeShuffleExchange (90)
+                              :                    :                    :                    :                                   +- NativeProject (89)
+                              :                    :                    :                    :                                      +- NativeFilter (88)
+                              :                    :                    :                    :                                         +- InputAdapter (87)
+                              :                    :                    :                    :                                            +- NativeParquetScan  (86)
+                              :                    :                    :                    +- NativeSort (109)
+                              :                    :                    :                       +- InputAdapter (108)
+                              :                    :                    :                          +- AQEShuffleRead (107)
+                              :                    :                    :                             +- ShuffleQueryStage (106), Statistics(X)
+                              :                    :                    :                                +- NativeShuffleExchange (105)
+                              :                    :                    :                                   +- NativeFilter (104)
+                              :                    :                    :                                      +- InputAdapter (103)
+                              :                    :                    :                                         +- NativeParquetScan  (102)
+                              :                    :                    +- NativeSort (124)
+                              :                    :                       +- InputAdapter (123)
+                              :                    :                          +- AQEShuffleRead (122)
+                              :                    :                             +- ShuffleQueryStage (121), Statistics(X)
+                              :                    :                                +- NativeShuffleExchange (120)
+                              :                    :                                   +- NativeFilter (119)
+                              :                    :                                      +- InputAdapter (118)
+                              :                    :                                         +- NativeParquetScan  (117)
+                              :                    +- NativeSort (139)
+                              :                       +- InputAdapter (138)
+                              :                          +- AQEShuffleRead (137)
+                              :                             +- ShuffleQueryStage (136), Statistics(X)
+                              :                                +- NativeShuffleExchange (135)
+                              :                                   +- NativeFilter (134)
+                              :                                      +- InputAdapter (133)
+                              :                                         +- NativeParquetScan  (132)
+                              +- NativeSort (154)
+                                 +- InputAdapter (153)
+                                    +- AQEShuffleRead (152)
+                                       +- ShuffleQueryStage (151), Statistics(X)
+                                          +- NativeShuffleExchange (150)
+                                             +- NativeFilter (149)
+                                                +- InputAdapter (148)
+                                                   +- NativeParquetScan  (147)
 +- == Initial Plan ==
-   TakeOrderedAndProject (255)
-   +- HashAggregate (254)
-      +- Exchange (253)
-         +- HashAggregate (252)
-            +- Project (251)
-               +- SortMergeJoin LeftOuter (250)
-                  :- Sort (245)
-                  :  +- Exchange (244)
-                  :     +- Project (243)
-                  :        +- SortMergeJoin LeftOuter (242)
-                  :           :- Sort (237)
-                  :           :  +- Exchange (236)
-                  :           :     +- Project (235)
-                  :           :        +- SortMergeJoin Inner (234)
-                  :           :           :- Sort (229)
-                  :           :           :  +- Exchange (228)
-                  :           :           :     +- Project (227)
-                  :           :           :        +- SortMergeJoin Inner (226)
-                  :           :           :           :- Sort (221)
-                  :           :           :           :  +- Exchange (220)
-                  :           :           :           :     +- Project (219)
-                  :           :           :           :        +- SortMergeJoin Inner (218)
-                  :           :           :           :           :- Sort (212)
-                  :           :           :           :           :  +- Exchange (211)
-                  :           :           :           :           :     +- Project (210)
-                  :           :           :           :           :        +- SortMergeJoin Inner (209)
-                  :           :           :           :           :           :- Sort (203)
-                  :           :           :           :           :           :  +- Exchange (202)
-                  :           :           :           :           :           :     +- Project (201)
-                  :           :           :           :           :           :        +- SortMergeJoin Inner (200)
-                  :           :           :           :           :           :           :- Sort (194)
-                  :           :           :           :           :           :           :  +- Exchange (193)
-                  :           :           :           :           :           :           :     +- Project (192)
-                  :           :           :           :           :           :           :        +- SortMergeJoin Inner (191)
-                  :           :           :           :           :           :           :           :- Sort (186)
-                  :           :           :           :           :           :           :           :  +- Exchange (185)
-                  :           :           :           :           :           :           :           :     +- Project (184)
-                  :           :           :           :           :           :           :           :        +- SortMergeJoin Inner (183)
-                  :           :           :           :           :           :           :           :           :- Sort (178)
-                  :           :           :           :           :           :           :           :           :  +- Exchange (177)
-                  :           :           :           :           :           :           :           :           :     +- Project (176)
-                  :           :           :           :           :           :           :           :           :        +- SortMergeJoin Inner (175)
-                  :           :           :           :           :           :           :           :           :           :- Sort (170)
-                  :           :           :           :           :           :           :           :           :           :  +- Exchange (169)
-                  :           :           :           :           :           :           :           :           :           :     +- Filter (168)
-                  :           :           :           :           :           :           :           :           :           :        +- Scan parquet (167)
-                  :           :           :           :           :           :           :           :           :           +- Sort (174)
-                  :           :           :           :           :           :           :           :           :              +- Exchange (173)
-                  :           :           :           :           :           :           :           :           :                 +- Filter (172)
-                  :           :           :           :           :           :           :           :           :                    +- Scan parquet (171)
-                  :           :           :           :           :           :           :           :           +- Sort (182)
-                  :           :           :           :           :           :           :           :              +- Exchange (181)
-                  :           :           :           :           :           :           :           :                 +- Filter (180)
-                  :           :           :           :           :           :           :           :                    +- Scan parquet (179)
-                  :           :           :           :           :           :           :           +- Sort (190)
-                  :           :           :           :           :           :           :              +- Exchange (189)
-                  :           :           :           :           :           :           :                 +- Filter (188)
-                  :           :           :           :           :           :           :                    +- Scan parquet (187)
-                  :           :           :           :           :           :           +- Sort (199)
-                  :           :           :           :           :           :              +- Exchange (198)
-                  :           :           :           :           :           :                 +- Project (197)
-                  :           :           :           :           :           :                    +- Filter (196)
-                  :           :           :           :           :           :                       +- Scan parquet (195)
-                  :           :           :           :           :           +- Sort (208)
-                  :           :           :           :           :              +- Exchange (207)
-                  :           :           :           :           :                 +- Project (206)
-                  :           :           :           :           :                    +- Filter (205)
-                  :           :           :           :           :                       +- Scan parquet (204)
-                  :           :           :           :           +- Sort (217)
-                  :           :           :           :              +- Exchange (216)
-                  :           :           :           :                 +- Project (215)
-                  :           :           :           :                    +- Filter (214)
-                  :           :           :           :                       +- Scan parquet (213)
-                  :           :           :           +- Sort (225)
-                  :           :           :              +- Exchange (224)
-                  :           :           :                 +- Filter (223)
-                  :           :           :                    +- Scan parquet (222)
-                  :           :           +- Sort (233)
-                  :           :              +- Exchange (232)
-                  :           :                 +- Filter (231)
-                  :           :                    +- Scan parquet (230)
-                  :           +- Sort (241)
-                  :              +- Exchange (240)
-                  :                 +- Filter (239)
-                  :                    +- Scan parquet (238)
-                  +- Sort (249)
-                     +- Exchange (248)
-                        +- Filter (247)
-                           +- Scan parquet (246)
+   TakeOrderedAndProject (253)
+   +- HashAggregate (252)
+      +- Exchange (251)
+         +- HashAggregate (250)
+            +- Project (249)
+               +- SortMergeJoin LeftOuter (248)
+                  :- Sort (243)
+                  :  +- Exchange (242)
+                  :     +- Project (241)
+                  :        +- SortMergeJoin LeftOuter (240)
+                  :           :- Sort (235)
+                  :           :  +- Exchange (234)
+                  :           :     +- Project (233)
+                  :           :        +- SortMergeJoin Inner (232)
+                  :           :           :- Sort (227)
+                  :           :           :  +- Exchange (226)
+                  :           :           :     +- Project (225)
+                  :           :           :        +- SortMergeJoin Inner (224)
+                  :           :           :           :- Sort (219)
+                  :           :           :           :  +- Exchange (218)
+                  :           :           :           :     +- Project (217)
+                  :           :           :           :        +- SortMergeJoin Inner (216)
+                  :           :           :           :           :- Sort (210)
+                  :           :           :           :           :  +- Exchange (209)
+                  :           :           :           :           :     +- Project (208)
+                  :           :           :           :           :        +- SortMergeJoin Inner (207)
+                  :           :           :           :           :           :- Sort (201)
+                  :           :           :           :           :           :  +- Exchange (200)
+                  :           :           :           :           :           :     +- Project (199)
+                  :           :           :           :           :           :        +- SortMergeJoin Inner (198)
+                  :           :           :           :           :           :           :- Sort (192)
+                  :           :           :           :           :           :           :  +- Exchange (191)
+                  :           :           :           :           :           :           :     +- Project (190)
+                  :           :           :           :           :           :           :        +- SortMergeJoin Inner (189)
+                  :           :           :           :           :           :           :           :- Sort (184)
+                  :           :           :           :           :           :           :           :  +- Exchange (183)
+                  :           :           :           :           :           :           :           :     +- Project (182)
+                  :           :           :           :           :           :           :           :        +- SortMergeJoin Inner (181)
+                  :           :           :           :           :           :           :           :           :- Sort (176)
+                  :           :           :           :           :           :           :           :           :  +- Exchange (175)
+                  :           :           :           :           :           :           :           :           :     +- Project (174)
+                  :           :           :           :           :           :           :           :           :        +- SortMergeJoin Inner (173)
+                  :           :           :           :           :           :           :           :           :           :- Sort (168)
+                  :           :           :           :           :           :           :           :           :           :  +- Exchange (167)
+                  :           :           :           :           :           :           :           :           :           :     +- Filter (166)
+                  :           :           :           :           :           :           :           :           :           :        +- Scan parquet (165)
+                  :           :           :           :           :           :           :           :           :           +- Sort (172)
+                  :           :           :           :           :           :           :           :           :              +- Exchange (171)
+                  :           :           :           :           :           :           :           :           :                 +- Filter (170)
+                  :           :           :           :           :           :           :           :           :                    +- Scan parquet (169)
+                  :           :           :           :           :           :           :           :           +- Sort (180)
+                  :           :           :           :           :           :           :           :              +- Exchange (179)
+                  :           :           :           :           :           :           :           :                 +- Filter (178)
+                  :           :           :           :           :           :           :           :                    +- Scan parquet (177)
+                  :           :           :           :           :           :           :           +- Sort (188)
+                  :           :           :           :           :           :           :              +- Exchange (187)
+                  :           :           :           :           :           :           :                 +- Filter (186)
+                  :           :           :           :           :           :           :                    +- Scan parquet (185)
+                  :           :           :           :           :           :           +- Sort (197)
+                  :           :           :           :           :           :              +- Exchange (196)
+                  :           :           :           :           :           :                 +- Project (195)
+                  :           :           :           :           :           :                    +- Filter (194)
+                  :           :           :           :           :           :                       +- Scan parquet (193)
+                  :           :           :           :           :           +- Sort (206)
+                  :           :           :           :           :              +- Exchange (205)
+                  :           :           :           :           :                 +- Project (204)
+                  :           :           :           :           :                    +- Filter (203)
+                  :           :           :           :           :                       +- Scan parquet (202)
+                  :           :           :           :           +- Sort (215)
+                  :           :           :           :              +- Exchange (214)
+                  :           :           :           :                 +- Project (213)
+                  :           :           :           :                    +- Filter (212)
+                  :           :           :           :                       +- Scan parquet (211)
+                  :           :           :           +- Sort (223)
+                  :           :           :              +- Exchange (222)
+                  :           :           :                 +- Filter (221)
+                  :           :           :                    +- Scan parquet (220)
+                  :           :           +- Sort (231)
+                  :           :              +- Exchange (230)
+                  :           :                 +- Filter (229)
+                  :           :                    +- Scan parquet (228)
+                  :           +- Sort (239)
+                  :              +- Exchange (238)
+                  :                 +- Filter (237)
+                  :                    +- Scan parquet (236)
+                  +- Sort (247)
+                     +- Exchange (246)
+                        +- Filter (245)
+                           +- Scan parquet (244)
 
 
-(167) Scan parquet
+(165) Scan parquet
 Output [8]: [cs_sold_date_sk#1, cs_ship_date_sk#2, cs_bill_cdemo_sk#3, cs_bill_hdemo_sk#4, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, cs_quantity#8]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
@@ -293,7 +291,7 @@ Input [8]: [#1#1, #2#2, #3#3, #4#4, #5#5, #6#6, #7#7, #8#8]
 Input [8]: [#1#1, #2#2, #3#3, #4#4, #5#5, #6#6, #7#7, #8#8]
 Arguments: [cs_item_sk#5 ASC NULLS FIRST], false
 
-(171) Scan parquet
+(169) Scan parquet
 Output [4]: [inv_date_sk#9, inv_item_sk#10, inv_warehouse_sk#11, inv_quantity_on_hand#12]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
@@ -327,1054 +325,1048 @@ Input [4]: [#9#9, #10#10, #11#11, #12#12]
 Input [4]: [#9#9, #10#10, #11#11, #12#12]
 Arguments: [inv_item_sk#10 ASC NULLS FIRST], false
 
-(17) SortMergeJoin [codegen id : X]
+(17) NativeSortMergeJoin
 Left keys [1]: [cs_item_sk#5]
 Right keys [1]: [inv_item_sk#10]
 Join type: Inner
 Join condition: (inv_quantity_on_hand#12 < cs_quantity#8)
 
-(18) Project [codegen id : X]
+(18) NativeProject
 Output [9]: [cs_sold_date_sk#1, cs_ship_date_sk#2, cs_bill_cdemo_sk#3, cs_bill_hdemo_sk#4, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, inv_date_sk#9, inv_warehouse_sk#11]
 Input [12]: [#1#1, #2#2, #3#3, #4#4, #5#5, #6#6, #7#7, #8#8, #9#9, #10#10, #11#11, #12#12]
 
-(19) ConvertToNative
-Input [9]: [cs_sold_date_sk#1, cs_ship_date_sk#2, cs_bill_cdemo_sk#3, cs_bill_hdemo_sk#4, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, inv_date_sk#9, inv_warehouse_sk#11]
-
-(20) NativeShuffleExchange
+(19) NativeShuffleExchange
 Input [9]: [cs_sold_date_sk#1, cs_ship_date_sk#2, cs_bill_cdemo_sk#3, cs_bill_hdemo_sk#4, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, inv_date_sk#9, inv_warehouse_sk#11]
 Arguments: hashpartitioning(inv_warehouse_sk#11, 100), ENSURE_REQUIREMENTS, [plan_id=3]
 
-(21) ShuffleQueryStage
+(20) ShuffleQueryStage
 Output [9]: [cs_sold_date_sk#1, cs_ship_date_sk#2, cs_bill_cdemo_sk#3, cs_bill_hdemo_sk#4, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, inv_date_sk#9, inv_warehouse_sk#11]
 Arguments: X
 
-(22) AQEShuffleRead
+(21) AQEShuffleRead
 Input [9]: [cs_sold_date_sk#1, cs_ship_date_sk#2, cs_bill_cdemo_sk#3, cs_bill_hdemo_sk#4, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, inv_date_sk#9, inv_warehouse_sk#11]
 Arguments: coalesced
 
-(23) InputAdapter
+(22) InputAdapter
 Input [9]: [cs_sold_date_sk#1, cs_ship_date_sk#2, cs_bill_cdemo_sk#3, cs_bill_hdemo_sk#4, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, inv_date_sk#9, inv_warehouse_sk#11]
 
-(24) NativeSort
+(23) NativeSort
 Input [9]: [cs_sold_date_sk#1, cs_ship_date_sk#2, cs_bill_cdemo_sk#3, cs_bill_hdemo_sk#4, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, inv_date_sk#9, inv_warehouse_sk#11]
 Arguments: [inv_warehouse_sk#11 ASC NULLS FIRST], false
 
-(179) Scan parquet
+(177) Scan parquet
 Output [2]: [w_warehouse_sk#13, w_warehouse_name#14]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(w_warehouse_sk)]
 ReadSchema: struct<w_warehouse_sk:int,w_warehouse_name:string>
 
-(26) InputAdapter
+(25) InputAdapter
 Input [2]: [w_warehouse_sk#13, w_warehouse_name#14]
 Arguments: [#13, #14]
 
-(27) NativeFilter
+(26) NativeFilter
 Input [2]: [#13#13, #14#14]
 Condition : isnotnull(w_warehouse_sk#13)
 
-(28) NativeShuffleExchange
+(27) NativeShuffleExchange
 Input [2]: [#13#13, #14#14]
 Arguments: hashpartitioning(w_warehouse_sk#13, 100), ENSURE_REQUIREMENTS, [plan_id=4]
 
-(29) ShuffleQueryStage
+(28) ShuffleQueryStage
 Output [2]: [#13#13, #14#14]
 Arguments: X
 
-(30) AQEShuffleRead
+(29) AQEShuffleRead
 Input [2]: [#13#13, #14#14]
 Arguments: coalesced
 
-(31) InputAdapter
+(30) InputAdapter
 Input [2]: [#13#13, #14#14]
 
-(32) NativeSort
+(31) NativeSort
 Input [2]: [#13#13, #14#14]
 Arguments: [w_warehouse_sk#13 ASC NULLS FIRST], false
 
-(33) NativeSortMergeJoin
+(32) NativeSortMergeJoin
 Left keys [1]: [inv_warehouse_sk#11]
 Right keys [1]: [w_warehouse_sk#13]
 Join type: Inner
 Join condition: None
 
-(34) NativeProject
+(33) NativeProject
 Output [9]: [cs_sold_date_sk#1, cs_ship_date_sk#2, cs_bill_cdemo_sk#3, cs_bill_hdemo_sk#4, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, inv_date_sk#9, w_warehouse_name#14]
 Input [11]: [cs_sold_date_sk#1, cs_ship_date_sk#2, cs_bill_cdemo_sk#3, cs_bill_hdemo_sk#4, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, inv_date_sk#9, inv_warehouse_sk#11, #13#13, #14#14]
 
-(35) NativeShuffleExchange
+(34) NativeShuffleExchange
 Input [9]: [cs_sold_date_sk#1, cs_ship_date_sk#2, cs_bill_cdemo_sk#3, cs_bill_hdemo_sk#4, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, inv_date_sk#9, w_warehouse_name#14]
 Arguments: hashpartitioning(cs_item_sk#5, 100), ENSURE_REQUIREMENTS, [plan_id=5]
 
-(36) ShuffleQueryStage
+(35) ShuffleQueryStage
 Output [9]: [cs_sold_date_sk#1, cs_ship_date_sk#2, cs_bill_cdemo_sk#3, cs_bill_hdemo_sk#4, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, inv_date_sk#9, w_warehouse_name#14]
 Arguments: X
 
-(37) AQEShuffleRead
+(36) AQEShuffleRead
 Input [9]: [cs_sold_date_sk#1, cs_ship_date_sk#2, cs_bill_cdemo_sk#3, cs_bill_hdemo_sk#4, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, inv_date_sk#9, w_warehouse_name#14]
 Arguments: coalesced
 
-(38) InputAdapter
+(37) InputAdapter
 Input [9]: [cs_sold_date_sk#1, cs_ship_date_sk#2, cs_bill_cdemo_sk#3, cs_bill_hdemo_sk#4, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, inv_date_sk#9, w_warehouse_name#14]
 
-(39) NativeSort
+(38) NativeSort
 Input [9]: [cs_sold_date_sk#1, cs_ship_date_sk#2, cs_bill_cdemo_sk#3, cs_bill_hdemo_sk#4, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, inv_date_sk#9, w_warehouse_name#14]
 Arguments: [cs_item_sk#5 ASC NULLS FIRST], false
 
-(187) Scan parquet
+(185) Scan parquet
 Output [2]: [i_item_sk#15, i_item_desc#16]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_item_desc:string>
 
-(41) InputAdapter
+(40) InputAdapter
 Input [2]: [i_item_sk#15, i_item_desc#16]
 Arguments: [#15, #16]
 
-(42) NativeFilter
+(41) NativeFilter
 Input [2]: [#15#15, #16#16]
 Condition : isnotnull(i_item_sk#15)
 
-(43) NativeShuffleExchange
+(42) NativeShuffleExchange
 Input [2]: [#15#15, #16#16]
 Arguments: hashpartitioning(i_item_sk#15, 100), ENSURE_REQUIREMENTS, [plan_id=6]
 
-(44) ShuffleQueryStage
+(43) ShuffleQueryStage
 Output [2]: [#15#15, #16#16]
 Arguments: X
 
-(45) AQEShuffleRead
+(44) AQEShuffleRead
 Input [2]: [#15#15, #16#16]
 Arguments: coalesced
 
-(46) InputAdapter
+(45) InputAdapter
 Input [2]: [#15#15, #16#16]
 
-(47) NativeSort
+(46) NativeSort
 Input [2]: [#15#15, #16#16]
 Arguments: [i_item_sk#15 ASC NULLS FIRST], false
 
-(48) NativeSortMergeJoin
+(47) NativeSortMergeJoin
 Left keys [1]: [cs_item_sk#5]
 Right keys [1]: [i_item_sk#15]
 Join type: Inner
 Join condition: None
 
-(49) NativeProject
+(48) NativeProject
 Output [10]: [cs_sold_date_sk#1, cs_ship_date_sk#2, cs_bill_cdemo_sk#3, cs_bill_hdemo_sk#4, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, inv_date_sk#9, w_warehouse_name#14, i_item_desc#16]
 Input [11]: [cs_sold_date_sk#1, cs_ship_date_sk#2, cs_bill_cdemo_sk#3, cs_bill_hdemo_sk#4, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, inv_date_sk#9, w_warehouse_name#14, #15#15, #16#16]
 
-(50) NativeShuffleExchange
+(49) NativeShuffleExchange
 Input [10]: [cs_sold_date_sk#1, cs_ship_date_sk#2, cs_bill_cdemo_sk#3, cs_bill_hdemo_sk#4, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, inv_date_sk#9, w_warehouse_name#14, i_item_desc#16]
 Arguments: hashpartitioning(cs_bill_cdemo_sk#3, 100), ENSURE_REQUIREMENTS, [plan_id=7]
 
-(51) ShuffleQueryStage
+(50) ShuffleQueryStage
 Output [10]: [cs_sold_date_sk#1, cs_ship_date_sk#2, cs_bill_cdemo_sk#3, cs_bill_hdemo_sk#4, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, inv_date_sk#9, w_warehouse_name#14, i_item_desc#16]
 Arguments: X
 
-(52) AQEShuffleRead
+(51) AQEShuffleRead
 Input [10]: [cs_sold_date_sk#1, cs_ship_date_sk#2, cs_bill_cdemo_sk#3, cs_bill_hdemo_sk#4, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, inv_date_sk#9, w_warehouse_name#14, i_item_desc#16]
 Arguments: coalesced
 
-(53) InputAdapter
+(52) InputAdapter
 Input [10]: [cs_sold_date_sk#1, cs_ship_date_sk#2, cs_bill_cdemo_sk#3, cs_bill_hdemo_sk#4, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, inv_date_sk#9, w_warehouse_name#14, i_item_desc#16]
 
-(54) NativeSort
+(53) NativeSort
 Input [10]: [cs_sold_date_sk#1, cs_ship_date_sk#2, cs_bill_cdemo_sk#3, cs_bill_hdemo_sk#4, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, inv_date_sk#9, w_warehouse_name#14, i_item_desc#16]
 Arguments: [cs_bill_cdemo_sk#3 ASC NULLS FIRST], false
 
-(195) Scan parquet
+(193) Scan parquet
 Output [2]: [cd_demo_sk#17, cd_marital_status#18]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(cd_marital_status), EqualTo(cd_marital_status,D), IsNotNull(cd_demo_sk)]
 ReadSchema: struct<cd_demo_sk:int,cd_marital_status:string>
 
-(56) InputAdapter
+(55) InputAdapter
 Input [2]: [cd_demo_sk#17, cd_marital_status#18]
 Arguments: [#17, #18]
 
-(57) NativeFilter
+(56) NativeFilter
 Input [2]: [#17#17, #18#18]
 Condition : ((isnotnull(cd_marital_status#18) AND (cd_marital_status#18 = D)) AND isnotnull(cd_demo_sk#17))
 
-(58) NativeProject
+(57) NativeProject
 Output [1]: [cd_demo_sk#17]
 Input [2]: [#17#17, #18#18]
 
-(59) NativeShuffleExchange
+(58) NativeShuffleExchange
 Input [1]: [cd_demo_sk#17]
 Arguments: hashpartitioning(cd_demo_sk#17, 100), ENSURE_REQUIREMENTS, [plan_id=8]
 
-(60) ShuffleQueryStage
+(59) ShuffleQueryStage
 Output [1]: [cd_demo_sk#17]
 Arguments: X
 
-(61) AQEShuffleRead
+(60) AQEShuffleRead
 Input [1]: [cd_demo_sk#17]
 Arguments: coalesced
 
-(62) InputAdapter
+(61) InputAdapter
 Input [1]: [cd_demo_sk#17]
 
-(63) NativeSort
+(62) NativeSort
 Input [1]: [cd_demo_sk#17]
 Arguments: [cd_demo_sk#17 ASC NULLS FIRST], false
 
-(64) NativeSortMergeJoin
+(63) NativeSortMergeJoin
 Left keys [1]: [cs_bill_cdemo_sk#3]
 Right keys [1]: [cd_demo_sk#17]
 Join type: Inner
 Join condition: None
 
-(65) NativeProject
+(64) NativeProject
 Output [9]: [cs_sold_date_sk#1, cs_ship_date_sk#2, cs_bill_hdemo_sk#4, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, inv_date_sk#9, w_warehouse_name#14, i_item_desc#16]
 Input [11]: [cs_sold_date_sk#1, cs_ship_date_sk#2, cs_bill_cdemo_sk#3, cs_bill_hdemo_sk#4, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, inv_date_sk#9, w_warehouse_name#14, i_item_desc#16, cd_demo_sk#17]
 
-(66) NativeShuffleExchange
+(65) NativeShuffleExchange
 Input [9]: [cs_sold_date_sk#1, cs_ship_date_sk#2, cs_bill_hdemo_sk#4, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, inv_date_sk#9, w_warehouse_name#14, i_item_desc#16]
 Arguments: hashpartitioning(cs_bill_hdemo_sk#4, 100), ENSURE_REQUIREMENTS, [plan_id=9]
 
-(67) ShuffleQueryStage
+(66) ShuffleQueryStage
 Output [9]: [cs_sold_date_sk#1, cs_ship_date_sk#2, cs_bill_hdemo_sk#4, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, inv_date_sk#9, w_warehouse_name#14, i_item_desc#16]
 Arguments: X
 
-(68) AQEShuffleRead
+(67) AQEShuffleRead
 Input [9]: [cs_sold_date_sk#1, cs_ship_date_sk#2, cs_bill_hdemo_sk#4, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, inv_date_sk#9, w_warehouse_name#14, i_item_desc#16]
 Arguments: coalesced
 
-(69) InputAdapter
+(68) InputAdapter
 Input [9]: [cs_sold_date_sk#1, cs_ship_date_sk#2, cs_bill_hdemo_sk#4, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, inv_date_sk#9, w_warehouse_name#14, i_item_desc#16]
 
-(70) NativeSort
+(69) NativeSort
 Input [9]: [cs_sold_date_sk#1, cs_ship_date_sk#2, cs_bill_hdemo_sk#4, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, inv_date_sk#9, w_warehouse_name#14, i_item_desc#16]
 Arguments: [cs_bill_hdemo_sk#4 ASC NULLS FIRST], false
 
-(204) Scan parquet
+(202) Scan parquet
 Output [2]: [hd_demo_sk#19, hd_buy_potential#20]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(hd_buy_potential), EqualTo(hd_buy_potential,>10000), IsNotNull(hd_demo_sk)]
 ReadSchema: struct<hd_demo_sk:int,hd_buy_potential:string>
 
-(72) InputAdapter
+(71) InputAdapter
 Input [2]: [hd_demo_sk#19, hd_buy_potential#20]
 Arguments: [#19, #20]
 
-(73) NativeFilter
+(72) NativeFilter
 Input [2]: [#19#19, #20#20]
 Condition : ((isnotnull(hd_buy_potential#20) AND (hd_buy_potential#20 = >10000)) AND isnotnull(hd_demo_sk#19))
 
-(74) NativeProject
+(73) NativeProject
 Output [1]: [hd_demo_sk#19]
 Input [2]: [#19#19, #20#20]
 
-(75) NativeShuffleExchange
+(74) NativeShuffleExchange
 Input [1]: [hd_demo_sk#19]
 Arguments: hashpartitioning(hd_demo_sk#19, 100), ENSURE_REQUIREMENTS, [plan_id=10]
 
-(76) ShuffleQueryStage
+(75) ShuffleQueryStage
 Output [1]: [hd_demo_sk#19]
 Arguments: X
 
-(77) AQEShuffleRead
+(76) AQEShuffleRead
 Input [1]: [hd_demo_sk#19]
 Arguments: coalesced
 
-(78) InputAdapter
+(77) InputAdapter
 Input [1]: [hd_demo_sk#19]
 
-(79) NativeSort
+(78) NativeSort
 Input [1]: [hd_demo_sk#19]
 Arguments: [hd_demo_sk#19 ASC NULLS FIRST], false
 
-(80) NativeSortMergeJoin
+(79) NativeSortMergeJoin
 Left keys [1]: [cs_bill_hdemo_sk#4]
 Right keys [1]: [hd_demo_sk#19]
 Join type: Inner
 Join condition: None
 
-(81) NativeProject
+(80) NativeProject
 Output [8]: [cs_sold_date_sk#1, cs_ship_date_sk#2, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, inv_date_sk#9, w_warehouse_name#14, i_item_desc#16]
 Input [10]: [cs_sold_date_sk#1, cs_ship_date_sk#2, cs_bill_hdemo_sk#4, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, inv_date_sk#9, w_warehouse_name#14, i_item_desc#16, hd_demo_sk#19]
 
-(82) NativeShuffleExchange
+(81) NativeShuffleExchange
 Input [8]: [cs_sold_date_sk#1, cs_ship_date_sk#2, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, inv_date_sk#9, w_warehouse_name#14, i_item_desc#16]
 Arguments: hashpartitioning(cs_sold_date_sk#1, 100), ENSURE_REQUIREMENTS, [plan_id=11]
 
-(83) ShuffleQueryStage
+(82) ShuffleQueryStage
 Output [8]: [cs_sold_date_sk#1, cs_ship_date_sk#2, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, inv_date_sk#9, w_warehouse_name#14, i_item_desc#16]
 Arguments: X
 
-(84) AQEShuffleRead
+(83) AQEShuffleRead
 Input [8]: [cs_sold_date_sk#1, cs_ship_date_sk#2, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, inv_date_sk#9, w_warehouse_name#14, i_item_desc#16]
 Arguments: coalesced
 
-(85) InputAdapter
+(84) InputAdapter
 Input [8]: [cs_sold_date_sk#1, cs_ship_date_sk#2, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, inv_date_sk#9, w_warehouse_name#14, i_item_desc#16]
 
-(86) NativeSort
+(85) NativeSort
 Input [8]: [cs_sold_date_sk#1, cs_ship_date_sk#2, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, inv_date_sk#9, w_warehouse_name#14, i_item_desc#16]
 Arguments: [cs_sold_date_sk#1 ASC NULLS FIRST], false
 
-(213) Scan parquet
+(211) Scan parquet
 Output [4]: [d_date_sk#21, d_date#22, d_week_seq#23, d_year#24]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,1999), IsNotNull(d_date_sk), IsNotNull(d_week_seq), IsNotNull(d_date)]
 ReadSchema: struct<d_date_sk:int,d_date:date,d_week_seq:int,d_year:int>
 
-(88) InputAdapter
+(87) InputAdapter
 Input [4]: [d_date_sk#21, d_date#22, d_week_seq#23, d_year#24]
 Arguments: [#21, #22, #23, #24]
 
-(89) NativeFilter
+(88) NativeFilter
 Input [4]: [#21#21, #22#22, #23#23, #24#24]
 Condition : ((((isnotnull(d_year#24) AND (d_year#24 = 1999)) AND isnotnull(d_date_sk#21)) AND isnotnull(d_week_seq#23)) AND isnotnull(d_date#22))
 
-(90) NativeProject
+(89) NativeProject
 Output [3]: [d_date_sk#21, d_date#22, d_week_seq#23]
 Input [4]: [#21#21, #22#22, #23#23, #24#24]
 
-(91) NativeShuffleExchange
+(90) NativeShuffleExchange
 Input [3]: [d_date_sk#21, d_date#22, d_week_seq#23]
 Arguments: hashpartitioning(d_date_sk#21, 100), ENSURE_REQUIREMENTS, [plan_id=12]
 
-(92) ShuffleQueryStage
+(91) ShuffleQueryStage
 Output [3]: [d_date_sk#21, d_date#22, d_week_seq#23]
 Arguments: X
 
-(93) AQEShuffleRead
+(92) AQEShuffleRead
 Input [3]: [d_date_sk#21, d_date#22, d_week_seq#23]
 Arguments: coalesced
 
-(94) InputAdapter
+(93) InputAdapter
 Input [3]: [d_date_sk#21, d_date#22, d_week_seq#23]
 
-(95) NativeSort
+(94) NativeSort
 Input [3]: [d_date_sk#21, d_date#22, d_week_seq#23]
 Arguments: [d_date_sk#21 ASC NULLS FIRST], false
 
-(96) NativeSortMergeJoin
+(95) NativeSortMergeJoin
 Left keys [1]: [cs_sold_date_sk#1]
 Right keys [1]: [d_date_sk#21]
 Join type: Inner
 Join condition: None
 
-(97) NativeProject
+(96) NativeProject
 Output [9]: [cs_ship_date_sk#2, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, inv_date_sk#9, w_warehouse_name#14, i_item_desc#16, d_date#22, d_week_seq#23]
 Input [11]: [cs_sold_date_sk#1, cs_ship_date_sk#2, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, inv_date_sk#9, w_warehouse_name#14, i_item_desc#16, d_date_sk#21, d_date#22, d_week_seq#23]
 
-(98) NativeShuffleExchange
+(97) NativeShuffleExchange
 Input [9]: [cs_ship_date_sk#2, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, inv_date_sk#9, w_warehouse_name#14, i_item_desc#16, d_date#22, d_week_seq#23]
 Arguments: hashpartitioning(d_week_seq#23, inv_date_sk#9, 100), ENSURE_REQUIREMENTS, [plan_id=13]
 
-(99) ShuffleQueryStage
+(98) ShuffleQueryStage
 Output [9]: [cs_ship_date_sk#2, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, inv_date_sk#9, w_warehouse_name#14, i_item_desc#16, d_date#22, d_week_seq#23]
 Arguments: X
 
-(100) AQEShuffleRead
+(99) AQEShuffleRead
 Input [9]: [cs_ship_date_sk#2, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, inv_date_sk#9, w_warehouse_name#14, i_item_desc#16, d_date#22, d_week_seq#23]
 Arguments: coalesced
 
-(101) InputAdapter
+(100) InputAdapter
 Input [9]: [cs_ship_date_sk#2, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, inv_date_sk#9, w_warehouse_name#14, i_item_desc#16, d_date#22, d_week_seq#23]
 
-(102) NativeSort
+(101) NativeSort
 Input [9]: [cs_ship_date_sk#2, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, inv_date_sk#9, w_warehouse_name#14, i_item_desc#16, d_date#22, d_week_seq#23]
 Arguments: [d_week_seq#23 ASC NULLS FIRST, inv_date_sk#9 ASC NULLS FIRST], false
 
-(222) Scan parquet
+(220) Scan parquet
 Output [2]: [d_date_sk#25, d_week_seq#26]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(d_week_seq), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_week_seq:int>
 
-(104) InputAdapter
+(103) InputAdapter
 Input [2]: [d_date_sk#25, d_week_seq#26]
 Arguments: [#25, #26]
 
-(105) NativeFilter
+(104) NativeFilter
 Input [2]: [#25#25, #26#26]
 Condition : (isnotnull(d_week_seq#26) AND isnotnull(d_date_sk#25))
 
-(106) NativeShuffleExchange
+(105) NativeShuffleExchange
 Input [2]: [#25#25, #26#26]
 Arguments: hashpartitioning(d_week_seq#26, d_date_sk#25, 100), ENSURE_REQUIREMENTS, [plan_id=14]
 
-(107) ShuffleQueryStage
+(106) ShuffleQueryStage
 Output [2]: [#25#25, #26#26]
 Arguments: X
 
-(108) AQEShuffleRead
+(107) AQEShuffleRead
 Input [2]: [#25#25, #26#26]
 Arguments: coalesced
 
-(109) InputAdapter
+(108) InputAdapter
 Input [2]: [#25#25, #26#26]
 
-(110) NativeSort
+(109) NativeSort
 Input [2]: [#25#25, #26#26]
 Arguments: [d_week_seq#26 ASC NULLS FIRST, d_date_sk#25 ASC NULLS FIRST], false
 
-(111) NativeSortMergeJoin
+(110) NativeSortMergeJoin
 Left keys [2]: [d_week_seq#23, inv_date_sk#9]
 Right keys [2]: [d_week_seq#26, d_date_sk#25]
 Join type: Inner
 Join condition: None
 
-(112) NativeProject
+(111) NativeProject
 Output [8]: [cs_ship_date_sk#2, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, w_warehouse_name#14, i_item_desc#16, d_date#22, d_week_seq#23]
 Input [11]: [cs_ship_date_sk#2, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, inv_date_sk#9, w_warehouse_name#14, i_item_desc#16, d_date#22, d_week_seq#23, #25#25, #26#26]
 
-(113) NativeShuffleExchange
+(112) NativeShuffleExchange
 Input [8]: [cs_ship_date_sk#2, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, w_warehouse_name#14, i_item_desc#16, d_date#22, d_week_seq#23]
 Arguments: hashpartitioning(cs_ship_date_sk#2, 100), ENSURE_REQUIREMENTS, [plan_id=15]
 
-(114) ShuffleQueryStage
+(113) ShuffleQueryStage
 Output [8]: [cs_ship_date_sk#2, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, w_warehouse_name#14, i_item_desc#16, d_date#22, d_week_seq#23]
 Arguments: X
 
-(115) AQEShuffleRead
+(114) AQEShuffleRead
 Input [8]: [cs_ship_date_sk#2, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, w_warehouse_name#14, i_item_desc#16, d_date#22, d_week_seq#23]
 Arguments: coalesced
 
-(116) InputAdapter
+(115) InputAdapter
 Input [8]: [cs_ship_date_sk#2, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, w_warehouse_name#14, i_item_desc#16, d_date#22, d_week_seq#23]
 
-(117) NativeSort
+(116) NativeSort
 Input [8]: [cs_ship_date_sk#2, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, w_warehouse_name#14, i_item_desc#16, d_date#22, d_week_seq#23]
 Arguments: [cs_ship_date_sk#2 ASC NULLS FIRST], false
 
-(230) Scan parquet
+(228) Scan parquet
 Output [2]: [d_date_sk#27, d_date#28]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(d_date), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date>
 
-(119) InputAdapter
+(118) InputAdapter
 Input [2]: [d_date_sk#27, d_date#28]
 Arguments: [#27, #28]
 
-(120) NativeFilter
+(119) NativeFilter
 Input [2]: [#27#27, #28#28]
 Condition : (isnotnull(d_date#28) AND isnotnull(d_date_sk#27))
 
-(121) NativeShuffleExchange
+(120) NativeShuffleExchange
 Input [2]: [#27#27, #28#28]
 Arguments: hashpartitioning(d_date_sk#27, 100), ENSURE_REQUIREMENTS, [plan_id=16]
 
-(122) ShuffleQueryStage
+(121) ShuffleQueryStage
 Output [2]: [#27#27, #28#28]
 Arguments: X
 
-(123) AQEShuffleRead
+(122) AQEShuffleRead
 Input [2]: [#27#27, #28#28]
 Arguments: coalesced
 
-(124) InputAdapter
+(123) InputAdapter
 Input [2]: [#27#27, #28#28]
 
-(125) NativeSort
+(124) NativeSort
 Input [2]: [#27#27, #28#28]
 Arguments: [d_date_sk#27 ASC NULLS FIRST], false
 
-(126) SortMergeJoin [codegen id : X]
+(125) NativeSortMergeJoin
 Left keys [1]: [cs_ship_date_sk#2]
 Right keys [1]: [d_date_sk#27]
 Join type: Inner
 Join condition: (d_date#28 > date_add(d_date#22, 5))
 
-(127) Project [codegen id : X]
+(126) NativeProject
 Output [6]: [cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, w_warehouse_name#14, i_item_desc#16, d_week_seq#23]
 Input [10]: [cs_ship_date_sk#2, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, w_warehouse_name#14, i_item_desc#16, d_date#22, d_week_seq#23, #27#27, #28#28]
 
-(128) ConvertToNative
-Input [6]: [cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, w_warehouse_name#14, i_item_desc#16, d_week_seq#23]
-
-(129) NativeShuffleExchange
+(127) NativeShuffleExchange
 Input [6]: [cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, w_warehouse_name#14, i_item_desc#16, d_week_seq#23]
 Arguments: hashpartitioning(cs_promo_sk#6, 100), ENSURE_REQUIREMENTS, [plan_id=17]
 
-(130) ShuffleQueryStage
+(128) ShuffleQueryStage
 Output [6]: [cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, w_warehouse_name#14, i_item_desc#16, d_week_seq#23]
 Arguments: X
 
-(131) AQEShuffleRead
+(129) AQEShuffleRead
 Input [6]: [cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, w_warehouse_name#14, i_item_desc#16, d_week_seq#23]
 Arguments: coalesced
 
-(132) InputAdapter
+(130) InputAdapter
 Input [6]: [cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, w_warehouse_name#14, i_item_desc#16, d_week_seq#23]
 
-(133) NativeSort
+(131) NativeSort
 Input [6]: [cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, w_warehouse_name#14, i_item_desc#16, d_week_seq#23]
 Arguments: [cs_promo_sk#6 ASC NULLS FIRST], false
 
-(238) Scan parquet
+(236) Scan parquet
 Output [1]: [p_promo_sk#29]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(p_promo_sk)]
 ReadSchema: struct<p_promo_sk:int>
 
-(135) InputAdapter
+(133) InputAdapter
 Input [1]: [p_promo_sk#29]
 Arguments: [#29]
 
-(136) NativeFilter
+(134) NativeFilter
 Input [1]: [#29#29]
 Condition : isnotnull(p_promo_sk#29)
 
-(137) NativeShuffleExchange
+(135) NativeShuffleExchange
 Input [1]: [#29#29]
 Arguments: hashpartitioning(p_promo_sk#29, 100), ENSURE_REQUIREMENTS, [plan_id=18]
 
-(138) ShuffleQueryStage
+(136) ShuffleQueryStage
 Output [1]: [#29#29]
 Arguments: X
 
-(139) AQEShuffleRead
+(137) AQEShuffleRead
 Input [1]: [#29#29]
 Arguments: coalesced
 
-(140) InputAdapter
+(138) InputAdapter
 Input [1]: [#29#29]
 
-(141) NativeSort
+(139) NativeSort
 Input [1]: [#29#29]
 Arguments: [p_promo_sk#29 ASC NULLS FIRST], false
 
-(142) NativeSortMergeJoin
+(140) NativeSortMergeJoin
 Left keys [1]: [cs_promo_sk#6]
 Right keys [1]: [p_promo_sk#29]
 Join type: LeftOuter
 Join condition: None
 
-(143) NativeProject
+(141) NativeProject
 Output [5]: [cs_item_sk#5, cs_order_number#7, w_warehouse_name#14, i_item_desc#16, d_week_seq#23]
 Input [7]: [cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, w_warehouse_name#14, i_item_desc#16, d_week_seq#23, #29#29]
 
-(144) NativeShuffleExchange
+(142) NativeShuffleExchange
 Input [5]: [cs_item_sk#5, cs_order_number#7, w_warehouse_name#14, i_item_desc#16, d_week_seq#23]
 Arguments: hashpartitioning(cs_item_sk#5, cs_order_number#7, 100), ENSURE_REQUIREMENTS, [plan_id=19]
 
-(145) ShuffleQueryStage
+(143) ShuffleQueryStage
 Output [5]: [cs_item_sk#5, cs_order_number#7, w_warehouse_name#14, i_item_desc#16, d_week_seq#23]
 Arguments: X
 
-(146) AQEShuffleRead
+(144) AQEShuffleRead
 Input [5]: [cs_item_sk#5, cs_order_number#7, w_warehouse_name#14, i_item_desc#16, d_week_seq#23]
 Arguments: coalesced
 
-(147) InputAdapter
+(145) InputAdapter
 Input [5]: [cs_item_sk#5, cs_order_number#7, w_warehouse_name#14, i_item_desc#16, d_week_seq#23]
 
-(148) NativeSort
+(146) NativeSort
 Input [5]: [cs_item_sk#5, cs_order_number#7, w_warehouse_name#14, i_item_desc#16, d_week_seq#23]
 Arguments: [cs_item_sk#5 ASC NULLS FIRST, cs_order_number#7 ASC NULLS FIRST], false
 
-(246) Scan parquet
+(244) Scan parquet
 Output [2]: [cr_item_sk#30, cr_order_number#31]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(cr_item_sk), IsNotNull(cr_order_number)]
 ReadSchema: struct<cr_item_sk:int,cr_order_number:int>
 
-(150) InputAdapter
+(148) InputAdapter
 Input [2]: [cr_item_sk#30, cr_order_number#31]
 Arguments: [#30, #31]
 
-(151) NativeFilter
+(149) NativeFilter
 Input [2]: [#30#30, #31#31]
 Condition : (isnotnull(cr_item_sk#30) AND isnotnull(cr_order_number#31))
 
-(152) NativeShuffleExchange
+(150) NativeShuffleExchange
 Input [2]: [#30#30, #31#31]
 Arguments: hashpartitioning(cr_item_sk#30, cr_order_number#31, 100), ENSURE_REQUIREMENTS, [plan_id=20]
 
-(153) ShuffleQueryStage
+(151) ShuffleQueryStage
 Output [2]: [#30#30, #31#31]
 Arguments: X
 
-(154) AQEShuffleRead
+(152) AQEShuffleRead
 Input [2]: [#30#30, #31#31]
 Arguments: coalesced
 
-(155) InputAdapter
+(153) InputAdapter
 Input [2]: [#30#30, #31#31]
 
-(156) NativeSort
+(154) NativeSort
 Input [2]: [#30#30, #31#31]
 Arguments: [cr_item_sk#30 ASC NULLS FIRST, cr_order_number#31 ASC NULLS FIRST], false
 
-(157) NativeSortMergeJoin
+(155) NativeSortMergeJoin
 Left keys [2]: [cs_item_sk#5, cs_order_number#7]
 Right keys [2]: [cr_item_sk#30, cr_order_number#31]
 Join type: LeftOuter
 Join condition: None
 
-(158) NativeProject
+(156) NativeProject
 Output [3]: [w_warehouse_name#14, i_item_desc#16, d_week_seq#23]
 Input [7]: [cs_item_sk#5, cs_order_number#7, w_warehouse_name#14, i_item_desc#16, d_week_seq#23, #30#30, #31#31]
 
-(159) NativeHashAggregate
+(157) NativeHashAggregate
 Input [3]: [w_warehouse_name#14, i_item_desc#16, d_week_seq#23]
 Keys [3]: [i_item_desc#16, w_warehouse_name#14, d_week_seq#23]
 Functions [1]: [partial_count(1)]
 Aggregate Attributes [1]: [count#32]
 Results [4]: [i_item_desc#16, w_warehouse_name#14, d_week_seq#23, #33]
 
-(160) NativeShuffleExchange
+(158) NativeShuffleExchange
 Input [4]: [i_item_desc#16, w_warehouse_name#14, d_week_seq#23, #33]
 Arguments: hashpartitioning(i_item_desc#16, w_warehouse_name#14, d_week_seq#23, 100), ENSURE_REQUIREMENTS, [plan_id=21]
 
-(161) ShuffleQueryStage
+(159) ShuffleQueryStage
 Output [4]: [i_item_desc#16, w_warehouse_name#14, d_week_seq#23, #33]
 Arguments: X
 
-(162) AQEShuffleRead
+(160) AQEShuffleRead
 Input [4]: [i_item_desc#16, w_warehouse_name#14, d_week_seq#23, #33]
 Arguments: coalesced
 
-(163) InputAdapter
+(161) InputAdapter
 Input [4]: [i_item_desc#16, w_warehouse_name#14, d_week_seq#23, #33]
 
-(164) NativeHashAggregate
+(162) NativeHashAggregate
 Input [4]: [i_item_desc#16, w_warehouse_name#14, d_week_seq#23, #33]
 Keys [3]: [i_item_desc#16, w_warehouse_name#14, d_week_seq#23]
 Functions [1]: [count(1)]
 Aggregate Attributes [1]: [count(1)#34]
 Results [4]: [i_item_desc#16, w_warehouse_name#14, d_week_seq#23, count(1)#34]
 
-(165) NativeProject
+(163) NativeProject
 Output [6]: [i_item_desc#16, w_warehouse_name#14, d_week_seq#23, count(1)#34 AS no_promo#35, count(1)#34 AS promo#36, count(1)#34 AS total_cnt#37]
 Input [4]: [i_item_desc#16, w_warehouse_name#14, d_week_seq#23, count(1)#34]
 
-(166) NativeTakeOrdered
+(164) NativeTakeOrdered
 Input [6]: [i_item_desc#16, w_warehouse_name#14, d_week_seq#23, no_promo#35, promo#36, total_cnt#37]
 Arguments: X, X, [total_cnt#37 DESC NULLS LAST, i_item_desc#16 ASC NULLS FIRST, w_warehouse_name#14 ASC NULLS FIRST, d_week_seq#23 ASC NULLS FIRST]
 
-(167) Scan parquet
+(165) Scan parquet
 Output [8]: [cs_sold_date_sk#1, cs_ship_date_sk#2, cs_bill_cdemo_sk#3, cs_bill_hdemo_sk#4, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, cs_quantity#8]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(cs_quantity), IsNotNull(cs_item_sk), IsNotNull(cs_bill_cdemo_sk), IsNotNull(cs_bill_hdemo_sk), IsNotNull(cs_sold_date_sk), IsNotNull(cs_ship_date_sk)]
 ReadSchema: struct<cs_sold_date_sk:int,cs_ship_date_sk:int,cs_bill_cdemo_sk:int,cs_bill_hdemo_sk:int,cs_item_sk:int,cs_promo_sk:int,cs_order_number:int,cs_quantity:int>
 
-(168) Filter
+(166) Filter
 Input [8]: [cs_sold_date_sk#1, cs_ship_date_sk#2, cs_bill_cdemo_sk#3, cs_bill_hdemo_sk#4, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, cs_quantity#8]
 Condition : (((((isnotnull(cs_quantity#8) AND isnotnull(cs_item_sk#5)) AND isnotnull(cs_bill_cdemo_sk#3)) AND isnotnull(cs_bill_hdemo_sk#4)) AND isnotnull(cs_sold_date_sk#1)) AND isnotnull(cs_ship_date_sk#2))
 
-(169) Exchange
+(167) Exchange
 Input [8]: [cs_sold_date_sk#1, cs_ship_date_sk#2, cs_bill_cdemo_sk#3, cs_bill_hdemo_sk#4, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, cs_quantity#8]
 Arguments: hashpartitioning(cs_item_sk#5, 100), ENSURE_REQUIREMENTS, [plan_id=22]
 
-(170) Sort
+(168) Sort
 Input [8]: [cs_sold_date_sk#1, cs_ship_date_sk#2, cs_bill_cdemo_sk#3, cs_bill_hdemo_sk#4, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, cs_quantity#8]
 Arguments: [cs_item_sk#5 ASC NULLS FIRST], false, 0
 
-(171) Scan parquet
+(169) Scan parquet
 Output [4]: [inv_date_sk#9, inv_item_sk#10, inv_warehouse_sk#11, inv_quantity_on_hand#12]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(inv_quantity_on_hand), IsNotNull(inv_item_sk), IsNotNull(inv_warehouse_sk), IsNotNull(inv_date_sk)]
 ReadSchema: struct<inv_date_sk:int,inv_item_sk:int,inv_warehouse_sk:int,inv_quantity_on_hand:int>
 
-(172) Filter
+(170) Filter
 Input [4]: [inv_date_sk#9, inv_item_sk#10, inv_warehouse_sk#11, inv_quantity_on_hand#12]
 Condition : (((isnotnull(inv_quantity_on_hand#12) AND isnotnull(inv_item_sk#10)) AND isnotnull(inv_warehouse_sk#11)) AND isnotnull(inv_date_sk#9))
 
-(173) Exchange
+(171) Exchange
 Input [4]: [inv_date_sk#9, inv_item_sk#10, inv_warehouse_sk#11, inv_quantity_on_hand#12]
 Arguments: hashpartitioning(inv_item_sk#10, 100), ENSURE_REQUIREMENTS, [plan_id=23]
 
-(174) Sort
+(172) Sort
 Input [4]: [inv_date_sk#9, inv_item_sk#10, inv_warehouse_sk#11, inv_quantity_on_hand#12]
 Arguments: [inv_item_sk#10 ASC NULLS FIRST], false, 0
 
-(175) SortMergeJoin
+(173) SortMergeJoin
 Left keys [1]: [cs_item_sk#5]
 Right keys [1]: [inv_item_sk#10]
 Join type: Inner
 Join condition: (inv_quantity_on_hand#12 < cs_quantity#8)
 
-(176) Project
+(174) Project
 Output [9]: [cs_sold_date_sk#1, cs_ship_date_sk#2, cs_bill_cdemo_sk#3, cs_bill_hdemo_sk#4, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, inv_date_sk#9, inv_warehouse_sk#11]
 Input [12]: [cs_sold_date_sk#1, cs_ship_date_sk#2, cs_bill_cdemo_sk#3, cs_bill_hdemo_sk#4, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, cs_quantity#8, inv_date_sk#9, inv_item_sk#10, inv_warehouse_sk#11, inv_quantity_on_hand#12]
 
-(177) Exchange
+(175) Exchange
 Input [9]: [cs_sold_date_sk#1, cs_ship_date_sk#2, cs_bill_cdemo_sk#3, cs_bill_hdemo_sk#4, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, inv_date_sk#9, inv_warehouse_sk#11]
 Arguments: hashpartitioning(inv_warehouse_sk#11, 100), ENSURE_REQUIREMENTS, [plan_id=24]
 
-(178) Sort
+(176) Sort
 Input [9]: [cs_sold_date_sk#1, cs_ship_date_sk#2, cs_bill_cdemo_sk#3, cs_bill_hdemo_sk#4, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, inv_date_sk#9, inv_warehouse_sk#11]
 Arguments: [inv_warehouse_sk#11 ASC NULLS FIRST], false, 0
 
-(179) Scan parquet
+(177) Scan parquet
 Output [2]: [w_warehouse_sk#13, w_warehouse_name#14]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(w_warehouse_sk)]
 ReadSchema: struct<w_warehouse_sk:int,w_warehouse_name:string>
 
-(180) Filter
+(178) Filter
 Input [2]: [w_warehouse_sk#13, w_warehouse_name#14]
 Condition : isnotnull(w_warehouse_sk#13)
 
-(181) Exchange
+(179) Exchange
 Input [2]: [w_warehouse_sk#13, w_warehouse_name#14]
 Arguments: hashpartitioning(w_warehouse_sk#13, 100), ENSURE_REQUIREMENTS, [plan_id=25]
 
-(182) Sort
+(180) Sort
 Input [2]: [w_warehouse_sk#13, w_warehouse_name#14]
 Arguments: [w_warehouse_sk#13 ASC NULLS FIRST], false, 0
 
-(183) SortMergeJoin
+(181) SortMergeJoin
 Left keys [1]: [inv_warehouse_sk#11]
 Right keys [1]: [w_warehouse_sk#13]
 Join type: Inner
 Join condition: None
 
-(184) Project
+(182) Project
 Output [9]: [cs_sold_date_sk#1, cs_ship_date_sk#2, cs_bill_cdemo_sk#3, cs_bill_hdemo_sk#4, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, inv_date_sk#9, w_warehouse_name#14]
 Input [11]: [cs_sold_date_sk#1, cs_ship_date_sk#2, cs_bill_cdemo_sk#3, cs_bill_hdemo_sk#4, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, inv_date_sk#9, inv_warehouse_sk#11, w_warehouse_sk#13, w_warehouse_name#14]
 
-(185) Exchange
+(183) Exchange
 Input [9]: [cs_sold_date_sk#1, cs_ship_date_sk#2, cs_bill_cdemo_sk#3, cs_bill_hdemo_sk#4, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, inv_date_sk#9, w_warehouse_name#14]
 Arguments: hashpartitioning(cs_item_sk#5, 100), ENSURE_REQUIREMENTS, [plan_id=26]
 
-(186) Sort
+(184) Sort
 Input [9]: [cs_sold_date_sk#1, cs_ship_date_sk#2, cs_bill_cdemo_sk#3, cs_bill_hdemo_sk#4, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, inv_date_sk#9, w_warehouse_name#14]
 Arguments: [cs_item_sk#5 ASC NULLS FIRST], false, 0
 
-(187) Scan parquet
+(185) Scan parquet
 Output [2]: [i_item_sk#15, i_item_desc#16]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_item_desc:string>
 
-(188) Filter
+(186) Filter
 Input [2]: [i_item_sk#15, i_item_desc#16]
 Condition : isnotnull(i_item_sk#15)
 
-(189) Exchange
+(187) Exchange
 Input [2]: [i_item_sk#15, i_item_desc#16]
 Arguments: hashpartitioning(i_item_sk#15, 100), ENSURE_REQUIREMENTS, [plan_id=27]
 
-(190) Sort
+(188) Sort
 Input [2]: [i_item_sk#15, i_item_desc#16]
 Arguments: [i_item_sk#15 ASC NULLS FIRST], false, 0
 
-(191) SortMergeJoin
+(189) SortMergeJoin
 Left keys [1]: [cs_item_sk#5]
 Right keys [1]: [i_item_sk#15]
 Join type: Inner
 Join condition: None
 
-(192) Project
+(190) Project
 Output [10]: [cs_sold_date_sk#1, cs_ship_date_sk#2, cs_bill_cdemo_sk#3, cs_bill_hdemo_sk#4, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, inv_date_sk#9, w_warehouse_name#14, i_item_desc#16]
 Input [11]: [cs_sold_date_sk#1, cs_ship_date_sk#2, cs_bill_cdemo_sk#3, cs_bill_hdemo_sk#4, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, inv_date_sk#9, w_warehouse_name#14, i_item_sk#15, i_item_desc#16]
 
-(193) Exchange
+(191) Exchange
 Input [10]: [cs_sold_date_sk#1, cs_ship_date_sk#2, cs_bill_cdemo_sk#3, cs_bill_hdemo_sk#4, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, inv_date_sk#9, w_warehouse_name#14, i_item_desc#16]
 Arguments: hashpartitioning(cs_bill_cdemo_sk#3, 100), ENSURE_REQUIREMENTS, [plan_id=28]
 
-(194) Sort
+(192) Sort
 Input [10]: [cs_sold_date_sk#1, cs_ship_date_sk#2, cs_bill_cdemo_sk#3, cs_bill_hdemo_sk#4, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, inv_date_sk#9, w_warehouse_name#14, i_item_desc#16]
 Arguments: [cs_bill_cdemo_sk#3 ASC NULLS FIRST], false, 0
 
-(195) Scan parquet
+(193) Scan parquet
 Output [2]: [cd_demo_sk#17, cd_marital_status#18]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(cd_marital_status), EqualTo(cd_marital_status,D), IsNotNull(cd_demo_sk)]
 ReadSchema: struct<cd_demo_sk:int,cd_marital_status:string>
 
-(196) Filter
+(194) Filter
 Input [2]: [cd_demo_sk#17, cd_marital_status#18]
 Condition : ((isnotnull(cd_marital_status#18) AND (cd_marital_status#18 = D)) AND isnotnull(cd_demo_sk#17))
 
-(197) Project
+(195) Project
 Output [1]: [cd_demo_sk#17]
 Input [2]: [cd_demo_sk#17, cd_marital_status#18]
 
-(198) Exchange
+(196) Exchange
 Input [1]: [cd_demo_sk#17]
 Arguments: hashpartitioning(cd_demo_sk#17, 100), ENSURE_REQUIREMENTS, [plan_id=29]
 
-(199) Sort
+(197) Sort
 Input [1]: [cd_demo_sk#17]
 Arguments: [cd_demo_sk#17 ASC NULLS FIRST], false, 0
 
-(200) SortMergeJoin
+(198) SortMergeJoin
 Left keys [1]: [cs_bill_cdemo_sk#3]
 Right keys [1]: [cd_demo_sk#17]
 Join type: Inner
 Join condition: None
 
-(201) Project
+(199) Project
 Output [9]: [cs_sold_date_sk#1, cs_ship_date_sk#2, cs_bill_hdemo_sk#4, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, inv_date_sk#9, w_warehouse_name#14, i_item_desc#16]
 Input [11]: [cs_sold_date_sk#1, cs_ship_date_sk#2, cs_bill_cdemo_sk#3, cs_bill_hdemo_sk#4, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, inv_date_sk#9, w_warehouse_name#14, i_item_desc#16, cd_demo_sk#17]
 
-(202) Exchange
+(200) Exchange
 Input [9]: [cs_sold_date_sk#1, cs_ship_date_sk#2, cs_bill_hdemo_sk#4, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, inv_date_sk#9, w_warehouse_name#14, i_item_desc#16]
 Arguments: hashpartitioning(cs_bill_hdemo_sk#4, 100), ENSURE_REQUIREMENTS, [plan_id=30]
 
-(203) Sort
+(201) Sort
 Input [9]: [cs_sold_date_sk#1, cs_ship_date_sk#2, cs_bill_hdemo_sk#4, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, inv_date_sk#9, w_warehouse_name#14, i_item_desc#16]
 Arguments: [cs_bill_hdemo_sk#4 ASC NULLS FIRST], false, 0
 
-(204) Scan parquet
+(202) Scan parquet
 Output [2]: [hd_demo_sk#19, hd_buy_potential#20]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(hd_buy_potential), EqualTo(hd_buy_potential,>10000), IsNotNull(hd_demo_sk)]
 ReadSchema: struct<hd_demo_sk:int,hd_buy_potential:string>
 
-(205) Filter
+(203) Filter
 Input [2]: [hd_demo_sk#19, hd_buy_potential#20]
 Condition : ((isnotnull(hd_buy_potential#20) AND (hd_buy_potential#20 = >10000)) AND isnotnull(hd_demo_sk#19))
 
-(206) Project
+(204) Project
 Output [1]: [hd_demo_sk#19]
 Input [2]: [hd_demo_sk#19, hd_buy_potential#20]
 
-(207) Exchange
+(205) Exchange
 Input [1]: [hd_demo_sk#19]
 Arguments: hashpartitioning(hd_demo_sk#19, 100), ENSURE_REQUIREMENTS, [plan_id=31]
 
-(208) Sort
+(206) Sort
 Input [1]: [hd_demo_sk#19]
 Arguments: [hd_demo_sk#19 ASC NULLS FIRST], false, 0
 
-(209) SortMergeJoin
+(207) SortMergeJoin
 Left keys [1]: [cs_bill_hdemo_sk#4]
 Right keys [1]: [hd_demo_sk#19]
 Join type: Inner
 Join condition: None
 
-(210) Project
+(208) Project
 Output [8]: [cs_sold_date_sk#1, cs_ship_date_sk#2, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, inv_date_sk#9, w_warehouse_name#14, i_item_desc#16]
 Input [10]: [cs_sold_date_sk#1, cs_ship_date_sk#2, cs_bill_hdemo_sk#4, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, inv_date_sk#9, w_warehouse_name#14, i_item_desc#16, hd_demo_sk#19]
 
-(211) Exchange
+(209) Exchange
 Input [8]: [cs_sold_date_sk#1, cs_ship_date_sk#2, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, inv_date_sk#9, w_warehouse_name#14, i_item_desc#16]
 Arguments: hashpartitioning(cs_sold_date_sk#1, 100), ENSURE_REQUIREMENTS, [plan_id=32]
 
-(212) Sort
+(210) Sort
 Input [8]: [cs_sold_date_sk#1, cs_ship_date_sk#2, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, inv_date_sk#9, w_warehouse_name#14, i_item_desc#16]
 Arguments: [cs_sold_date_sk#1 ASC NULLS FIRST], false, 0
 
-(213) Scan parquet
+(211) Scan parquet
 Output [4]: [d_date_sk#21, d_date#22, d_week_seq#23, d_year#24]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,1999), IsNotNull(d_date_sk), IsNotNull(d_week_seq), IsNotNull(d_date)]
 ReadSchema: struct<d_date_sk:int,d_date:date,d_week_seq:int,d_year:int>
 
-(214) Filter
+(212) Filter
 Input [4]: [d_date_sk#21, d_date#22, d_week_seq#23, d_year#24]
 Condition : ((((isnotnull(d_year#24) AND (d_year#24 = 1999)) AND isnotnull(d_date_sk#21)) AND isnotnull(d_week_seq#23)) AND isnotnull(d_date#22))
 
-(215) Project
+(213) Project
 Output [3]: [d_date_sk#21, d_date#22, d_week_seq#23]
 Input [4]: [d_date_sk#21, d_date#22, d_week_seq#23, d_year#24]
 
-(216) Exchange
+(214) Exchange
 Input [3]: [d_date_sk#21, d_date#22, d_week_seq#23]
 Arguments: hashpartitioning(d_date_sk#21, 100), ENSURE_REQUIREMENTS, [plan_id=33]
 
-(217) Sort
+(215) Sort
 Input [3]: [d_date_sk#21, d_date#22, d_week_seq#23]
 Arguments: [d_date_sk#21 ASC NULLS FIRST], false, 0
 
-(218) SortMergeJoin
+(216) SortMergeJoin
 Left keys [1]: [cs_sold_date_sk#1]
 Right keys [1]: [d_date_sk#21]
 Join type: Inner
 Join condition: None
 
-(219) Project
+(217) Project
 Output [9]: [cs_ship_date_sk#2, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, inv_date_sk#9, w_warehouse_name#14, i_item_desc#16, d_date#22, d_week_seq#23]
 Input [11]: [cs_sold_date_sk#1, cs_ship_date_sk#2, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, inv_date_sk#9, w_warehouse_name#14, i_item_desc#16, d_date_sk#21, d_date#22, d_week_seq#23]
 
-(220) Exchange
+(218) Exchange
 Input [9]: [cs_ship_date_sk#2, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, inv_date_sk#9, w_warehouse_name#14, i_item_desc#16, d_date#22, d_week_seq#23]
 Arguments: hashpartitioning(d_week_seq#23, inv_date_sk#9, 100), ENSURE_REQUIREMENTS, [plan_id=34]
 
-(221) Sort
+(219) Sort
 Input [9]: [cs_ship_date_sk#2, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, inv_date_sk#9, w_warehouse_name#14, i_item_desc#16, d_date#22, d_week_seq#23]
 Arguments: [d_week_seq#23 ASC NULLS FIRST, inv_date_sk#9 ASC NULLS FIRST], false, 0
 
-(222) Scan parquet
+(220) Scan parquet
 Output [2]: [d_date_sk#25, d_week_seq#26]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(d_week_seq), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_week_seq:int>
 
-(223) Filter
+(221) Filter
 Input [2]: [d_date_sk#25, d_week_seq#26]
 Condition : (isnotnull(d_week_seq#26) AND isnotnull(d_date_sk#25))
 
-(224) Exchange
+(222) Exchange
 Input [2]: [d_date_sk#25, d_week_seq#26]
 Arguments: hashpartitioning(d_week_seq#26, d_date_sk#25, 100), ENSURE_REQUIREMENTS, [plan_id=35]
 
-(225) Sort
+(223) Sort
 Input [2]: [d_date_sk#25, d_week_seq#26]
 Arguments: [d_week_seq#26 ASC NULLS FIRST, d_date_sk#25 ASC NULLS FIRST], false, 0
 
-(226) SortMergeJoin
+(224) SortMergeJoin
 Left keys [2]: [d_week_seq#23, inv_date_sk#9]
 Right keys [2]: [d_week_seq#26, d_date_sk#25]
 Join type: Inner
 Join condition: None
 
-(227) Project
+(225) Project
 Output [8]: [cs_ship_date_sk#2, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, w_warehouse_name#14, i_item_desc#16, d_date#22, d_week_seq#23]
 Input [11]: [cs_ship_date_sk#2, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, inv_date_sk#9, w_warehouse_name#14, i_item_desc#16, d_date#22, d_week_seq#23, d_date_sk#25, d_week_seq#26]
 
-(228) Exchange
+(226) Exchange
 Input [8]: [cs_ship_date_sk#2, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, w_warehouse_name#14, i_item_desc#16, d_date#22, d_week_seq#23]
 Arguments: hashpartitioning(cs_ship_date_sk#2, 100), ENSURE_REQUIREMENTS, [plan_id=36]
 
-(229) Sort
+(227) Sort
 Input [8]: [cs_ship_date_sk#2, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, w_warehouse_name#14, i_item_desc#16, d_date#22, d_week_seq#23]
 Arguments: [cs_ship_date_sk#2 ASC NULLS FIRST], false, 0
 
-(230) Scan parquet
+(228) Scan parquet
 Output [2]: [d_date_sk#27, d_date#28]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(d_date), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date>
 
-(231) Filter
+(229) Filter
 Input [2]: [d_date_sk#27, d_date#28]
 Condition : (isnotnull(d_date#28) AND isnotnull(d_date_sk#27))
 
-(232) Exchange
+(230) Exchange
 Input [2]: [d_date_sk#27, d_date#28]
 Arguments: hashpartitioning(d_date_sk#27, 100), ENSURE_REQUIREMENTS, [plan_id=37]
 
-(233) Sort
+(231) Sort
 Input [2]: [d_date_sk#27, d_date#28]
 Arguments: [d_date_sk#27 ASC NULLS FIRST], false, 0
 
-(234) SortMergeJoin
+(232) SortMergeJoin
 Left keys [1]: [cs_ship_date_sk#2]
 Right keys [1]: [d_date_sk#27]
 Join type: Inner
 Join condition: (d_date#28 > date_add(d_date#22, 5))
 
-(235) Project
+(233) Project
 Output [6]: [cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, w_warehouse_name#14, i_item_desc#16, d_week_seq#23]
 Input [10]: [cs_ship_date_sk#2, cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, w_warehouse_name#14, i_item_desc#16, d_date#22, d_week_seq#23, d_date_sk#27, d_date#28]
 
-(236) Exchange
+(234) Exchange
 Input [6]: [cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, w_warehouse_name#14, i_item_desc#16, d_week_seq#23]
 Arguments: hashpartitioning(cs_promo_sk#6, 100), ENSURE_REQUIREMENTS, [plan_id=38]
 
-(237) Sort
+(235) Sort
 Input [6]: [cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, w_warehouse_name#14, i_item_desc#16, d_week_seq#23]
 Arguments: [cs_promo_sk#6 ASC NULLS FIRST], false, 0
 
-(238) Scan parquet
+(236) Scan parquet
 Output [1]: [p_promo_sk#29]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(p_promo_sk)]
 ReadSchema: struct<p_promo_sk:int>
 
-(239) Filter
+(237) Filter
 Input [1]: [p_promo_sk#29]
 Condition : isnotnull(p_promo_sk#29)
 
-(240) Exchange
+(238) Exchange
 Input [1]: [p_promo_sk#29]
 Arguments: hashpartitioning(p_promo_sk#29, 100), ENSURE_REQUIREMENTS, [plan_id=39]
 
-(241) Sort
+(239) Sort
 Input [1]: [p_promo_sk#29]
 Arguments: [p_promo_sk#29 ASC NULLS FIRST], false, 0
 
-(242) SortMergeJoin
+(240) SortMergeJoin
 Left keys [1]: [cs_promo_sk#6]
 Right keys [1]: [p_promo_sk#29]
 Join type: LeftOuter
 Join condition: None
 
-(243) Project
+(241) Project
 Output [5]: [cs_item_sk#5, cs_order_number#7, w_warehouse_name#14, i_item_desc#16, d_week_seq#23]
 Input [7]: [cs_item_sk#5, cs_promo_sk#6, cs_order_number#7, w_warehouse_name#14, i_item_desc#16, d_week_seq#23, p_promo_sk#29]
 
-(244) Exchange
+(242) Exchange
 Input [5]: [cs_item_sk#5, cs_order_number#7, w_warehouse_name#14, i_item_desc#16, d_week_seq#23]
 Arguments: hashpartitioning(cs_item_sk#5, cs_order_number#7, 100), ENSURE_REQUIREMENTS, [plan_id=40]
 
-(245) Sort
+(243) Sort
 Input [5]: [cs_item_sk#5, cs_order_number#7, w_warehouse_name#14, i_item_desc#16, d_week_seq#23]
 Arguments: [cs_item_sk#5 ASC NULLS FIRST, cs_order_number#7 ASC NULLS FIRST], false, 0
 
-(246) Scan parquet
+(244) Scan parquet
 Output [2]: [cr_item_sk#30, cr_order_number#31]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(cr_item_sk), IsNotNull(cr_order_number)]
 ReadSchema: struct<cr_item_sk:int,cr_order_number:int>
 
-(247) Filter
+(245) Filter
 Input [2]: [cr_item_sk#30, cr_order_number#31]
 Condition : (isnotnull(cr_item_sk#30) AND isnotnull(cr_order_number#31))
 
-(248) Exchange
+(246) Exchange
 Input [2]: [cr_item_sk#30, cr_order_number#31]
 Arguments: hashpartitioning(cr_item_sk#30, cr_order_number#31, 100), ENSURE_REQUIREMENTS, [plan_id=41]
 
-(249) Sort
+(247) Sort
 Input [2]: [cr_item_sk#30, cr_order_number#31]
 Arguments: [cr_item_sk#30 ASC NULLS FIRST, cr_order_number#31 ASC NULLS FIRST], false, 0
 
-(250) SortMergeJoin
+(248) SortMergeJoin
 Left keys [2]: [cs_item_sk#5, cs_order_number#7]
 Right keys [2]: [cr_item_sk#30, cr_order_number#31]
 Join type: LeftOuter
 Join condition: None
 
-(251) Project
+(249) Project
 Output [3]: [w_warehouse_name#14, i_item_desc#16, d_week_seq#23]
 Input [7]: [cs_item_sk#5, cs_order_number#7, w_warehouse_name#14, i_item_desc#16, d_week_seq#23, cr_item_sk#30, cr_order_number#31]
 
-(252) HashAggregate
+(250) HashAggregate
 Input [3]: [w_warehouse_name#14, i_item_desc#16, d_week_seq#23]
 Keys [3]: [i_item_desc#16, w_warehouse_name#14, d_week_seq#23]
 Functions [1]: [partial_count(1)]
 Aggregate Attributes [1]: [count#32]
 Results [4]: [i_item_desc#16, w_warehouse_name#14, d_week_seq#23, count#38]
 
-(253) Exchange
+(251) Exchange
 Input [4]: [i_item_desc#16, w_warehouse_name#14, d_week_seq#23, count#38]
 Arguments: hashpartitioning(i_item_desc#16, w_warehouse_name#14, d_week_seq#23, 100), ENSURE_REQUIREMENTS, [plan_id=42]
 
-(254) HashAggregate
+(252) HashAggregate
 Input [4]: [i_item_desc#16, w_warehouse_name#14, d_week_seq#23, count#38]
 Keys [3]: [i_item_desc#16, w_warehouse_name#14, d_week_seq#23]
 Functions [1]: [count(1)]
 Aggregate Attributes [1]: [count(1)#34]
 Results [6]: [i_item_desc#16, w_warehouse_name#14, d_week_seq#23, count(1)#34 AS no_promo#35, count(1)#34 AS promo#36, count(1)#34 AS total_cnt#37]
 
-(255) TakeOrderedAndProject
+(253) TakeOrderedAndProject
 Input [6]: [i_item_desc#16, w_warehouse_name#14, d_week_seq#23, no_promo#35, promo#36, total_cnt#37]
 Arguments: X, [total_cnt#37 DESC NULLS LAST, i_item_desc#16 ASC NULLS FIRST, w_warehouse_name#14 ASC NULLS FIRST, d_week_seq#23 ASC NULLS FIRST], [i_item_desc#16, w_warehouse_name#14, d_week_seq#23, no_promo#35, promo#36, total_cnt#37]
 
-(256) AdaptiveSparkPlan
+(254) AdaptiveSparkPlan
 Output [6]: [i_item_desc#16, w_warehouse_name#14, d_week_seq#23, no_promo#35, promo#36, total_cnt#37]
 Arguments: isFinalPlan=true
 

--- a/dev/auron-it/src/main/resources/tpcds-plan-stability/spark-3.5/q74.txt
+++ b/dev/auron-it/src/main/resources/tpcds-plan-stability/spark-3.5/q74.txt
@@ -1,9 +1,9 @@
 == Physical Plan ==
 AdaptiveSparkPlan (253)
 +- == Final Plan ==
-   TakeOrderedAndProject (152)
-   +- * Project (151)
-      +- * SortMergeJoin Inner (150)
+   NativeTakeOrdered (152)
+   +- NativeProject (151)
+      +- NativeSortMergeJoin Inner (150)
          :- NativeProject (122)
          :  +- NativeSortMergeJoin Inner (121)
          :     :- NativeSortMergeJoin Inner (77)
@@ -882,19 +882,19 @@ Input [2]: [customer_id#52, year_total#53]
 Input [2]: [customer_id#52, year_total#53]
 Arguments: [customer_id#52 ASC NULLS FIRST], false
 
-(150) SortMergeJoin [codegen id : X]
+(150) NativeSortMergeJoin
 Left keys [1]: [customer_id#14]
 Right keys [1]: [customer_id#52]
 Join type: Inner
 Join condition: (CASE WHEN (year_total#42 > 0.00) THEN (year_total#53 / year_total#42) END > CASE WHEN (year_total#15 > 0.00) THEN (year_total#28 / year_total#15) END)
 
-(151) Project [codegen id : X]
+(151) NativeProject
 Output [3]: [customer_id#25, customer_first_name#26, customer_last_name#27]
 Input [9]: [customer_id#14, year_total#15, customer_id#25, customer_first_name#26, customer_last_name#27, year_total#28, year_total#42, customer_id#52, year_total#53]
 
-(152) TakeOrderedAndProject
+(152) NativeTakeOrdered
 Input [3]: [customer_id#25, customer_first_name#26, customer_last_name#27]
-Arguments: X, [customer_id#25 ASC NULLS FIRST, customer_id#25 ASC NULLS FIRST, customer_id#25 ASC NULLS FIRST], [customer_id#25, customer_first_name#26, customer_last_name#27]
+Arguments: X, X, [customer_id#25 ASC NULLS FIRST, customer_id#25 ASC NULLS FIRST, customer_id#25 ASC NULLS FIRST]
 
 (153) Scan parquet
 Output [4]: [c_customer_sk#1, c_customer_id#2, c_first_name#3, c_last_name#4]

--- a/dev/auron-it/src/main/resources/tpcds-plan-stability/spark-3.5/q75.txt
+++ b/dev/auron-it/src/main/resources/tpcds-plan-stability/spark-3.5/q75.txt
@@ -1,9 +1,9 @@
 == Physical Plan ==
 AdaptiveSparkPlan (455)
 +- == Final Plan ==
-   TakeOrderedAndProject (269)
-   +- * Project (268)
-      +- * SortMergeJoin Inner (267)
+   NativeTakeOrdered (269)
+   +- NativeProject (268)
+      +- NativeSortMergeJoin Inner (267)
          :- NativeSort (160)
          :  +- InputAdapter (159)
          :     +- AQEShuffleRead (158)
@@ -1553,19 +1553,19 @@ Input [7]: [d_year#75, i_brand_id#70, i_class_id#71, i_category_id#72, i_manufac
 Input [7]: [d_year#75, i_brand_id#70, i_class_id#71, i_category_id#72, i_manufact_id#73, sales_cnt#113, sales_amt#114]
 Arguments: [i_brand_id#70 ASC NULLS FIRST, i_class_id#71 ASC NULLS FIRST, i_category_id#72 ASC NULLS FIRST, i_manufact_id#73 ASC NULLS FIRST], false
 
-(267) SortMergeJoin [codegen id : X]
+(267) NativeSortMergeJoin
 Left keys [4]: [i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11]
 Right keys [4]: [i_brand_id#70, i_class_id#71, i_category_id#72, i_manufact_id#73]
 Join type: Inner
 Join condition: ((cast(sales_cnt#63 as decimal(17,2)) / cast(sales_cnt#113 as decimal(17,2))) < 0.90000000000000000000)
 
-(268) Project [codegen id : X]
+(268) NativeProject
 Output [10]: [d_year#75 AS prev_year#115, d_year#13 AS year#116, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#113 AS prev_yr_cnt#117, sales_cnt#63 AS curr_yr_cnt#118, (sales_cnt#63 - sales_cnt#113) AS sales_cnt_diff#119, (sales_amt#64 - sales_amt#114) AS sales_amt_diff#120]
 Input [14]: [d_year#13, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, sales_cnt#63, sales_amt#64, d_year#75, i_brand_id#70, i_class_id#71, i_category_id#72, i_manufact_id#73, sales_cnt#113, sales_amt#114]
 
-(269) TakeOrderedAndProject
+(269) NativeTakeOrdered
 Input [10]: [prev_year#115, year#116, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, prev_yr_cnt#117, curr_yr_cnt#118, sales_cnt_diff#119, sales_amt_diff#120]
-Arguments: X, [sales_cnt_diff#119 ASC NULLS FIRST, sales_amt_diff#120 ASC NULLS FIRST], [prev_year#115, year#116, i_brand_id#7, i_class_id#8, i_category_id#9, i_manufact_id#11, prev_yr_cnt#117, curr_yr_cnt#118, sales_cnt_diff#119, sales_amt_diff#120]
+Arguments: X, X, [sales_cnt_diff#119 ASC NULLS FIRST, sales_amt_diff#120 ASC NULLS FIRST]
 
 (270) Scan parquet
 Output [5]: [cs_sold_date_sk#1, cs_item_sk#2, cs_order_number#3, cs_quantity#4, cs_ext_sales_price#5]

--- a/dev/auron-it/src/main/resources/tpcds-plan-stability/spark-3.5/q81.txt
+++ b/dev/auron-it/src/main/resources/tpcds-plan-stability/spark-3.5/q81.txt
@@ -1,209 +1,208 @@
 == Physical Plan ==
-AdaptiveSparkPlan (200)
+AdaptiveSparkPlan (199)
 +- == Final Plan ==
-   NativeTakeOrdered (128)
-   +- NativeProject (127)
-      +- NativeSortMergeJoin Inner (126)
-         :- NativeSort (117)
-         :  +- InputAdapter (116)
-         :     +- AQEShuffleRead (115)
-         :        +- ShuffleQueryStage (114), Statistics(X)
-         :           +- NativeShuffleExchange (113)
-         :              +- NativeProject (112)
-         :                 +- NativeSortMergeJoin Inner (111)
-         :                    :- NativeSort (102)
-         :                    :  +- InputAdapter (101)
-         :                    :     +- AQEShuffleRead (100)
-         :                    :        +- ShuffleQueryStage (99), Statistics(X)
-         :                    :           +- NativeShuffleExchange (98)
-         :                    :              +- ConvertToNative (97)
-         :                    :                 +- * Project (96)
-         :                    :                    +- * SortMergeJoin Inner (95)
-         :                    :                       :- NativeSort (48)
-         :                    :                       :  +- InputAdapter (47)
-         :                    :                       :     +- AQEShuffleRead (46)
-         :                    :                       :        +- ShuffleQueryStage (45), Statistics(X)
-         :                    :                       :           +- NativeShuffleExchange (44)
-         :                    :                       :              +- NativeFilter (43)
-         :                    :                       :                 +- NativeProject (42)
-         :                    :                       :                    +- NativeHashAggregate (41)
-         :                    :                       :                       +- InputAdapter (40)
-         :                    :                       :                          +- AQEShuffleRead (39)
-         :                    :                       :                             +- ShuffleQueryStage (38), Statistics(X)
-         :                    :                       :                                +- NativeShuffleExchange (37)
-         :                    :                       :                                   +- NativeHashAggregate (36)
-         :                    :                       :                                      +- NativeProject (35)
-         :                    :                       :                                         +- NativeProject (34)
-         :                    :                       :                                            +- NativeSortMergeJoin Inner (33)
-         :                    :                       :                                               :- NativeSort (24)
-         :                    :                       :                                               :  +- InputAdapter (23)
-         :                    :                       :                                               :     +- AQEShuffleRead (22)
-         :                    :                       :                                               :        +- ShuffleQueryStage (21), Statistics(X)
-         :                    :                       :                                               :           +- NativeShuffleExchange (20)
-         :                    :                       :                                               :              +- NativeProject (19)
-         :                    :                       :                                               :                 +- NativeSortMergeJoin Inner (18)
-         :                    :                       :                                               :                    :- NativeSort (8)
-         :                    :                       :                                               :                    :  +- InputAdapter (7)
-         :                    :                       :                                               :                    :     +- AQEShuffleRead (6)
-         :                    :                       :                                               :                    :        +- ShuffleQueryStage (5), Statistics(X)
-         :                    :                       :                                               :                    :           +- NativeShuffleExchange (4)
-         :                    :                       :                                               :                    :              +- NativeFilter (3)
-         :                    :                       :                                               :                    :                 +- InputAdapter (2)
-         :                    :                       :                                               :                    :                    +- NativeParquetScan  (1)
-         :                    :                       :                                               :                    +- NativeSort (17)
-         :                    :                       :                                               :                       +- InputAdapter (16)
-         :                    :                       :                                               :                          +- AQEShuffleRead (15)
-         :                    :                       :                                               :                             +- ShuffleQueryStage (14), Statistics(X)
-         :                    :                       :                                               :                                +- NativeShuffleExchange (13)
-         :                    :                       :                                               :                                   +- NativeProject (12)
-         :                    :                       :                                               :                                      +- NativeFilter (11)
-         :                    :                       :                                               :                                         +- InputAdapter (10)
-         :                    :                       :                                               :                                            +- NativeParquetScan  (9)
-         :                    :                       :                                               +- NativeSort (32)
-         :                    :                       :                                                  +- InputAdapter (31)
-         :                    :                       :                                                     +- AQEShuffleRead (30)
-         :                    :                       :                                                        +- ShuffleQueryStage (29), Statistics(X)
-         :                    :                       :                                                           +- NativeShuffleExchange (28)
-         :                    :                       :                                                              +- NativeFilter (27)
-         :                    :                       :                                                                 +- InputAdapter (26)
-         :                    :                       :                                                                    +- NativeParquetScan  (25)
-         :                    :                       +- NativeSort (94)
-         :                    :                          +- NativeFilter (93)
-         :                    :                             +- NativeProject (92)
-         :                    :                                +- NativeHashAggregate (91)
-         :                    :                                   +- InputAdapter (90)
-         :                    :                                      +- AQEShuffleRead (89)
-         :                    :                                         +- ShuffleQueryStage (88), Statistics(X)
-         :                    :                                            +- NativeShuffleExchange (87)
-         :                    :                                               +- NativeHashAggregate (86)
-         :                    :                                                  +- NativeProject (85)
-         :                    :                                                     +- NativeHashAggregate (84)
-         :                    :                                                        +- InputAdapter (83)
-         :                    :                                                           +- AQEShuffleRead (82)
-         :                    :                                                              +- ShuffleQueryStage (81), Statistics(X)
-         :                    :                                                                 +- NativeShuffleExchange (80)
-         :                    :                                                                    +- NativeHashAggregate (79)
-         :                    :                                                                       +- NativeProject (78)
-         :                    :                                                                          +- NativeProject (77)
-         :                    :                                                                             +- NativeSortMergeJoin Inner (76)
-         :                    :                                                                                :- NativeSort (69)
-         :                    :                                                                                :  +- InputAdapter (68)
-         :                    :                                                                                :     +- AQEShuffleRead (67)
-         :                    :                                                                                :        +- ShuffleQueryStage (66), Statistics(X)
-         :                    :                                                                                :           +- NativeShuffleExchange (65)
-         :                    :                                                                                :              +- NativeProject (64)
-         :                    :                                                                                :                 +- NativeSortMergeJoin Inner (63)
-         :                    :                                                                                :                    :- NativeSort (56)
-         :                    :                                                                                :                    :  +- InputAdapter (55)
-         :                    :                                                                                :                    :     +- AQEShuffleRead (54)
-         :                    :                                                                                :                    :        +- ShuffleQueryStage (53), Statistics(X)
-         :                    :                                                                                :                    :           +- NativeShuffleExchange (52)
-         :                    :                                                                                :                    :              +- NativeFilter (51)
-         :                    :                                                                                :                    :                 +- InputAdapter (50)
-         :                    :                                                                                :                    :                    +- NativeParquetScan  (49)
-         :                    :                                                                                :                    +- NativeSort (62)
-         :                    :                                                                                :                       +- InputAdapter (61)
-         :                    :                                                                                :                          +- InputAdapter (60)
-         :                    :                                                                                :                             +- AQEShuffleRead (59)
-         :                    :                                                                                :                                +- ShuffleQueryStage (58), Statistics(X)
-         :                    :                                                                                :                                   +- ReusedExchange (57)
-         :                    :                                                                                +- NativeSort (75)
-         :                    :                                                                                   +- InputAdapter (74)
-         :                    :                                                                                      +- InputAdapter (73)
-         :                    :                                                                                         +- AQEShuffleRead (72)
-         :                    :                                                                                            +- ShuffleQueryStage (71), Statistics(X)
-         :                    :                                                                                               +- ReusedExchange (70)
-         :                    +- NativeSort (110)
-         :                       +- InputAdapter (109)
-         :                          +- AQEShuffleRead (108)
-         :                             +- ShuffleQueryStage (107), Statistics(X)
-         :                                +- NativeShuffleExchange (106)
-         :                                   +- NativeFilter (105)
-         :                                      +- InputAdapter (104)
-         :                                         +- NativeParquetScan  (103)
-         +- NativeSort (125)
-            +- InputAdapter (124)
-               +- AQEShuffleRead (123)
-                  +- ShuffleQueryStage (122), Statistics(X)
-                     +- NativeShuffleExchange (121)
-                        +- NativeFilter (120)
-                           +- InputAdapter (119)
-                              +- NativeParquetScan  (118)
+   NativeTakeOrdered (127)
+   +- NativeProject (126)
+      +- NativeSortMergeJoin Inner (125)
+         :- NativeSort (116)
+         :  +- InputAdapter (115)
+         :     +- AQEShuffleRead (114)
+         :        +- ShuffleQueryStage (113), Statistics(X)
+         :           +- NativeShuffleExchange (112)
+         :              +- NativeProject (111)
+         :                 +- NativeSortMergeJoin Inner (110)
+         :                    :- NativeSort (101)
+         :                    :  +- InputAdapter (100)
+         :                    :     +- AQEShuffleRead (99)
+         :                    :        +- ShuffleQueryStage (98), Statistics(X)
+         :                    :           +- NativeShuffleExchange (97)
+         :                    :              +- NativeProject (96)
+         :                    :                 +- NativeSortMergeJoin Inner (95)
+         :                    :                    :- NativeSort (48)
+         :                    :                    :  +- InputAdapter (47)
+         :                    :                    :     +- AQEShuffleRead (46)
+         :                    :                    :        +- ShuffleQueryStage (45), Statistics(X)
+         :                    :                    :           +- NativeShuffleExchange (44)
+         :                    :                    :              +- NativeFilter (43)
+         :                    :                    :                 +- NativeProject (42)
+         :                    :                    :                    +- NativeHashAggregate (41)
+         :                    :                    :                       +- InputAdapter (40)
+         :                    :                    :                          +- AQEShuffleRead (39)
+         :                    :                    :                             +- ShuffleQueryStage (38), Statistics(X)
+         :                    :                    :                                +- NativeShuffleExchange (37)
+         :                    :                    :                                   +- NativeHashAggregate (36)
+         :                    :                    :                                      +- NativeProject (35)
+         :                    :                    :                                         +- NativeProject (34)
+         :                    :                    :                                            +- NativeSortMergeJoin Inner (33)
+         :                    :                    :                                               :- NativeSort (24)
+         :                    :                    :                                               :  +- InputAdapter (23)
+         :                    :                    :                                               :     +- AQEShuffleRead (22)
+         :                    :                    :                                               :        +- ShuffleQueryStage (21), Statistics(X)
+         :                    :                    :                                               :           +- NativeShuffleExchange (20)
+         :                    :                    :                                               :              +- NativeProject (19)
+         :                    :                    :                                               :                 +- NativeSortMergeJoin Inner (18)
+         :                    :                    :                                               :                    :- NativeSort (8)
+         :                    :                    :                                               :                    :  +- InputAdapter (7)
+         :                    :                    :                                               :                    :     +- AQEShuffleRead (6)
+         :                    :                    :                                               :                    :        +- ShuffleQueryStage (5), Statistics(X)
+         :                    :                    :                                               :                    :           +- NativeShuffleExchange (4)
+         :                    :                    :                                               :                    :              +- NativeFilter (3)
+         :                    :                    :                                               :                    :                 +- InputAdapter (2)
+         :                    :                    :                                               :                    :                    +- NativeParquetScan  (1)
+         :                    :                    :                                               :                    +- NativeSort (17)
+         :                    :                    :                                               :                       +- InputAdapter (16)
+         :                    :                    :                                               :                          +- AQEShuffleRead (15)
+         :                    :                    :                                               :                             +- ShuffleQueryStage (14), Statistics(X)
+         :                    :                    :                                               :                                +- NativeShuffleExchange (13)
+         :                    :                    :                                               :                                   +- NativeProject (12)
+         :                    :                    :                                               :                                      +- NativeFilter (11)
+         :                    :                    :                                               :                                         +- InputAdapter (10)
+         :                    :                    :                                               :                                            +- NativeParquetScan  (9)
+         :                    :                    :                                               +- NativeSort (32)
+         :                    :                    :                                                  +- InputAdapter (31)
+         :                    :                    :                                                     +- AQEShuffleRead (30)
+         :                    :                    :                                                        +- ShuffleQueryStage (29), Statistics(X)
+         :                    :                    :                                                           +- NativeShuffleExchange (28)
+         :                    :                    :                                                              +- NativeFilter (27)
+         :                    :                    :                                                                 +- InputAdapter (26)
+         :                    :                    :                                                                    +- NativeParquetScan  (25)
+         :                    :                    +- NativeSort (94)
+         :                    :                       +- NativeFilter (93)
+         :                    :                          +- NativeProject (92)
+         :                    :                             +- NativeHashAggregate (91)
+         :                    :                                +- InputAdapter (90)
+         :                    :                                   +- AQEShuffleRead (89)
+         :                    :                                      +- ShuffleQueryStage (88), Statistics(X)
+         :                    :                                         +- NativeShuffleExchange (87)
+         :                    :                                            +- NativeHashAggregate (86)
+         :                    :                                               +- NativeProject (85)
+         :                    :                                                  +- NativeHashAggregate (84)
+         :                    :                                                     +- InputAdapter (83)
+         :                    :                                                        +- AQEShuffleRead (82)
+         :                    :                                                           +- ShuffleQueryStage (81), Statistics(X)
+         :                    :                                                              +- NativeShuffleExchange (80)
+         :                    :                                                                 +- NativeHashAggregate (79)
+         :                    :                                                                    +- NativeProject (78)
+         :                    :                                                                       +- NativeProject (77)
+         :                    :                                                                          +- NativeSortMergeJoin Inner (76)
+         :                    :                                                                             :- NativeSort (69)
+         :                    :                                                                             :  +- InputAdapter (68)
+         :                    :                                                                             :     +- AQEShuffleRead (67)
+         :                    :                                                                             :        +- ShuffleQueryStage (66), Statistics(X)
+         :                    :                                                                             :           +- NativeShuffleExchange (65)
+         :                    :                                                                             :              +- NativeProject (64)
+         :                    :                                                                             :                 +- NativeSortMergeJoin Inner (63)
+         :                    :                                                                             :                    :- NativeSort (56)
+         :                    :                                                                             :                    :  +- InputAdapter (55)
+         :                    :                                                                             :                    :     +- AQEShuffleRead (54)
+         :                    :                                                                             :                    :        +- ShuffleQueryStage (53), Statistics(X)
+         :                    :                                                                             :                    :           +- NativeShuffleExchange (52)
+         :                    :                                                                             :                    :              +- NativeFilter (51)
+         :                    :                                                                             :                    :                 +- InputAdapter (50)
+         :                    :                                                                             :                    :                    +- NativeParquetScan  (49)
+         :                    :                                                                             :                    +- NativeSort (62)
+         :                    :                                                                             :                       +- InputAdapter (61)
+         :                    :                                                                             :                          +- InputAdapter (60)
+         :                    :                                                                             :                             +- AQEShuffleRead (59)
+         :                    :                                                                             :                                +- ShuffleQueryStage (58), Statistics(X)
+         :                    :                                                                             :                                   +- ReusedExchange (57)
+         :                    :                                                                             +- NativeSort (75)
+         :                    :                                                                                +- InputAdapter (74)
+         :                    :                                                                                   +- InputAdapter (73)
+         :                    :                                                                                      +- AQEShuffleRead (72)
+         :                    :                                                                                         +- ShuffleQueryStage (71), Statistics(X)
+         :                    :                                                                                            +- ReusedExchange (70)
+         :                    +- NativeSort (109)
+         :                       +- InputAdapter (108)
+         :                          +- AQEShuffleRead (107)
+         :                             +- ShuffleQueryStage (106), Statistics(X)
+         :                                +- NativeShuffleExchange (105)
+         :                                   +- NativeFilter (104)
+         :                                      +- InputAdapter (103)
+         :                                         +- NativeParquetScan  (102)
+         +- NativeSort (124)
+            +- InputAdapter (123)
+               +- AQEShuffleRead (122)
+                  +- ShuffleQueryStage (121), Statistics(X)
+                     +- NativeShuffleExchange (120)
+                        +- NativeFilter (119)
+                           +- InputAdapter (118)
+                              +- NativeParquetScan  (117)
 +- == Initial Plan ==
-   TakeOrderedAndProject (199)
-   +- Project (198)
-      +- SortMergeJoin Inner (197)
-         :- Sort (192)
-         :  +- Exchange (191)
-         :     +- Project (190)
-         :        +- SortMergeJoin Inner (189)
-         :           :- Sort (184)
-         :           :  +- Exchange (183)
-         :           :     +- Project (182)
-         :           :        +- SortMergeJoin Inner (181)
-         :           :           :- Sort (153)
-         :           :           :  +- Exchange (152)
-         :           :           :     +- Filter (151)
-         :           :           :        +- HashAggregate (150)
-         :           :           :           +- Exchange (149)
-         :           :           :              +- HashAggregate (148)
-         :           :           :                 +- Project (147)
-         :           :           :                    +- SortMergeJoin Inner (146)
-         :           :           :                       :- Sort (141)
-         :           :           :                       :  +- Exchange (140)
-         :           :           :                       :     +- Project (139)
-         :           :           :                       :        +- SortMergeJoin Inner (138)
-         :           :           :                       :           :- Sort (132)
-         :           :           :                       :           :  +- Exchange (131)
-         :           :           :                       :           :     +- Filter (130)
-         :           :           :                       :           :        +- Scan parquet (129)
-         :           :           :                       :           +- Sort (137)
-         :           :           :                       :              +- Exchange (136)
-         :           :           :                       :                 +- Project (135)
-         :           :           :                       :                    +- Filter (134)
-         :           :           :                       :                       +- Scan parquet (133)
-         :           :           :                       +- Sort (145)
-         :           :           :                          +- Exchange (144)
-         :           :           :                             +- Filter (143)
-         :           :           :                                +- Scan parquet (142)
-         :           :           +- Sort (180)
-         :           :              +- Filter (179)
-         :           :                 +- HashAggregate (178)
-         :           :                    +- Exchange (177)
-         :           :                       +- HashAggregate (176)
-         :           :                          +- HashAggregate (175)
-         :           :                             +- Exchange (174)
-         :           :                                +- HashAggregate (173)
-         :           :                                   +- Project (172)
-         :           :                                      +- SortMergeJoin Inner (171)
-         :           :                                         :- Sort (166)
-         :           :                                         :  +- Exchange (165)
-         :           :                                         :     +- Project (164)
-         :           :                                         :        +- SortMergeJoin Inner (163)
-         :           :                                         :           :- Sort (157)
-         :           :                                         :           :  +- Exchange (156)
-         :           :                                         :           :     +- Filter (155)
-         :           :                                         :           :        +- Scan parquet (154)
-         :           :                                         :           +- Sort (162)
-         :           :                                         :              +- Exchange (161)
-         :           :                                         :                 +- Project (160)
-         :           :                                         :                    +- Filter (159)
-         :           :                                         :                       +- Scan parquet (158)
-         :           :                                         +- Sort (170)
-         :           :                                            +- Exchange (169)
-         :           :                                               +- Filter (168)
-         :           :                                                  +- Scan parquet (167)
-         :           +- Sort (188)
-         :              +- Exchange (187)
-         :                 +- Filter (186)
-         :                    +- Scan parquet (185)
-         +- Sort (196)
-            +- Exchange (195)
-               +- Filter (194)
-                  +- Scan parquet (193)
+   TakeOrderedAndProject (198)
+   +- Project (197)
+      +- SortMergeJoin Inner (196)
+         :- Sort (191)
+         :  +- Exchange (190)
+         :     +- Project (189)
+         :        +- SortMergeJoin Inner (188)
+         :           :- Sort (183)
+         :           :  +- Exchange (182)
+         :           :     +- Project (181)
+         :           :        +- SortMergeJoin Inner (180)
+         :           :           :- Sort (152)
+         :           :           :  +- Exchange (151)
+         :           :           :     +- Filter (150)
+         :           :           :        +- HashAggregate (149)
+         :           :           :           +- Exchange (148)
+         :           :           :              +- HashAggregate (147)
+         :           :           :                 +- Project (146)
+         :           :           :                    +- SortMergeJoin Inner (145)
+         :           :           :                       :- Sort (140)
+         :           :           :                       :  +- Exchange (139)
+         :           :           :                       :     +- Project (138)
+         :           :           :                       :        +- SortMergeJoin Inner (137)
+         :           :           :                       :           :- Sort (131)
+         :           :           :                       :           :  +- Exchange (130)
+         :           :           :                       :           :     +- Filter (129)
+         :           :           :                       :           :        +- Scan parquet (128)
+         :           :           :                       :           +- Sort (136)
+         :           :           :                       :              +- Exchange (135)
+         :           :           :                       :                 +- Project (134)
+         :           :           :                       :                    +- Filter (133)
+         :           :           :                       :                       +- Scan parquet (132)
+         :           :           :                       +- Sort (144)
+         :           :           :                          +- Exchange (143)
+         :           :           :                             +- Filter (142)
+         :           :           :                                +- Scan parquet (141)
+         :           :           +- Sort (179)
+         :           :              +- Filter (178)
+         :           :                 +- HashAggregate (177)
+         :           :                    +- Exchange (176)
+         :           :                       +- HashAggregate (175)
+         :           :                          +- HashAggregate (174)
+         :           :                             +- Exchange (173)
+         :           :                                +- HashAggregate (172)
+         :           :                                   +- Project (171)
+         :           :                                      +- SortMergeJoin Inner (170)
+         :           :                                         :- Sort (165)
+         :           :                                         :  +- Exchange (164)
+         :           :                                         :     +- Project (163)
+         :           :                                         :        +- SortMergeJoin Inner (162)
+         :           :                                         :           :- Sort (156)
+         :           :                                         :           :  +- Exchange (155)
+         :           :                                         :           :     +- Filter (154)
+         :           :                                         :           :        +- Scan parquet (153)
+         :           :                                         :           +- Sort (161)
+         :           :                                         :              +- Exchange (160)
+         :           :                                         :                 +- Project (159)
+         :           :                                         :                    +- Filter (158)
+         :           :                                         :                       +- Scan parquet (157)
+         :           :                                         +- Sort (169)
+         :           :                                            +- Exchange (168)
+         :           :                                               +- Filter (167)
+         :           :                                                  +- Scan parquet (166)
+         :           +- Sort (187)
+         :              +- Exchange (186)
+         :                 +- Filter (185)
+         :                    +- Scan parquet (184)
+         +- Sort (195)
+            +- Exchange (194)
+               +- Filter (193)
+                  +- Scan parquet (192)
 
 
-(129) Scan parquet
+(128) Scan parquet
 Output [4]: [cr_returned_date_sk#1, cr_returning_customer_sk#2, cr_returning_addr_sk#3, cr_return_amt_inc_tax#4]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
@@ -237,7 +236,7 @@ Input [4]: [#1#1, #2#2, #3#3, #4#4]
 Input [4]: [#1#1, #2#2, #3#3, #4#4]
 Arguments: [cr_returned_date_sk#1 ASC NULLS FIRST], false
 
-(133) Scan parquet
+(132) Scan parquet
 Output [2]: [d_date_sk#5, d_year#6]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
@@ -304,7 +303,7 @@ Input [3]: [cr_returning_customer_sk#2, cr_returning_addr_sk#3, cr_return_amt_in
 Input [3]: [cr_returning_customer_sk#2, cr_returning_addr_sk#3, cr_return_amt_inc_tax#4]
 Arguments: [cr_returning_addr_sk#3 ASC NULLS FIRST], false
 
-(142) Scan parquet
+(141) Scan parquet
 Output [2]: [ca_address_sk#7, ca_state#8]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
@@ -408,7 +407,7 @@ Input [3]: [ctr_customer_sk#13, ctr_state#14, ctr_total_return#15]
 Input [3]: [ctr_customer_sk#13, ctr_state#14, ctr_total_return#15]
 Arguments: [ctr_state#14 ASC NULLS FIRST], false
 
-(154) Scan parquet
+(153) Scan parquet
 Output [4]: [cr_returned_date_sk#16, cr_returning_customer_sk#17, cr_returning_addr_sk#18, cr_return_amt_inc_tax#19]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
@@ -603,490 +602,487 @@ Condition : isnotnull((avg(ctr_total_return) * 1.2)#31)
 Input [2]: [(avg(ctr_total_return) * 1.2)#31, ctr_state#25]
 Arguments: [ctr_state#25 ASC NULLS FIRST], false
 
-(95) SortMergeJoin [codegen id : X]
+(95) NativeSortMergeJoin
 Left keys [1]: [ctr_state#14]
 Right keys [1]: [ctr_state#25]
 Join type: Inner
 Join condition: (cast(ctr_total_return#15 as decimal(24,7)) > (avg(ctr_total_return) * 1.2)#31)
 
-(96) Project [codegen id : X]
+(96) NativeProject
 Output [2]: [ctr_customer_sk#13, ctr_total_return#15]
 Input [5]: [ctr_customer_sk#13, ctr_state#14, ctr_total_return#15, (avg(ctr_total_return) * 1.2)#31, ctr_state#25]
 
-(97) ConvertToNative
-Input [2]: [ctr_customer_sk#13, ctr_total_return#15]
-
-(98) NativeShuffleExchange
+(97) NativeShuffleExchange
 Input [2]: [ctr_customer_sk#13, ctr_total_return#15]
 Arguments: hashpartitioning(ctr_customer_sk#13, 100), ENSURE_REQUIREMENTS, [plan_id=11]
 
-(99) ShuffleQueryStage
+(98) ShuffleQueryStage
 Output [2]: [ctr_customer_sk#13, ctr_total_return#15]
 Arguments: X
 
-(100) AQEShuffleRead
+(99) AQEShuffleRead
 Input [2]: [ctr_customer_sk#13, ctr_total_return#15]
 Arguments: coalesced
 
-(101) InputAdapter
+(100) InputAdapter
 Input [2]: [ctr_customer_sk#13, ctr_total_return#15]
 
-(102) NativeSort
+(101) NativeSort
 Input [2]: [ctr_customer_sk#13, ctr_total_return#15]
 Arguments: [ctr_customer_sk#13 ASC NULLS FIRST], false
 
-(185) Scan parquet
+(184) Scan parquet
 Output [6]: [c_customer_sk#32, c_customer_id#33, c_current_addr_sk#34, c_salutation#35, c_first_name#36, c_last_name#37]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_current_addr_sk)]
 ReadSchema: struct<c_customer_sk:int,c_customer_id:string,c_current_addr_sk:int,c_salutation:string,c_first_name:string,c_last_name:string>
 
-(104) InputAdapter
+(103) InputAdapter
 Input [6]: [c_customer_sk#32, c_customer_id#33, c_current_addr_sk#34, c_salutation#35, c_first_name#36, c_last_name#37]
 Arguments: [#32, #33, #34, #35, #36, #37]
 
-(105) NativeFilter
+(104) NativeFilter
 Input [6]: [#32#32, #33#33, #34#34, #35#35, #36#36, #37#37]
 Condition : (isnotnull(c_customer_sk#32) AND isnotnull(c_current_addr_sk#34))
 
-(106) NativeShuffleExchange
+(105) NativeShuffleExchange
 Input [6]: [#32#32, #33#33, #34#34, #35#35, #36#36, #37#37]
 Arguments: hashpartitioning(c_customer_sk#32, 100), ENSURE_REQUIREMENTS, [plan_id=12]
 
-(107) ShuffleQueryStage
+(106) ShuffleQueryStage
 Output [6]: [#32#32, #33#33, #34#34, #35#35, #36#36, #37#37]
 Arguments: X
 
-(108) AQEShuffleRead
+(107) AQEShuffleRead
 Input [6]: [#32#32, #33#33, #34#34, #35#35, #36#36, #37#37]
 Arguments: coalesced
 
-(109) InputAdapter
+(108) InputAdapter
 Input [6]: [#32#32, #33#33, #34#34, #35#35, #36#36, #37#37]
 
-(110) NativeSort
+(109) NativeSort
 Input [6]: [#32#32, #33#33, #34#34, #35#35, #36#36, #37#37]
 Arguments: [c_customer_sk#32 ASC NULLS FIRST], false
 
-(111) NativeSortMergeJoin
+(110) NativeSortMergeJoin
 Left keys [1]: [ctr_customer_sk#13]
 Right keys [1]: [c_customer_sk#32]
 Join type: Inner
 Join condition: None
 
-(112) NativeProject
+(111) NativeProject
 Output [6]: [ctr_total_return#15, c_customer_id#33, c_current_addr_sk#34, c_salutation#35, c_first_name#36, c_last_name#37]
 Input [8]: [ctr_customer_sk#13, ctr_total_return#15, #32#32, #33#33, #34#34, #35#35, #36#36, #37#37]
 
-(113) NativeShuffleExchange
+(112) NativeShuffleExchange
 Input [6]: [ctr_total_return#15, c_customer_id#33, c_current_addr_sk#34, c_salutation#35, c_first_name#36, c_last_name#37]
 Arguments: hashpartitioning(c_current_addr_sk#34, 100), ENSURE_REQUIREMENTS, [plan_id=13]
 
-(114) ShuffleQueryStage
+(113) ShuffleQueryStage
 Output [6]: [ctr_total_return#15, c_customer_id#33, c_current_addr_sk#34, c_salutation#35, c_first_name#36, c_last_name#37]
 Arguments: X
 
-(115) AQEShuffleRead
+(114) AQEShuffleRead
 Input [6]: [ctr_total_return#15, c_customer_id#33, c_current_addr_sk#34, c_salutation#35, c_first_name#36, c_last_name#37]
 Arguments: coalesced
 
-(116) InputAdapter
+(115) InputAdapter
 Input [6]: [ctr_total_return#15, c_customer_id#33, c_current_addr_sk#34, c_salutation#35, c_first_name#36, c_last_name#37]
 
-(117) NativeSort
+(116) NativeSort
 Input [6]: [ctr_total_return#15, c_customer_id#33, c_current_addr_sk#34, c_salutation#35, c_first_name#36, c_last_name#37]
 Arguments: [c_current_addr_sk#34 ASC NULLS FIRST], false
 
-(193) Scan parquet
+(192) Scan parquet
 Output [12]: [ca_address_sk#38, ca_street_number#39, ca_street_name#40, ca_street_type#41, ca_suite_number#42, ca_city#43, ca_county#44, ca_state#45, ca_zip#46, ca_country#47, ca_gmt_offset#48, ca_location_type#49]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(ca_state), EqualTo(ca_state,GA), IsNotNull(ca_address_sk)]
 ReadSchema: struct<ca_address_sk:int,ca_street_number:string,ca_street_name:string,ca_street_type:string,ca_suite_number:string,ca_city:string,ca_county:string,ca_state:string,ca_zip:string,ca_country:string,ca_gmt_offset:decimal(5,2),ca_location_type:string>
 
-(119) InputAdapter
+(118) InputAdapter
 Input [12]: [ca_address_sk#38, ca_street_number#39, ca_street_name#40, ca_street_type#41, ca_suite_number#42, ca_city#43, ca_county#44, ca_state#45, ca_zip#46, ca_country#47, ca_gmt_offset#48, ca_location_type#49]
 Arguments: [#38, #39, #40, #41, #42, #43, #44, #45, #46, #47, #48, #49]
 
-(120) NativeFilter
+(119) NativeFilter
 Input [12]: [#38#38, #39#39, #40#40, #41#41, #42#42, #43#43, #44#44, #45#45, #46#46, #47#47, #48#48, #49#49]
 Condition : ((isnotnull(ca_state#45) AND (ca_state#45 = GA)) AND isnotnull(ca_address_sk#38))
 
-(121) NativeShuffleExchange
+(120) NativeShuffleExchange
 Input [12]: [#38#38, #39#39, #40#40, #41#41, #42#42, #43#43, #44#44, #45#45, #46#46, #47#47, #48#48, #49#49]
 Arguments: hashpartitioning(ca_address_sk#38, 100), ENSURE_REQUIREMENTS, [plan_id=14]
 
-(122) ShuffleQueryStage
+(121) ShuffleQueryStage
 Output [12]: [#38#38, #39#39, #40#40, #41#41, #42#42, #43#43, #44#44, #45#45, #46#46, #47#47, #48#48, #49#49]
 Arguments: X
 
-(123) AQEShuffleRead
+(122) AQEShuffleRead
 Input [12]: [#38#38, #39#39, #40#40, #41#41, #42#42, #43#43, #44#44, #45#45, #46#46, #47#47, #48#48, #49#49]
 Arguments: coalesced
 
-(124) InputAdapter
+(123) InputAdapter
 Input [12]: [#38#38, #39#39, #40#40, #41#41, #42#42, #43#43, #44#44, #45#45, #46#46, #47#47, #48#48, #49#49]
 
-(125) NativeSort
+(124) NativeSort
 Input [12]: [#38#38, #39#39, #40#40, #41#41, #42#42, #43#43, #44#44, #45#45, #46#46, #47#47, #48#48, #49#49]
 Arguments: [ca_address_sk#38 ASC NULLS FIRST], false
 
-(126) NativeSortMergeJoin
+(125) NativeSortMergeJoin
 Left keys [1]: [c_current_addr_sk#34]
 Right keys [1]: [ca_address_sk#38]
 Join type: Inner
 Join condition: None
 
-(127) NativeProject
+(126) NativeProject
 Output [16]: [c_customer_id#33, c_salutation#35, c_first_name#36, c_last_name#37, ca_street_number#39, ca_street_name#40, ca_street_type#41, ca_suite_number#42, ca_city#43, ca_county#44, ca_state#45, ca_zip#46, ca_country#47, ca_gmt_offset#48, ca_location_type#49, ctr_total_return#15]
 Input [18]: [ctr_total_return#15, c_customer_id#33, c_current_addr_sk#34, c_salutation#35, c_first_name#36, c_last_name#37, #38#38, #39#39, #40#40, #41#41, #42#42, #43#43, #44#44, #45#45, #46#46, #47#47, #48#48, #49#49]
 
-(128) NativeTakeOrdered
+(127) NativeTakeOrdered
 Input [16]: [c_customer_id#33, c_salutation#35, c_first_name#36, c_last_name#37, ca_street_number#39, ca_street_name#40, ca_street_type#41, ca_suite_number#42, ca_city#43, ca_county#44, ca_state#45, ca_zip#46, ca_country#47, ca_gmt_offset#48, ca_location_type#49, ctr_total_return#15]
 Arguments: X, X, [c_customer_id#33 ASC NULLS FIRST, c_salutation#35 ASC NULLS FIRST, c_first_name#36 ASC NULLS FIRST, c_last_name#37 ASC NULLS FIRST, ca_street_number#39 ASC NULLS FIRST, ca_street_name#40 ASC NULLS FIRST, ca_street_type#41 ASC NULLS FIRST, ca_suite_number#42 ASC NULLS FIRST, ca_city#43 ASC NULLS FIRST, ca_county#44 ASC NULLS FIRST, ca_state#45 ASC NULLS FIRST, ca_zip#46 ASC NULLS FIRST, ca_country#47 ASC NULLS FIRST, ca_gmt_offset#48 ASC NULLS FIRST, ca_location_type#49 ASC NULLS FIRST, ctr_total_return#15 ASC NULLS FIRST]
 
-(129) Scan parquet
+(128) Scan parquet
 Output [4]: [cr_returned_date_sk#1, cr_returning_customer_sk#2, cr_returning_addr_sk#3, cr_return_amt_inc_tax#4]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(cr_returned_date_sk), IsNotNull(cr_returning_addr_sk), IsNotNull(cr_returning_customer_sk)]
 ReadSchema: struct<cr_returned_date_sk:int,cr_returning_customer_sk:int,cr_returning_addr_sk:int,cr_return_amt_inc_tax:decimal(7,2)>
 
-(130) Filter
+(129) Filter
 Input [4]: [cr_returned_date_sk#1, cr_returning_customer_sk#2, cr_returning_addr_sk#3, cr_return_amt_inc_tax#4]
 Condition : ((isnotnull(cr_returned_date_sk#1) AND isnotnull(cr_returning_addr_sk#3)) AND isnotnull(cr_returning_customer_sk#2))
 
-(131) Exchange
+(130) Exchange
 Input [4]: [cr_returned_date_sk#1, cr_returning_customer_sk#2, cr_returning_addr_sk#3, cr_return_amt_inc_tax#4]
 Arguments: hashpartitioning(cr_returned_date_sk#1, 100), ENSURE_REQUIREMENTS, [plan_id=15]
 
-(132) Sort
+(131) Sort
 Input [4]: [cr_returned_date_sk#1, cr_returning_customer_sk#2, cr_returning_addr_sk#3, cr_return_amt_inc_tax#4]
 Arguments: [cr_returned_date_sk#1 ASC NULLS FIRST], false, 0
 
-(133) Scan parquet
+(132) Scan parquet
 Output [2]: [d_date_sk#5, d_year#6]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2000), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
-(134) Filter
+(133) Filter
 Input [2]: [d_date_sk#5, d_year#6]
 Condition : ((isnotnull(d_year#6) AND (d_year#6 = 2000)) AND isnotnull(d_date_sk#5))
 
-(135) Project
+(134) Project
 Output [1]: [d_date_sk#5]
 Input [2]: [d_date_sk#5, d_year#6]
 
-(136) Exchange
+(135) Exchange
 Input [1]: [d_date_sk#5]
 Arguments: hashpartitioning(d_date_sk#5, 100), ENSURE_REQUIREMENTS, [plan_id=16]
 
-(137) Sort
+(136) Sort
 Input [1]: [d_date_sk#5]
 Arguments: [d_date_sk#5 ASC NULLS FIRST], false, 0
 
-(138) SortMergeJoin
+(137) SortMergeJoin
 Left keys [1]: [cr_returned_date_sk#1]
 Right keys [1]: [d_date_sk#5]
 Join type: Inner
 Join condition: None
 
-(139) Project
+(138) Project
 Output [3]: [cr_returning_customer_sk#2, cr_returning_addr_sk#3, cr_return_amt_inc_tax#4]
 Input [5]: [cr_returned_date_sk#1, cr_returning_customer_sk#2, cr_returning_addr_sk#3, cr_return_amt_inc_tax#4, d_date_sk#5]
 
-(140) Exchange
+(139) Exchange
 Input [3]: [cr_returning_customer_sk#2, cr_returning_addr_sk#3, cr_return_amt_inc_tax#4]
 Arguments: hashpartitioning(cr_returning_addr_sk#3, 100), ENSURE_REQUIREMENTS, [plan_id=17]
 
-(141) Sort
+(140) Sort
 Input [3]: [cr_returning_customer_sk#2, cr_returning_addr_sk#3, cr_return_amt_inc_tax#4]
 Arguments: [cr_returning_addr_sk#3 ASC NULLS FIRST], false, 0
 
-(142) Scan parquet
+(141) Scan parquet
 Output [2]: [ca_address_sk#7, ca_state#8]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(ca_address_sk), IsNotNull(ca_state)]
 ReadSchema: struct<ca_address_sk:int,ca_state:string>
 
-(143) Filter
+(142) Filter
 Input [2]: [ca_address_sk#7, ca_state#8]
 Condition : (isnotnull(ca_address_sk#7) AND isnotnull(ca_state#8))
 
-(144) Exchange
+(143) Exchange
 Input [2]: [ca_address_sk#7, ca_state#8]
 Arguments: hashpartitioning(ca_address_sk#7, 100), ENSURE_REQUIREMENTS, [plan_id=18]
 
-(145) Sort
+(144) Sort
 Input [2]: [ca_address_sk#7, ca_state#8]
 Arguments: [ca_address_sk#7 ASC NULLS FIRST], false, 0
 
-(146) SortMergeJoin
+(145) SortMergeJoin
 Left keys [1]: [cr_returning_addr_sk#3]
 Right keys [1]: [ca_address_sk#7]
 Join type: Inner
 Join condition: None
 
-(147) Project
+(146) Project
 Output [3]: [cr_returning_customer_sk#2, cr_return_amt_inc_tax#4, ca_state#8]
 Input [5]: [cr_returning_customer_sk#2, cr_returning_addr_sk#3, cr_return_amt_inc_tax#4, ca_address_sk#7, ca_state#8]
 
-(148) HashAggregate
+(147) HashAggregate
 Input [3]: [cr_returning_customer_sk#2, cr_return_amt_inc_tax#4, ca_state#8]
 Keys [2]: [cr_returning_customer_sk#2, ca_state#8]
 Functions [1]: [partial_sum(UnscaledValue(cr_return_amt_inc_tax#4))]
 Aggregate Attributes [1]: [sum#10]
 Results [3]: [cr_returning_customer_sk#2, ca_state#8, sum#50]
 
-(149) Exchange
+(148) Exchange
 Input [3]: [cr_returning_customer_sk#2, ca_state#8, sum#50]
 Arguments: hashpartitioning(cr_returning_customer_sk#2, ca_state#8, 100), ENSURE_REQUIREMENTS, [plan_id=19]
 
-(150) HashAggregate
+(149) HashAggregate
 Input [3]: [cr_returning_customer_sk#2, ca_state#8, sum#50]
 Keys [2]: [cr_returning_customer_sk#2, ca_state#8]
 Functions [1]: [sum(UnscaledValue(cr_return_amt_inc_tax#4))]
 Aggregate Attributes [1]: [sum(UnscaledValue(cr_return_amt_inc_tax#4))#12]
 Results [3]: [cr_returning_customer_sk#2 AS ctr_customer_sk#13, ca_state#8 AS ctr_state#14, MakeDecimal(sum(UnscaledValue(cr_return_amt_inc_tax#4))#12,17,2) AS ctr_total_return#15]
 
-(151) Filter
+(150) Filter
 Input [3]: [ctr_customer_sk#13, ctr_state#14, ctr_total_return#15]
 Condition : isnotnull(ctr_total_return#15)
 
-(152) Exchange
+(151) Exchange
 Input [3]: [ctr_customer_sk#13, ctr_state#14, ctr_total_return#15]
 Arguments: hashpartitioning(ctr_state#14, 100), ENSURE_REQUIREMENTS, [plan_id=20]
 
-(153) Sort
+(152) Sort
 Input [3]: [ctr_customer_sk#13, ctr_state#14, ctr_total_return#15]
 Arguments: [ctr_state#14 ASC NULLS FIRST], false, 0
 
-(154) Scan parquet
+(153) Scan parquet
 Output [4]: [cr_returned_date_sk#16, cr_returning_customer_sk#17, cr_returning_addr_sk#18, cr_return_amt_inc_tax#19]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(cr_returned_date_sk), IsNotNull(cr_returning_addr_sk)]
 ReadSchema: struct<cr_returned_date_sk:int,cr_returning_customer_sk:int,cr_returning_addr_sk:int,cr_return_amt_inc_tax:decimal(7,2)>
 
-(155) Filter
+(154) Filter
 Input [4]: [cr_returned_date_sk#16, cr_returning_customer_sk#17, cr_returning_addr_sk#18, cr_return_amt_inc_tax#19]
 Condition : (isnotnull(cr_returned_date_sk#16) AND isnotnull(cr_returning_addr_sk#18))
 
-(156) Exchange
+(155) Exchange
 Input [4]: [cr_returned_date_sk#16, cr_returning_customer_sk#17, cr_returning_addr_sk#18, cr_return_amt_inc_tax#19]
 Arguments: hashpartitioning(cr_returned_date_sk#16, 100), ENSURE_REQUIREMENTS, [plan_id=21]
 
-(157) Sort
+(156) Sort
 Input [4]: [cr_returned_date_sk#16, cr_returning_customer_sk#17, cr_returning_addr_sk#18, cr_return_amt_inc_tax#19]
 Arguments: [cr_returned_date_sk#16 ASC NULLS FIRST], false, 0
 
-(158) Scan parquet
+(157) Scan parquet
 Output [2]: [d_date_sk#20, d_year#51]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2000), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
-(159) Filter
+(158) Filter
 Input [2]: [d_date_sk#20, d_year#51]
 Condition : ((isnotnull(d_year#51) AND (d_year#51 = 2000)) AND isnotnull(d_date_sk#20))
 
-(160) Project
+(159) Project
 Output [1]: [d_date_sk#20]
 Input [2]: [d_date_sk#20, d_year#51]
 
-(161) Exchange
+(160) Exchange
 Input [1]: [d_date_sk#20]
 Arguments: hashpartitioning(d_date_sk#20, 100), ENSURE_REQUIREMENTS, [plan_id=22]
 
-(162) Sort
+(161) Sort
 Input [1]: [d_date_sk#20]
 Arguments: [d_date_sk#20 ASC NULLS FIRST], false, 0
 
-(163) SortMergeJoin
+(162) SortMergeJoin
 Left keys [1]: [cr_returned_date_sk#16]
 Right keys [1]: [d_date_sk#20]
 Join type: Inner
 Join condition: None
 
-(164) Project
+(163) Project
 Output [3]: [cr_returning_customer_sk#17, cr_returning_addr_sk#18, cr_return_amt_inc_tax#19]
 Input [5]: [cr_returned_date_sk#16, cr_returning_customer_sk#17, cr_returning_addr_sk#18, cr_return_amt_inc_tax#19, d_date_sk#20]
 
-(165) Exchange
+(164) Exchange
 Input [3]: [cr_returning_customer_sk#17, cr_returning_addr_sk#18, cr_return_amt_inc_tax#19]
 Arguments: hashpartitioning(cr_returning_addr_sk#18, 100), ENSURE_REQUIREMENTS, [plan_id=23]
 
-(166) Sort
+(165) Sort
 Input [3]: [cr_returning_customer_sk#17, cr_returning_addr_sk#18, cr_return_amt_inc_tax#19]
 Arguments: [cr_returning_addr_sk#18 ASC NULLS FIRST], false, 0
 
-(167) Scan parquet
+(166) Scan parquet
 Output [2]: [ca_address_sk#21, ca_state#22]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(ca_address_sk), IsNotNull(ca_state)]
 ReadSchema: struct<ca_address_sk:int,ca_state:string>
 
-(168) Filter
+(167) Filter
 Input [2]: [ca_address_sk#21, ca_state#22]
 Condition : (isnotnull(ca_address_sk#21) AND isnotnull(ca_state#22))
 
-(169) Exchange
+(168) Exchange
 Input [2]: [ca_address_sk#21, ca_state#22]
 Arguments: hashpartitioning(ca_address_sk#21, 100), ENSURE_REQUIREMENTS, [plan_id=24]
 
-(170) Sort
+(169) Sort
 Input [2]: [ca_address_sk#21, ca_state#22]
 Arguments: [ca_address_sk#21 ASC NULLS FIRST], false, 0
 
-(171) SortMergeJoin
+(170) SortMergeJoin
 Left keys [1]: [cr_returning_addr_sk#18]
 Right keys [1]: [ca_address_sk#21]
 Join type: Inner
 Join condition: None
 
-(172) Project
+(171) Project
 Output [3]: [cr_returning_customer_sk#17, cr_return_amt_inc_tax#19, ca_state#22]
 Input [5]: [cr_returning_customer_sk#17, cr_returning_addr_sk#18, cr_return_amt_inc_tax#19, ca_address_sk#21, ca_state#22]
 
-(173) HashAggregate
+(172) HashAggregate
 Input [3]: [cr_returning_customer_sk#17, cr_return_amt_inc_tax#19, ca_state#22]
 Keys [2]: [cr_returning_customer_sk#17, ca_state#22]
 Functions [1]: [partial_sum(UnscaledValue(cr_return_amt_inc_tax#19))]
 Aggregate Attributes [1]: [sum#24]
 Results [3]: [cr_returning_customer_sk#17, ca_state#22, sum#52]
 
-(174) Exchange
+(173) Exchange
 Input [3]: [cr_returning_customer_sk#17, ca_state#22, sum#52]
 Arguments: hashpartitioning(cr_returning_customer_sk#17, ca_state#22, 100), ENSURE_REQUIREMENTS, [plan_id=25]
 
-(175) HashAggregate
+(174) HashAggregate
 Input [3]: [cr_returning_customer_sk#17, ca_state#22, sum#52]
 Keys [2]: [cr_returning_customer_sk#17, ca_state#22]
 Functions [1]: [sum(UnscaledValue(cr_return_amt_inc_tax#19))]
 Aggregate Attributes [1]: [sum(UnscaledValue(cr_return_amt_inc_tax#19))#12]
 Results [2]: [ca_state#22 AS ctr_state#25, MakeDecimal(sum(UnscaledValue(cr_return_amt_inc_tax#19))#12,17,2) AS ctr_total_return#26]
 
-(176) HashAggregate
+(175) HashAggregate
 Input [2]: [ctr_state#25, ctr_total_return#26]
 Keys [1]: [ctr_state#25]
 Functions [1]: [partial_avg(ctr_total_return#26)]
 Aggregate Attributes [2]: [sum#27, count#28]
 Results [3]: [ctr_state#25, sum#53, count#54]
 
-(177) Exchange
+(176) Exchange
 Input [3]: [ctr_state#25, sum#53, count#54]
 Arguments: hashpartitioning(ctr_state#25, 100), ENSURE_REQUIREMENTS, [plan_id=26]
 
-(178) HashAggregate
+(177) HashAggregate
 Input [3]: [ctr_state#25, sum#53, count#54]
 Keys [1]: [ctr_state#25]
 Functions [1]: [avg(ctr_total_return#26)]
 Aggregate Attributes [1]: [avg(ctr_total_return#26)#30]
 Results [2]: [(avg(ctr_total_return#26)#30 * 1.2) AS (avg(ctr_total_return) * 1.2)#31, ctr_state#25]
 
-(179) Filter
+(178) Filter
 Input [2]: [(avg(ctr_total_return) * 1.2)#31, ctr_state#25]
 Condition : isnotnull((avg(ctr_total_return) * 1.2)#31)
 
-(180) Sort
+(179) Sort
 Input [2]: [(avg(ctr_total_return) * 1.2)#31, ctr_state#25]
 Arguments: [ctr_state#25 ASC NULLS FIRST], false, 0
 
-(181) SortMergeJoin
+(180) SortMergeJoin
 Left keys [1]: [ctr_state#14]
 Right keys [1]: [ctr_state#25]
 Join type: Inner
 Join condition: (cast(ctr_total_return#15 as decimal(24,7)) > (avg(ctr_total_return) * 1.2)#31)
 
-(182) Project
+(181) Project
 Output [2]: [ctr_customer_sk#13, ctr_total_return#15]
 Input [5]: [ctr_customer_sk#13, ctr_state#14, ctr_total_return#15, (avg(ctr_total_return) * 1.2)#31, ctr_state#25]
 
-(183) Exchange
+(182) Exchange
 Input [2]: [ctr_customer_sk#13, ctr_total_return#15]
 Arguments: hashpartitioning(ctr_customer_sk#13, 100), ENSURE_REQUIREMENTS, [plan_id=27]
 
-(184) Sort
+(183) Sort
 Input [2]: [ctr_customer_sk#13, ctr_total_return#15]
 Arguments: [ctr_customer_sk#13 ASC NULLS FIRST], false, 0
 
-(185) Scan parquet
+(184) Scan parquet
 Output [6]: [c_customer_sk#32, c_customer_id#33, c_current_addr_sk#34, c_salutation#35, c_first_name#36, c_last_name#37]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_current_addr_sk)]
 ReadSchema: struct<c_customer_sk:int,c_customer_id:string,c_current_addr_sk:int,c_salutation:string,c_first_name:string,c_last_name:string>
 
-(186) Filter
+(185) Filter
 Input [6]: [c_customer_sk#32, c_customer_id#33, c_current_addr_sk#34, c_salutation#35, c_first_name#36, c_last_name#37]
 Condition : (isnotnull(c_customer_sk#32) AND isnotnull(c_current_addr_sk#34))
 
-(187) Exchange
+(186) Exchange
 Input [6]: [c_customer_sk#32, c_customer_id#33, c_current_addr_sk#34, c_salutation#35, c_first_name#36, c_last_name#37]
 Arguments: hashpartitioning(c_customer_sk#32, 100), ENSURE_REQUIREMENTS, [plan_id=28]
 
-(188) Sort
+(187) Sort
 Input [6]: [c_customer_sk#32, c_customer_id#33, c_current_addr_sk#34, c_salutation#35, c_first_name#36, c_last_name#37]
 Arguments: [c_customer_sk#32 ASC NULLS FIRST], false, 0
 
-(189) SortMergeJoin
+(188) SortMergeJoin
 Left keys [1]: [ctr_customer_sk#13]
 Right keys [1]: [c_customer_sk#32]
 Join type: Inner
 Join condition: None
 
-(190) Project
+(189) Project
 Output [6]: [ctr_total_return#15, c_customer_id#33, c_current_addr_sk#34, c_salutation#35, c_first_name#36, c_last_name#37]
 Input [8]: [ctr_customer_sk#13, ctr_total_return#15, c_customer_sk#32, c_customer_id#33, c_current_addr_sk#34, c_salutation#35, c_first_name#36, c_last_name#37]
 
-(191) Exchange
+(190) Exchange
 Input [6]: [ctr_total_return#15, c_customer_id#33, c_current_addr_sk#34, c_salutation#35, c_first_name#36, c_last_name#37]
 Arguments: hashpartitioning(c_current_addr_sk#34, 100), ENSURE_REQUIREMENTS, [plan_id=29]
 
-(192) Sort
+(191) Sort
 Input [6]: [ctr_total_return#15, c_customer_id#33, c_current_addr_sk#34, c_salutation#35, c_first_name#36, c_last_name#37]
 Arguments: [c_current_addr_sk#34 ASC NULLS FIRST], false, 0
 
-(193) Scan parquet
+(192) Scan parquet
 Output [12]: [ca_address_sk#38, ca_street_number#39, ca_street_name#40, ca_street_type#41, ca_suite_number#42, ca_city#43, ca_county#44, ca_state#45, ca_zip#46, ca_country#47, ca_gmt_offset#48, ca_location_type#49]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(ca_state), EqualTo(ca_state,GA), IsNotNull(ca_address_sk)]
 ReadSchema: struct<ca_address_sk:int,ca_street_number:string,ca_street_name:string,ca_street_type:string,ca_suite_number:string,ca_city:string,ca_county:string,ca_state:string,ca_zip:string,ca_country:string,ca_gmt_offset:decimal(5,2),ca_location_type:string>
 
-(194) Filter
+(193) Filter
 Input [12]: [ca_address_sk#38, ca_street_number#39, ca_street_name#40, ca_street_type#41, ca_suite_number#42, ca_city#43, ca_county#44, ca_state#45, ca_zip#46, ca_country#47, ca_gmt_offset#48, ca_location_type#49]
 Condition : ((isnotnull(ca_state#45) AND (ca_state#45 = GA)) AND isnotnull(ca_address_sk#38))
 
-(195) Exchange
+(194) Exchange
 Input [12]: [ca_address_sk#38, ca_street_number#39, ca_street_name#40, ca_street_type#41, ca_suite_number#42, ca_city#43, ca_county#44, ca_state#45, ca_zip#46, ca_country#47, ca_gmt_offset#48, ca_location_type#49]
 Arguments: hashpartitioning(ca_address_sk#38, 100), ENSURE_REQUIREMENTS, [plan_id=30]
 
-(196) Sort
+(195) Sort
 Input [12]: [ca_address_sk#38, ca_street_number#39, ca_street_name#40, ca_street_type#41, ca_suite_number#42, ca_city#43, ca_county#44, ca_state#45, ca_zip#46, ca_country#47, ca_gmt_offset#48, ca_location_type#49]
 Arguments: [ca_address_sk#38 ASC NULLS FIRST], false, 0
 
-(197) SortMergeJoin
+(196) SortMergeJoin
 Left keys [1]: [c_current_addr_sk#34]
 Right keys [1]: [ca_address_sk#38]
 Join type: Inner
 Join condition: None
 
-(198) Project
+(197) Project
 Output [16]: [c_customer_id#33, c_salutation#35, c_first_name#36, c_last_name#37, ca_street_number#39, ca_street_name#40, ca_street_type#41, ca_suite_number#42, ca_city#43, ca_county#44, ca_state#45, ca_zip#46, ca_country#47, ca_gmt_offset#48, ca_location_type#49, ctr_total_return#15]
 Input [18]: [ctr_total_return#15, c_customer_id#33, c_current_addr_sk#34, c_salutation#35, c_first_name#36, c_last_name#37, ca_address_sk#38, ca_street_number#39, ca_street_name#40, ca_street_type#41, ca_suite_number#42, ca_city#43, ca_county#44, ca_state#45, ca_zip#46, ca_country#47, ca_gmt_offset#48, ca_location_type#49]
 
-(199) TakeOrderedAndProject
+(198) TakeOrderedAndProject
 Input [16]: [c_customer_id#33, c_salutation#35, c_first_name#36, c_last_name#37, ca_street_number#39, ca_street_name#40, ca_street_type#41, ca_suite_number#42, ca_city#43, ca_county#44, ca_state#45, ca_zip#46, ca_country#47, ca_gmt_offset#48, ca_location_type#49, ctr_total_return#15]
 Arguments: X, [c_customer_id#33 ASC NULLS FIRST, c_salutation#35 ASC NULLS FIRST, c_first_name#36 ASC NULLS FIRST, c_last_name#37 ASC NULLS FIRST, ca_street_number#39 ASC NULLS FIRST, ca_street_name#40 ASC NULLS FIRST, ca_street_type#41 ASC NULLS FIRST, ca_suite_number#42 ASC NULLS FIRST, ca_city#43 ASC NULLS FIRST, ca_county#44 ASC NULLS FIRST, ca_state#45 ASC NULLS FIRST, ca_zip#46 ASC NULLS FIRST, ca_country#47 ASC NULLS FIRST, ca_gmt_offset#48 ASC NULLS FIRST, ca_location_type#49 ASC NULLS FIRST, ctr_total_return#15 ASC NULLS FIRST], [c_customer_id#33, c_salutation#35, c_first_name#36, c_last_name#37, ca_street_number#39, ca_street_name#40, ca_street_type#41, ca_suite_number#42, ca_city#43, ca_county#44, ca_state#45, ca_zip#46, ca_country#47, ca_gmt_offset#48, ca_location_type#49, ctr_total_return#15]
 
-(200) AdaptiveSparkPlan
+(199) AdaptiveSparkPlan
 Output [16]: [c_customer_id#33, c_salutation#35, c_first_name#36, c_last_name#37, ca_street_number#39, ca_street_name#40, ca_street_type#41, ca_suite_number#42, ca_city#43, ca_county#44, ca_state#45, ca_zip#46, ca_country#47, ca_gmt_offset#48, ca_location_type#49, ctr_total_return#15]
 Arguments: isFinalPlan=true
 

--- a/dev/auron-it/src/main/resources/tpcds-plan-stability/spark-3.5/q85.txt
+++ b/dev/auron-it/src/main/resources/tpcds-plan-stability/spark-3.5/q85.txt
@@ -1,195 +1,193 @@
 == Physical Plan ==
-AdaptiveSparkPlan (186)
+AdaptiveSparkPlan (184)
 +- == Final Plan ==
-   NativeTakeOrdered (121)
-   +- NativeProject (120)
-      +- NativeHashAggregate (119)
-         +- InputAdapter (118)
-            +- AQEShuffleRead (117)
-               +- ShuffleQueryStage (116), Statistics(X)
-                  +- NativeShuffleExchange (115)
-                     +- NativeHashAggregate (114)
-                        +- NativeProject (113)
-                           +- NativeProject (112)
-                              +- NativeSortMergeJoin Inner (111)
-                                 :- NativeSort (102)
-                                 :  +- InputAdapter (101)
-                                 :     +- AQEShuffleRead (100)
-                                 :        +- ShuffleQueryStage (99), Statistics(X)
-                                 :           +- NativeShuffleExchange (98)
-                                 :              +- NativeProject (97)
-                                 :                 +- NativeSortMergeJoin Inner (96)
-                                 :                    :- NativeSort (86)
-                                 :                    :  +- InputAdapter (85)
-                                 :                    :     +- AQEShuffleRead (84)
-                                 :                    :        +- ShuffleQueryStage (83), Statistics(X)
-                                 :                    :           +- NativeShuffleExchange (82)
-                                 :                    :              +- ConvertToNative (81)
-                                 :                    :                 +- * Project (80)
-                                 :                    :                    +- * SortMergeJoin Inner (79)
-                                 :                    :                       :- NativeSort (69)
-                                 :                    :                       :  +- InputAdapter (68)
-                                 :                    :                       :     +- AQEShuffleRead (67)
-                                 :                    :                       :        +- ShuffleQueryStage (66), Statistics(X)
-                                 :                    :                       :           +- NativeShuffleExchange (65)
-                                 :                    :                       :              +- NativeProject (64)
-                                 :                    :                       :                 +- NativeSortMergeJoin Inner (63)
-                                 :                    :                       :                    :- NativeSort (54)
-                                 :                    :                       :                    :  +- InputAdapter (53)
-                                 :                    :                       :                    :     +- AQEShuffleRead (52)
-                                 :                    :                       :                    :        +- ShuffleQueryStage (51), Statistics(X)
-                                 :                    :                       :                    :           +- NativeShuffleExchange (50)
-                                 :                    :                       :                    :              +- ConvertToNative (49)
-                                 :                    :                       :                    :                 +- * Project (48)
-                                 :                    :                       :                    :                    +- * SortMergeJoin Inner (47)
-                                 :                    :                       :                    :                       :- NativeSort (38)
-                                 :                    :                       :                    :                       :  +- InputAdapter (37)
-                                 :                    :                       :                    :                       :     +- AQEShuffleRead (36)
-                                 :                    :                       :                    :                       :        +- ShuffleQueryStage (35), Statistics(X)
-                                 :                    :                       :                    :                       :           +- NativeShuffleExchange (34)
-                                 :                    :                       :                    :                       :              +- NativeProject (33)
-                                 :                    :                       :                    :                       :                 +- NativeSortMergeJoin Inner (32)
-                                 :                    :                       :                    :                       :                    :- NativeSort (23)
-                                 :                    :                       :                    :                       :                    :  +- InputAdapter (22)
-                                 :                    :                       :                    :                       :                    :     +- AQEShuffleRead (21)
-                                 :                    :                       :                    :                       :                    :        +- ShuffleQueryStage (20), Statistics(X)
-                                 :                    :                       :                    :                       :                    :           +- NativeShuffleExchange (19)
-                                 :                    :                       :                    :                       :                    :              +- NativeProject (18)
-                                 :                    :                       :                    :                       :                    :                 +- NativeSortMergeJoin Inner (17)
-                                 :                    :                       :                    :                       :                    :                    :- NativeSort (8)
-                                 :                    :                       :                    :                       :                    :                    :  +- InputAdapter (7)
-                                 :                    :                       :                    :                       :                    :                    :     +- AQEShuffleRead (6)
-                                 :                    :                       :                    :                       :                    :                    :        +- ShuffleQueryStage (5), Statistics(X)
-                                 :                    :                       :                    :                       :                    :                    :           +- NativeShuffleExchange (4)
-                                 :                    :                       :                    :                       :                    :                    :              +- NativeFilter (3)
-                                 :                    :                       :                    :                       :                    :                    :                 +- InputAdapter (2)
-                                 :                    :                       :                    :                       :                    :                    :                    +- NativeParquetScan  (1)
-                                 :                    :                       :                    :                       :                    :                    +- NativeSort (16)
-                                 :                    :                       :                    :                       :                    :                       +- InputAdapter (15)
-                                 :                    :                       :                    :                       :                    :                          +- AQEShuffleRead (14)
-                                 :                    :                       :                    :                       :                    :                             +- ShuffleQueryStage (13), Statistics(X)
-                                 :                    :                       :                    :                       :                    :                                +- NativeShuffleExchange (12)
-                                 :                    :                       :                    :                       :                    :                                   +- NativeFilter (11)
-                                 :                    :                       :                    :                       :                    :                                      +- InputAdapter (10)
-                                 :                    :                       :                    :                       :                    :                                         +- NativeParquetScan  (9)
-                                 :                    :                       :                    :                       :                    +- NativeSort (31)
-                                 :                    :                       :                    :                       :                       +- InputAdapter (30)
-                                 :                    :                       :                    :                       :                          +- AQEShuffleRead (29)
-                                 :                    :                       :                    :                       :                             +- ShuffleQueryStage (28), Statistics(X)
-                                 :                    :                       :                    :                       :                                +- NativeShuffleExchange (27)
-                                 :                    :                       :                    :                       :                                   +- NativeFilter (26)
-                                 :                    :                       :                    :                       :                                      +- InputAdapter (25)
-                                 :                    :                       :                    :                       :                                         +- NativeParquetScan  (24)
-                                 :                    :                       :                    :                       +- NativeSort (46)
-                                 :                    :                       :                    :                          +- InputAdapter (45)
-                                 :                    :                       :                    :                             +- AQEShuffleRead (44)
-                                 :                    :                       :                    :                                +- ShuffleQueryStage (43), Statistics(X)
-                                 :                    :                       :                    :                                   +- NativeShuffleExchange (42)
-                                 :                    :                       :                    :                                      +- NativeFilter (41)
-                                 :                    :                       :                    :                                         +- InputAdapter (40)
-                                 :                    :                       :                    :                                            +- NativeParquetScan  (39)
-                                 :                    :                       :                    +- NativeSort (62)
-                                 :                    :                       :                       +- InputAdapter (61)
-                                 :                    :                       :                          +- AQEShuffleRead (60)
-                                 :                    :                       :                             +- ShuffleQueryStage (59), Statistics(X)
-                                 :                    :                       :                                +- NativeShuffleExchange (58)
-                                 :                    :                       :                                   +- NativeFilter (57)
-                                 :                    :                       :                                      +- InputAdapter (56)
-                                 :                    :                       :                                         +- NativeParquetScan  (55)
-                                 :                    :                       +- NativeSort (78)
-                                 :                    :                          +- InputAdapter (77)
-                                 :                    :                             +- AQEShuffleRead (76)
-                                 :                    :                                +- ShuffleQueryStage (75), Statistics(X)
-                                 :                    :                                   +- NativeShuffleExchange (74)
-                                 :                    :                                      +- NativeProject (73)
-                                 :                    :                                         +- NativeFilter (72)
-                                 :                    :                                            +- InputAdapter (71)
-                                 :                    :                                               +- NativeParquetScan  (70)
-                                 :                    +- NativeSort (95)
-                                 :                       +- InputAdapter (94)
-                                 :                          +- AQEShuffleRead (93)
-                                 :                             +- ShuffleQueryStage (92), Statistics(X)
-                                 :                                +- NativeShuffleExchange (91)
-                                 :                                   +- NativeProject (90)
-                                 :                                      +- NativeFilter (89)
-                                 :                                         +- InputAdapter (88)
-                                 :                                            +- NativeParquetScan  (87)
-                                 +- NativeSort (110)
-                                    +- InputAdapter (109)
-                                       +- AQEShuffleRead (108)
-                                          +- ShuffleQueryStage (107), Statistics(X)
-                                             +- NativeShuffleExchange (106)
-                                                +- NativeFilter (105)
-                                                   +- InputAdapter (104)
-                                                      +- NativeParquetScan  (103)
+   NativeTakeOrdered (119)
+   +- NativeProject (118)
+      +- NativeHashAggregate (117)
+         +- InputAdapter (116)
+            +- AQEShuffleRead (115)
+               +- ShuffleQueryStage (114), Statistics(X)
+                  +- NativeShuffleExchange (113)
+                     +- NativeHashAggregate (112)
+                        +- NativeProject (111)
+                           +- NativeProject (110)
+                              +- NativeSortMergeJoin Inner (109)
+                                 :- NativeSort (100)
+                                 :  +- InputAdapter (99)
+                                 :     +- AQEShuffleRead (98)
+                                 :        +- ShuffleQueryStage (97), Statistics(X)
+                                 :           +- NativeShuffleExchange (96)
+                                 :              +- NativeProject (95)
+                                 :                 +- NativeSortMergeJoin Inner (94)
+                                 :                    :- NativeSort (84)
+                                 :                    :  +- InputAdapter (83)
+                                 :                    :     +- AQEShuffleRead (82)
+                                 :                    :        +- ShuffleQueryStage (81), Statistics(X)
+                                 :                    :           +- NativeShuffleExchange (80)
+                                 :                    :              +- NativeProject (79)
+                                 :                    :                 +- NativeSortMergeJoin Inner (78)
+                                 :                    :                    :- NativeSort (68)
+                                 :                    :                    :  +- InputAdapter (67)
+                                 :                    :                    :     +- AQEShuffleRead (66)
+                                 :                    :                    :        +- ShuffleQueryStage (65), Statistics(X)
+                                 :                    :                    :           +- NativeShuffleExchange (64)
+                                 :                    :                    :              +- NativeProject (63)
+                                 :                    :                    :                 +- NativeSortMergeJoin Inner (62)
+                                 :                    :                    :                    :- NativeSort (53)
+                                 :                    :                    :                    :  +- InputAdapter (52)
+                                 :                    :                    :                    :     +- AQEShuffleRead (51)
+                                 :                    :                    :                    :        +- ShuffleQueryStage (50), Statistics(X)
+                                 :                    :                    :                    :           +- NativeShuffleExchange (49)
+                                 :                    :                    :                    :              +- NativeProject (48)
+                                 :                    :                    :                    :                 +- NativeSortMergeJoin Inner (47)
+                                 :                    :                    :                    :                    :- NativeSort (38)
+                                 :                    :                    :                    :                    :  +- InputAdapter (37)
+                                 :                    :                    :                    :                    :     +- AQEShuffleRead (36)
+                                 :                    :                    :                    :                    :        +- ShuffleQueryStage (35), Statistics(X)
+                                 :                    :                    :                    :                    :           +- NativeShuffleExchange (34)
+                                 :                    :                    :                    :                    :              +- NativeProject (33)
+                                 :                    :                    :                    :                    :                 +- NativeSortMergeJoin Inner (32)
+                                 :                    :                    :                    :                    :                    :- NativeSort (23)
+                                 :                    :                    :                    :                    :                    :  +- InputAdapter (22)
+                                 :                    :                    :                    :                    :                    :     +- AQEShuffleRead (21)
+                                 :                    :                    :                    :                    :                    :        +- ShuffleQueryStage (20), Statistics(X)
+                                 :                    :                    :                    :                    :                    :           +- NativeShuffleExchange (19)
+                                 :                    :                    :                    :                    :                    :              +- NativeProject (18)
+                                 :                    :                    :                    :                    :                    :                 +- NativeSortMergeJoin Inner (17)
+                                 :                    :                    :                    :                    :                    :                    :- NativeSort (8)
+                                 :                    :                    :                    :                    :                    :                    :  +- InputAdapter (7)
+                                 :                    :                    :                    :                    :                    :                    :     +- AQEShuffleRead (6)
+                                 :                    :                    :                    :                    :                    :                    :        +- ShuffleQueryStage (5), Statistics(X)
+                                 :                    :                    :                    :                    :                    :                    :           +- NativeShuffleExchange (4)
+                                 :                    :                    :                    :                    :                    :                    :              +- NativeFilter (3)
+                                 :                    :                    :                    :                    :                    :                    :                 +- InputAdapter (2)
+                                 :                    :                    :                    :                    :                    :                    :                    +- NativeParquetScan  (1)
+                                 :                    :                    :                    :                    :                    :                    +- NativeSort (16)
+                                 :                    :                    :                    :                    :                    :                       +- InputAdapter (15)
+                                 :                    :                    :                    :                    :                    :                          +- AQEShuffleRead (14)
+                                 :                    :                    :                    :                    :                    :                             +- ShuffleQueryStage (13), Statistics(X)
+                                 :                    :                    :                    :                    :                    :                                +- NativeShuffleExchange (12)
+                                 :                    :                    :                    :                    :                    :                                   +- NativeFilter (11)
+                                 :                    :                    :                    :                    :                    :                                      +- InputAdapter (10)
+                                 :                    :                    :                    :                    :                    :                                         +- NativeParquetScan  (9)
+                                 :                    :                    :                    :                    :                    +- NativeSort (31)
+                                 :                    :                    :                    :                    :                       +- InputAdapter (30)
+                                 :                    :                    :                    :                    :                          +- AQEShuffleRead (29)
+                                 :                    :                    :                    :                    :                             +- ShuffleQueryStage (28), Statistics(X)
+                                 :                    :                    :                    :                    :                                +- NativeShuffleExchange (27)
+                                 :                    :                    :                    :                    :                                   +- NativeFilter (26)
+                                 :                    :                    :                    :                    :                                      +- InputAdapter (25)
+                                 :                    :                    :                    :                    :                                         +- NativeParquetScan  (24)
+                                 :                    :                    :                    :                    +- NativeSort (46)
+                                 :                    :                    :                    :                       +- InputAdapter (45)
+                                 :                    :                    :                    :                          +- AQEShuffleRead (44)
+                                 :                    :                    :                    :                             +- ShuffleQueryStage (43), Statistics(X)
+                                 :                    :                    :                    :                                +- NativeShuffleExchange (42)
+                                 :                    :                    :                    :                                   +- NativeFilter (41)
+                                 :                    :                    :                    :                                      +- InputAdapter (40)
+                                 :                    :                    :                    :                                         +- NativeParquetScan  (39)
+                                 :                    :                    :                    +- NativeSort (61)
+                                 :                    :                    :                       +- InputAdapter (60)
+                                 :                    :                    :                          +- AQEShuffleRead (59)
+                                 :                    :                    :                             +- ShuffleQueryStage (58), Statistics(X)
+                                 :                    :                    :                                +- NativeShuffleExchange (57)
+                                 :                    :                    :                                   +- NativeFilter (56)
+                                 :                    :                    :                                      +- InputAdapter (55)
+                                 :                    :                    :                                         +- NativeParquetScan  (54)
+                                 :                    :                    +- NativeSort (77)
+                                 :                    :                       +- InputAdapter (76)
+                                 :                    :                          +- AQEShuffleRead (75)
+                                 :                    :                             +- ShuffleQueryStage (74), Statistics(X)
+                                 :                    :                                +- NativeShuffleExchange (73)
+                                 :                    :                                   +- NativeProject (72)
+                                 :                    :                                      +- NativeFilter (71)
+                                 :                    :                                         +- InputAdapter (70)
+                                 :                    :                                            +- NativeParquetScan  (69)
+                                 :                    +- NativeSort (93)
+                                 :                       +- InputAdapter (92)
+                                 :                          +- AQEShuffleRead (91)
+                                 :                             +- ShuffleQueryStage (90), Statistics(X)
+                                 :                                +- NativeShuffleExchange (89)
+                                 :                                   +- NativeProject (88)
+                                 :                                      +- NativeFilter (87)
+                                 :                                         +- InputAdapter (86)
+                                 :                                            +- NativeParquetScan  (85)
+                                 +- NativeSort (108)
+                                    +- InputAdapter (107)
+                                       +- AQEShuffleRead (106)
+                                          +- ShuffleQueryStage (105), Statistics(X)
+                                             +- NativeShuffleExchange (104)
+                                                +- NativeFilter (103)
+                                                   +- InputAdapter (102)
+                                                      +- NativeParquetScan  (101)
 +- == Initial Plan ==
-   TakeOrderedAndProject (185)
-   +- HashAggregate (184)
-      +- Exchange (183)
-         +- HashAggregate (182)
-            +- Project (181)
-               +- SortMergeJoin Inner (180)
-                  :- Sort (175)
-                  :  +- Exchange (174)
-                  :     +- Project (173)
-                  :        +- SortMergeJoin Inner (172)
-                  :           :- Sort (166)
-                  :           :  +- Exchange (165)
-                  :           :     +- Project (164)
-                  :           :        +- SortMergeJoin Inner (163)
-                  :           :           :- Sort (157)
-                  :           :           :  +- Exchange (156)
-                  :           :           :     +- Project (155)
-                  :           :           :        +- SortMergeJoin Inner (154)
-                  :           :           :           :- Sort (149)
-                  :           :           :           :  +- Exchange (148)
-                  :           :           :           :     +- Project (147)
-                  :           :           :           :        +- SortMergeJoin Inner (146)
-                  :           :           :           :           :- Sort (141)
-                  :           :           :           :           :  +- Exchange (140)
-                  :           :           :           :           :     +- Project (139)
-                  :           :           :           :           :        +- SortMergeJoin Inner (138)
-                  :           :           :           :           :           :- Sort (133)
-                  :           :           :           :           :           :  +- Exchange (132)
-                  :           :           :           :           :           :     +- Project (131)
-                  :           :           :           :           :           :        +- SortMergeJoin Inner (130)
-                  :           :           :           :           :           :           :- Sort (125)
-                  :           :           :           :           :           :           :  +- Exchange (124)
-                  :           :           :           :           :           :           :     +- Filter (123)
-                  :           :           :           :           :           :           :        +- Scan parquet (122)
-                  :           :           :           :           :           :           +- Sort (129)
-                  :           :           :           :           :           :              +- Exchange (128)
-                  :           :           :           :           :           :                 +- Filter (127)
-                  :           :           :           :           :           :                    +- Scan parquet (126)
-                  :           :           :           :           :           +- Sort (137)
-                  :           :           :           :           :              +- Exchange (136)
-                  :           :           :           :           :                 +- Filter (135)
-                  :           :           :           :           :                    +- Scan parquet (134)
-                  :           :           :           :           +- Sort (145)
-                  :           :           :           :              +- Exchange (144)
-                  :           :           :           :                 +- Filter (143)
-                  :           :           :           :                    +- Scan parquet (142)
-                  :           :           :           +- Sort (153)
-                  :           :           :              +- Exchange (152)
-                  :           :           :                 +- Filter (151)
-                  :           :           :                    +- Scan parquet (150)
-                  :           :           +- Sort (162)
-                  :           :              +- Exchange (161)
-                  :           :                 +- Project (160)
-                  :           :                    +- Filter (159)
-                  :           :                       +- Scan parquet (158)
-                  :           +- Sort (171)
-                  :              +- Exchange (170)
-                  :                 +- Project (169)
-                  :                    +- Filter (168)
-                  :                       +- Scan parquet (167)
-                  +- Sort (179)
-                     +- Exchange (178)
-                        +- Filter (177)
-                           +- Scan parquet (176)
+   TakeOrderedAndProject (183)
+   +- HashAggregate (182)
+      +- Exchange (181)
+         +- HashAggregate (180)
+            +- Project (179)
+               +- SortMergeJoin Inner (178)
+                  :- Sort (173)
+                  :  +- Exchange (172)
+                  :     +- Project (171)
+                  :        +- SortMergeJoin Inner (170)
+                  :           :- Sort (164)
+                  :           :  +- Exchange (163)
+                  :           :     +- Project (162)
+                  :           :        +- SortMergeJoin Inner (161)
+                  :           :           :- Sort (155)
+                  :           :           :  +- Exchange (154)
+                  :           :           :     +- Project (153)
+                  :           :           :        +- SortMergeJoin Inner (152)
+                  :           :           :           :- Sort (147)
+                  :           :           :           :  +- Exchange (146)
+                  :           :           :           :     +- Project (145)
+                  :           :           :           :        +- SortMergeJoin Inner (144)
+                  :           :           :           :           :- Sort (139)
+                  :           :           :           :           :  +- Exchange (138)
+                  :           :           :           :           :     +- Project (137)
+                  :           :           :           :           :        +- SortMergeJoin Inner (136)
+                  :           :           :           :           :           :- Sort (131)
+                  :           :           :           :           :           :  +- Exchange (130)
+                  :           :           :           :           :           :     +- Project (129)
+                  :           :           :           :           :           :        +- SortMergeJoin Inner (128)
+                  :           :           :           :           :           :           :- Sort (123)
+                  :           :           :           :           :           :           :  +- Exchange (122)
+                  :           :           :           :           :           :           :     +- Filter (121)
+                  :           :           :           :           :           :           :        +- Scan parquet (120)
+                  :           :           :           :           :           :           +- Sort (127)
+                  :           :           :           :           :           :              +- Exchange (126)
+                  :           :           :           :           :           :                 +- Filter (125)
+                  :           :           :           :           :           :                    +- Scan parquet (124)
+                  :           :           :           :           :           +- Sort (135)
+                  :           :           :           :           :              +- Exchange (134)
+                  :           :           :           :           :                 +- Filter (133)
+                  :           :           :           :           :                    +- Scan parquet (132)
+                  :           :           :           :           +- Sort (143)
+                  :           :           :           :              +- Exchange (142)
+                  :           :           :           :                 +- Filter (141)
+                  :           :           :           :                    +- Scan parquet (140)
+                  :           :           :           +- Sort (151)
+                  :           :           :              +- Exchange (150)
+                  :           :           :                 +- Filter (149)
+                  :           :           :                    +- Scan parquet (148)
+                  :           :           +- Sort (160)
+                  :           :              +- Exchange (159)
+                  :           :                 +- Project (158)
+                  :           :                    +- Filter (157)
+                  :           :                       +- Scan parquet (156)
+                  :           +- Sort (169)
+                  :              +- Exchange (168)
+                  :                 +- Project (167)
+                  :                    +- Filter (166)
+                  :                       +- Scan parquet (165)
+                  +- Sort (177)
+                     +- Exchange (176)
+                        +- Filter (175)
+                           +- Scan parquet (174)
 
 
-(122) Scan parquet
+(120) Scan parquet
 Output [7]: [ws_sold_date_sk#1, ws_item_sk#2, ws_web_page_sk#3, ws_order_number#4, ws_quantity#5, ws_sales_price#6, ws_net_profit#7]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
@@ -223,7 +221,7 @@ Input [7]: [#1#1, #2#2, #3#3, #4#4, #5#5, #6#6, #7#7]
 Input [7]: [#1#1, #2#2, #3#3, #4#4, #5#5, #6#6, #7#7]
 Arguments: [ws_item_sk#2 ASC NULLS FIRST, ws_order_number#4 ASC NULLS FIRST], false
 
-(126) Scan parquet
+(124) Scan parquet
 Output [8]: [wr_item_sk#8, wr_refunded_cdemo_sk#9, wr_refunded_addr_sk#10, wr_returning_cdemo_sk#11, wr_reason_sk#12, wr_order_number#13, wr_fee#14, wr_refunded_cash#15]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
@@ -286,7 +284,7 @@ Input [11]: [ws_sold_date_sk#1, ws_web_page_sk#3, ws_quantity#5, ws_sales_price#
 Input [11]: [ws_sold_date_sk#1, ws_web_page_sk#3, ws_quantity#5, ws_sales_price#6, ws_net_profit#7, wr_refunded_cdemo_sk#9, wr_refunded_addr_sk#10, wr_returning_cdemo_sk#11, wr_reason_sk#12, wr_fee#14, wr_refunded_cash#15]
 Arguments: [ws_web_page_sk#3 ASC NULLS FIRST], false
 
-(134) Scan parquet
+(132) Scan parquet
 Output [1]: [wp_web_page_sk#16]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
@@ -349,7 +347,7 @@ Input [10]: [ws_sold_date_sk#1, ws_quantity#5, ws_sales_price#6, ws_net_profit#7
 Input [10]: [ws_sold_date_sk#1, ws_quantity#5, ws_sales_price#6, ws_net_profit#7, wr_refunded_cdemo_sk#9, wr_refunded_addr_sk#10, wr_returning_cdemo_sk#11, wr_reason_sk#12, wr_fee#14, wr_refunded_cash#15]
 Arguments: [wr_refunded_cdemo_sk#9 ASC NULLS FIRST], false
 
-(142) Scan parquet
+(140) Scan parquet
 Output [3]: [cd_demo_sk#17, cd_marital_status#18, cd_education_status#19]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
@@ -383,624 +381,618 @@ Input [3]: [#17#17, #18#18, #19#19]
 Input [3]: [#17#17, #18#18, #19#19]
 Arguments: [cd_demo_sk#17 ASC NULLS FIRST], false
 
-(47) SortMergeJoin [codegen id : X]
+(47) NativeSortMergeJoin
 Left keys [1]: [wr_refunded_cdemo_sk#9]
 Right keys [1]: [cd_demo_sk#17]
 Join type: Inner
 Join condition: ((((((cd_marital_status#18 = M) AND (cd_education_status#19 = Advanced Degree)) AND (ws_sales_price#6 >= 100.00)) AND (ws_sales_price#6 <= 150.00)) OR ((((cd_marital_status#18 = S) AND (cd_education_status#19 = College)) AND (ws_sales_price#6 >= 50.00)) AND (ws_sales_price#6 <= 100.00))) OR ((((cd_marital_status#18 = W) AND (cd_education_status#19 = 2 yr Degree)) AND (ws_sales_price#6 >= 150.00)) AND (ws_sales_price#6 <= 200.00)))
 
-(48) Project [codegen id : X]
+(48) NativeProject
 Output [10]: [ws_sold_date_sk#1, ws_quantity#5, ws_net_profit#7, wr_refunded_addr_sk#10, wr_returning_cdemo_sk#11, wr_reason_sk#12, wr_fee#14, wr_refunded_cash#15, cd_marital_status#18, cd_education_status#19]
 Input [13]: [ws_sold_date_sk#1, ws_quantity#5, ws_sales_price#6, ws_net_profit#7, wr_refunded_cdemo_sk#9, wr_refunded_addr_sk#10, wr_returning_cdemo_sk#11, wr_reason_sk#12, wr_fee#14, wr_refunded_cash#15, #17#17, #18#18, #19#19]
 
-(49) ConvertToNative
-Input [10]: [ws_sold_date_sk#1, ws_quantity#5, ws_net_profit#7, wr_refunded_addr_sk#10, wr_returning_cdemo_sk#11, wr_reason_sk#12, wr_fee#14, wr_refunded_cash#15, cd_marital_status#18, cd_education_status#19]
-
-(50) NativeShuffleExchange
+(49) NativeShuffleExchange
 Input [10]: [ws_sold_date_sk#1, ws_quantity#5, ws_net_profit#7, wr_refunded_addr_sk#10, wr_returning_cdemo_sk#11, wr_reason_sk#12, wr_fee#14, wr_refunded_cash#15, cd_marital_status#18, cd_education_status#19]
 Arguments: hashpartitioning(wr_returning_cdemo_sk#11, cd_marital_status#18, cd_education_status#19, 100), ENSURE_REQUIREMENTS, [plan_id=7]
 
-(51) ShuffleQueryStage
+(50) ShuffleQueryStage
 Output [10]: [ws_sold_date_sk#1, ws_quantity#5, ws_net_profit#7, wr_refunded_addr_sk#10, wr_returning_cdemo_sk#11, wr_reason_sk#12, wr_fee#14, wr_refunded_cash#15, cd_marital_status#18, cd_education_status#19]
 Arguments: X
 
-(52) AQEShuffleRead
+(51) AQEShuffleRead
 Input [10]: [ws_sold_date_sk#1, ws_quantity#5, ws_net_profit#7, wr_refunded_addr_sk#10, wr_returning_cdemo_sk#11, wr_reason_sk#12, wr_fee#14, wr_refunded_cash#15, cd_marital_status#18, cd_education_status#19]
 Arguments: coalesced
 
-(53) InputAdapter
+(52) InputAdapter
 Input [10]: [ws_sold_date_sk#1, ws_quantity#5, ws_net_profit#7, wr_refunded_addr_sk#10, wr_returning_cdemo_sk#11, wr_reason_sk#12, wr_fee#14, wr_refunded_cash#15, cd_marital_status#18, cd_education_status#19]
 
-(54) NativeSort
+(53) NativeSort
 Input [10]: [ws_sold_date_sk#1, ws_quantity#5, ws_net_profit#7, wr_refunded_addr_sk#10, wr_returning_cdemo_sk#11, wr_reason_sk#12, wr_fee#14, wr_refunded_cash#15, cd_marital_status#18, cd_education_status#19]
 Arguments: [wr_returning_cdemo_sk#11 ASC NULLS FIRST, cd_marital_status#18 ASC NULLS FIRST, cd_education_status#19 ASC NULLS FIRST], false
 
-(150) Scan parquet
+(148) Scan parquet
 Output [3]: [cd_demo_sk#20, cd_marital_status#21, cd_education_status#22]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(cd_demo_sk), IsNotNull(cd_marital_status), IsNotNull(cd_education_status)]
 ReadSchema: struct<cd_demo_sk:int,cd_marital_status:string,cd_education_status:string>
 
-(56) InputAdapter
+(55) InputAdapter
 Input [3]: [cd_demo_sk#20, cd_marital_status#21, cd_education_status#22]
 Arguments: [#20, #21, #22]
 
-(57) NativeFilter
+(56) NativeFilter
 Input [3]: [#20#20, #21#21, #22#22]
 Condition : ((isnotnull(cd_demo_sk#20) AND isnotnull(cd_marital_status#21)) AND isnotnull(cd_education_status#22))
 
-(58) NativeShuffleExchange
+(57) NativeShuffleExchange
 Input [3]: [#20#20, #21#21, #22#22]
 Arguments: hashpartitioning(cd_demo_sk#20, cd_marital_status#21, cd_education_status#22, 100), ENSURE_REQUIREMENTS, [plan_id=8]
 
-(59) ShuffleQueryStage
+(58) ShuffleQueryStage
 Output [3]: [#20#20, #21#21, #22#22]
 Arguments: X
 
-(60) AQEShuffleRead
+(59) AQEShuffleRead
 Input [3]: [#20#20, #21#21, #22#22]
 Arguments: coalesced
 
-(61) InputAdapter
+(60) InputAdapter
 Input [3]: [#20#20, #21#21, #22#22]
 
-(62) NativeSort
+(61) NativeSort
 Input [3]: [#20#20, #21#21, #22#22]
 Arguments: [cd_demo_sk#20 ASC NULLS FIRST, cd_marital_status#21 ASC NULLS FIRST, cd_education_status#22 ASC NULLS FIRST], false
 
-(63) NativeSortMergeJoin
+(62) NativeSortMergeJoin
 Left keys [3]: [wr_returning_cdemo_sk#11, cd_marital_status#18, cd_education_status#19]
 Right keys [3]: [cd_demo_sk#20, cd_marital_status#21, cd_education_status#22]
 Join type: Inner
 Join condition: None
 
-(64) NativeProject
+(63) NativeProject
 Output [7]: [ws_sold_date_sk#1, ws_quantity#5, ws_net_profit#7, wr_refunded_addr_sk#10, wr_reason_sk#12, wr_fee#14, wr_refunded_cash#15]
 Input [13]: [ws_sold_date_sk#1, ws_quantity#5, ws_net_profit#7, wr_refunded_addr_sk#10, wr_returning_cdemo_sk#11, wr_reason_sk#12, wr_fee#14, wr_refunded_cash#15, cd_marital_status#18, cd_education_status#19, #20#20, #21#21, #22#22]
 
-(65) NativeShuffleExchange
+(64) NativeShuffleExchange
 Input [7]: [ws_sold_date_sk#1, ws_quantity#5, ws_net_profit#7, wr_refunded_addr_sk#10, wr_reason_sk#12, wr_fee#14, wr_refunded_cash#15]
 Arguments: hashpartitioning(wr_refunded_addr_sk#10, 100), ENSURE_REQUIREMENTS, [plan_id=9]
 
-(66) ShuffleQueryStage
+(65) ShuffleQueryStage
 Output [7]: [ws_sold_date_sk#1, ws_quantity#5, ws_net_profit#7, wr_refunded_addr_sk#10, wr_reason_sk#12, wr_fee#14, wr_refunded_cash#15]
 Arguments: X
 
-(67) AQEShuffleRead
+(66) AQEShuffleRead
 Input [7]: [ws_sold_date_sk#1, ws_quantity#5, ws_net_profit#7, wr_refunded_addr_sk#10, wr_reason_sk#12, wr_fee#14, wr_refunded_cash#15]
 Arguments: coalesced
 
-(68) InputAdapter
+(67) InputAdapter
 Input [7]: [ws_sold_date_sk#1, ws_quantity#5, ws_net_profit#7, wr_refunded_addr_sk#10, wr_reason_sk#12, wr_fee#14, wr_refunded_cash#15]
 
-(69) NativeSort
+(68) NativeSort
 Input [7]: [ws_sold_date_sk#1, ws_quantity#5, ws_net_profit#7, wr_refunded_addr_sk#10, wr_reason_sk#12, wr_fee#14, wr_refunded_cash#15]
 Arguments: [wr_refunded_addr_sk#10 ASC NULLS FIRST], false
 
-(158) Scan parquet
+(156) Scan parquet
 Output [3]: [ca_address_sk#23, ca_state#24, ca_country#25]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(ca_country), EqualTo(ca_country,United States), IsNotNull(ca_address_sk), Or(Or(In(ca_state, [IN,NJ,OH]),In(ca_state, [CT,KY,WI])),In(ca_state, [AR,IA,LA]))]
 ReadSchema: struct<ca_address_sk:int,ca_state:string,ca_country:string>
 
-(71) InputAdapter
+(70) InputAdapter
 Input [3]: [ca_address_sk#23, ca_state#24, ca_country#25]
 Arguments: [#23, #24, #25]
 
-(72) NativeFilter
+(71) NativeFilter
 Input [3]: [#23#23, #24#24, #25#25]
 Condition : (((isnotnull(ca_country#25) AND (ca_country#25 = United States)) AND isnotnull(ca_address_sk#23)) AND ((ca_state#24 IN (IN,OH,NJ) OR ca_state#24 IN (WI,CT,KY)) OR ca_state#24 IN (LA,IA,AR)))
 
-(73) NativeProject
+(72) NativeProject
 Output [2]: [ca_address_sk#23, ca_state#24]
 Input [3]: [#23#23, #24#24, #25#25]
 
-(74) NativeShuffleExchange
+(73) NativeShuffleExchange
 Input [2]: [ca_address_sk#23, ca_state#24]
 Arguments: hashpartitioning(ca_address_sk#23, 100), ENSURE_REQUIREMENTS, [plan_id=10]
 
-(75) ShuffleQueryStage
+(74) ShuffleQueryStage
 Output [2]: [ca_address_sk#23, ca_state#24]
 Arguments: X
 
-(76) AQEShuffleRead
+(75) AQEShuffleRead
 Input [2]: [ca_address_sk#23, ca_state#24]
 Arguments: coalesced
 
-(77) InputAdapter
+(76) InputAdapter
 Input [2]: [ca_address_sk#23, ca_state#24]
 
-(78) NativeSort
+(77) NativeSort
 Input [2]: [ca_address_sk#23, ca_state#24]
 Arguments: [ca_address_sk#23 ASC NULLS FIRST], false
 
-(79) SortMergeJoin [codegen id : X]
+(78) NativeSortMergeJoin
 Left keys [1]: [wr_refunded_addr_sk#10]
 Right keys [1]: [ca_address_sk#23]
 Join type: Inner
 Join condition: ((((ca_state#24 IN (IN,OH,NJ) AND (ws_net_profit#7 >= 100.00)) AND (ws_net_profit#7 <= 200.00)) OR ((ca_state#24 IN (WI,CT,KY) AND (ws_net_profit#7 >= 150.00)) AND (ws_net_profit#7 <= 300.00))) OR ((ca_state#24 IN (LA,IA,AR) AND (ws_net_profit#7 >= 50.00)) AND (ws_net_profit#7 <= 250.00)))
 
-(80) Project [codegen id : X]
+(79) NativeProject
 Output [5]: [ws_sold_date_sk#1, ws_quantity#5, wr_reason_sk#12, wr_fee#14, wr_refunded_cash#15]
 Input [9]: [ws_sold_date_sk#1, ws_quantity#5, ws_net_profit#7, wr_refunded_addr_sk#10, wr_reason_sk#12, wr_fee#14, wr_refunded_cash#15, ca_address_sk#23, ca_state#24]
 
-(81) ConvertToNative
-Input [5]: [ws_sold_date_sk#1, ws_quantity#5, wr_reason_sk#12, wr_fee#14, wr_refunded_cash#15]
-
-(82) NativeShuffleExchange
+(80) NativeShuffleExchange
 Input [5]: [ws_sold_date_sk#1, ws_quantity#5, wr_reason_sk#12, wr_fee#14, wr_refunded_cash#15]
 Arguments: hashpartitioning(ws_sold_date_sk#1, 100), ENSURE_REQUIREMENTS, [plan_id=11]
 
-(83) ShuffleQueryStage
+(81) ShuffleQueryStage
 Output [5]: [ws_sold_date_sk#1, ws_quantity#5, wr_reason_sk#12, wr_fee#14, wr_refunded_cash#15]
 Arguments: X
 
-(84) AQEShuffleRead
+(82) AQEShuffleRead
 Input [5]: [ws_sold_date_sk#1, ws_quantity#5, wr_reason_sk#12, wr_fee#14, wr_refunded_cash#15]
 Arguments: coalesced
 
-(85) InputAdapter
+(83) InputAdapter
 Input [5]: [ws_sold_date_sk#1, ws_quantity#5, wr_reason_sk#12, wr_fee#14, wr_refunded_cash#15]
 
-(86) NativeSort
+(84) NativeSort
 Input [5]: [ws_sold_date_sk#1, ws_quantity#5, wr_reason_sk#12, wr_fee#14, wr_refunded_cash#15]
 Arguments: [ws_sold_date_sk#1 ASC NULLS FIRST], false
 
-(167) Scan parquet
+(165) Scan parquet
 Output [2]: [d_date_sk#26, d_year#27]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2000), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
-(88) InputAdapter
+(86) InputAdapter
 Input [2]: [d_date_sk#26, d_year#27]
 Arguments: [#26, #27]
 
-(89) NativeFilter
+(87) NativeFilter
 Input [2]: [#26#26, #27#27]
 Condition : ((isnotnull(d_year#27) AND (d_year#27 = 2000)) AND isnotnull(d_date_sk#26))
 
-(90) NativeProject
+(88) NativeProject
 Output [1]: [d_date_sk#26]
 Input [2]: [#26#26, #27#27]
 
-(91) NativeShuffleExchange
+(89) NativeShuffleExchange
 Input [1]: [d_date_sk#26]
 Arguments: hashpartitioning(d_date_sk#26, 100), ENSURE_REQUIREMENTS, [plan_id=12]
 
-(92) ShuffleQueryStage
+(90) ShuffleQueryStage
 Output [1]: [d_date_sk#26]
 Arguments: X
 
-(93) AQEShuffleRead
+(91) AQEShuffleRead
 Input [1]: [d_date_sk#26]
 Arguments: coalesced
 
-(94) InputAdapter
+(92) InputAdapter
 Input [1]: [d_date_sk#26]
 
-(95) NativeSort
+(93) NativeSort
 Input [1]: [d_date_sk#26]
 Arguments: [d_date_sk#26 ASC NULLS FIRST], false
 
-(96) NativeSortMergeJoin
+(94) NativeSortMergeJoin
 Left keys [1]: [ws_sold_date_sk#1]
 Right keys [1]: [d_date_sk#26]
 Join type: Inner
 Join condition: None
 
-(97) NativeProject
+(95) NativeProject
 Output [4]: [ws_quantity#5, wr_reason_sk#12, wr_fee#14, wr_refunded_cash#15]
 Input [6]: [ws_sold_date_sk#1, ws_quantity#5, wr_reason_sk#12, wr_fee#14, wr_refunded_cash#15, d_date_sk#26]
 
-(98) NativeShuffleExchange
+(96) NativeShuffleExchange
 Input [4]: [ws_quantity#5, wr_reason_sk#12, wr_fee#14, wr_refunded_cash#15]
 Arguments: hashpartitioning(wr_reason_sk#12, 100), ENSURE_REQUIREMENTS, [plan_id=13]
 
-(99) ShuffleQueryStage
+(97) ShuffleQueryStage
 Output [4]: [ws_quantity#5, wr_reason_sk#12, wr_fee#14, wr_refunded_cash#15]
 Arguments: X
 
-(100) AQEShuffleRead
+(98) AQEShuffleRead
 Input [4]: [ws_quantity#5, wr_reason_sk#12, wr_fee#14, wr_refunded_cash#15]
 Arguments: coalesced
 
-(101) InputAdapter
+(99) InputAdapter
 Input [4]: [ws_quantity#5, wr_reason_sk#12, wr_fee#14, wr_refunded_cash#15]
 
-(102) NativeSort
+(100) NativeSort
 Input [4]: [ws_quantity#5, wr_reason_sk#12, wr_fee#14, wr_refunded_cash#15]
 Arguments: [wr_reason_sk#12 ASC NULLS FIRST], false
 
-(176) Scan parquet
+(174) Scan parquet
 Output [2]: [r_reason_sk#28, r_reason_desc#29]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(r_reason_sk)]
 ReadSchema: struct<r_reason_sk:int,r_reason_desc:string>
 
-(104) InputAdapter
+(102) InputAdapter
 Input [2]: [r_reason_sk#28, r_reason_desc#29]
 Arguments: [#28, #29]
 
-(105) NativeFilter
+(103) NativeFilter
 Input [2]: [#28#28, #29#29]
 Condition : isnotnull(r_reason_sk#28)
 
-(106) NativeShuffleExchange
+(104) NativeShuffleExchange
 Input [2]: [#28#28, #29#29]
 Arguments: hashpartitioning(r_reason_sk#28, 100), ENSURE_REQUIREMENTS, [plan_id=14]
 
-(107) ShuffleQueryStage
+(105) ShuffleQueryStage
 Output [2]: [#28#28, #29#29]
 Arguments: X
 
-(108) AQEShuffleRead
+(106) AQEShuffleRead
 Input [2]: [#28#28, #29#29]
 Arguments: coalesced
 
-(109) InputAdapter
+(107) InputAdapter
 Input [2]: [#28#28, #29#29]
 
-(110) NativeSort
+(108) NativeSort
 Input [2]: [#28#28, #29#29]
 Arguments: [r_reason_sk#28 ASC NULLS FIRST], false
 
-(111) NativeSortMergeJoin
+(109) NativeSortMergeJoin
 Left keys [1]: [wr_reason_sk#12]
 Right keys [1]: [r_reason_sk#28]
 Join type: Inner
 Join condition: None
 
-(112) NativeProject
+(110) NativeProject
 Output [4]: [ws_quantity#5, wr_fee#14, wr_refunded_cash#15, r_reason_desc#29]
 Input [6]: [ws_quantity#5, wr_reason_sk#12, wr_fee#14, wr_refunded_cash#15, #28#28, #29#29]
 
-(113) NativeProject
+(111) NativeProject
 Output [4]: [r_reason_desc#29 AS r_reason_desc#29, ws_quantity#5 AS _c1#30, UnscaledValue(wr_refunded_cash#15) AS _c2#31, UnscaledValue(wr_fee#14) AS _c3#32]
 Input [4]: [ws_quantity#5, wr_fee#14, wr_refunded_cash#15, r_reason_desc#29]
 
-(114) NativeHashAggregate
+(112) NativeHashAggregate
 Input [4]: [r_reason_desc#29, _c1#30, _c2#31, _c3#32]
 Keys [1]: [r_reason_desc#29]
 Functions [3]: [partial_avg(_c1#30), partial_avg(_c2#31), partial_avg(_c3#32)]
 Aggregate Attributes [6]: [sum#33, count#34, sum#35, count#36, sum#37, count#38]
 Results [7]: [r_reason_desc#29, #39, #40, #39, #40, #39, #40]
 
-(115) NativeShuffleExchange
+(113) NativeShuffleExchange
 Input [7]: [r_reason_desc#29, #39, #40, #39, #40, #39, #40]
 Arguments: hashpartitioning(r_reason_desc#29, 100), ENSURE_REQUIREMENTS, [plan_id=15]
 
-(116) ShuffleQueryStage
+(114) ShuffleQueryStage
 Output [7]: [r_reason_desc#29, #39, #40, #39, #40, #39, #40]
 Arguments: X
 
-(117) AQEShuffleRead
+(115) AQEShuffleRead
 Input [7]: [r_reason_desc#29, #39, #40, #39, #40, #39, #40]
 Arguments: coalesced
 
-(118) InputAdapter
+(116) InputAdapter
 Input [7]: [r_reason_desc#29, #39, #40, #39, #40, #39, #40]
 
-(119) NativeHashAggregate
+(117) NativeHashAggregate
 Input [7]: [r_reason_desc#29, #39, #40, #39, #40, #39, #40]
 Keys [1]: [r_reason_desc#29]
 Functions [3]: [avg(ws_quantity#5), avg(UnscaledValue(wr_refunded_cash#15)), avg(UnscaledValue(wr_fee#14))]
 Aggregate Attributes [3]: [avg(ws_quantity#5)#41, avg(UnscaledValue(wr_refunded_cash#15))#42, avg(UnscaledValue(wr_fee#14))#43]
 Results [4]: [r_reason_desc#29, avg(ws_quantity#5)#41, avg(UnscaledValue(wr_refunded_cash#15))#42, avg(UnscaledValue(wr_fee#14))#43]
 
-(120) NativeProject
+(118) NativeProject
 Output [4]: [substr(r_reason_desc#29, 1, 20) AS substr(r_reason_desc, 1, 20)#44, avg(ws_quantity#5)#41 AS avg(ws_quantity)#45, cast((avg(UnscaledValue(wr_refunded_cash#15))#42 / 100.0) as decimal(11,6)) AS avg(wr_refunded_cash)#46, cast((avg(UnscaledValue(wr_fee#14))#43 / 100.0) as decimal(11,6)) AS avg(wr_fee)#47]
 Input [4]: [r_reason_desc#29, avg(ws_quantity#5)#41, avg(UnscaledValue(wr_refunded_cash#15))#42, avg(UnscaledValue(wr_fee#14))#43]
 
-(121) NativeTakeOrdered
+(119) NativeTakeOrdered
 Input [4]: [substr(r_reason_desc, 1, 20)#44, avg(ws_quantity)#45, avg(wr_refunded_cash)#46, avg(wr_fee)#47]
 Arguments: X, X, [substr(r_reason_desc, 1, 20)#44 ASC NULLS FIRST, avg(ws_quantity)#45 ASC NULLS FIRST, avg(wr_refunded_cash)#46 ASC NULLS FIRST, avg(wr_fee)#47 ASC NULLS FIRST]
 
-(122) Scan parquet
+(120) Scan parquet
 Output [7]: [ws_sold_date_sk#1, ws_item_sk#2, ws_web_page_sk#3, ws_order_number#4, ws_quantity#5, ws_sales_price#6, ws_net_profit#7]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(ws_item_sk), IsNotNull(ws_order_number), IsNotNull(ws_web_page_sk), IsNotNull(ws_sold_date_sk), Or(Or(And(GreaterThanOrEqual(ws_sales_price,100.00),LessThanOrEqual(ws_sales_price,150.00)),And(GreaterThanOrEqual(ws_sales_price,50.00),LessThanOrEqual(ws_sales_price,100.00))),And(GreaterThanOrEqual(ws_sales_price,150.00),LessThanOrEqual(ws_sales_price,200.00))), Or(Or(And(GreaterThanOrEqual(ws_net_profit,100.00),LessThanOrEqual(ws_net_profit,200.00)),And(GreaterThanOrEqual(ws_net_profit,150.00),LessThanOrEqual(ws_net_profit,300.00))),And(GreaterThanOrEqual(ws_net_profit,50.00),LessThanOrEqual(ws_net_profit,250.00)))]
 ReadSchema: struct<ws_sold_date_sk:int,ws_item_sk:int,ws_web_page_sk:int,ws_order_number:int,ws_quantity:int,ws_sales_price:decimal(7,2),ws_net_profit:decimal(7,2)>
 
-(123) Filter
+(121) Filter
 Input [7]: [ws_sold_date_sk#1, ws_item_sk#2, ws_web_page_sk#3, ws_order_number#4, ws_quantity#5, ws_sales_price#6, ws_net_profit#7]
 Condition : (((((isnotnull(ws_item_sk#2) AND isnotnull(ws_order_number#4)) AND isnotnull(ws_web_page_sk#3)) AND isnotnull(ws_sold_date_sk#1)) AND ((((ws_sales_price#6 >= 100.00) AND (ws_sales_price#6 <= 150.00)) OR ((ws_sales_price#6 >= 50.00) AND (ws_sales_price#6 <= 100.00))) OR ((ws_sales_price#6 >= 150.00) AND (ws_sales_price#6 <= 200.00)))) AND ((((ws_net_profit#7 >= 100.00) AND (ws_net_profit#7 <= 200.00)) OR ((ws_net_profit#7 >= 150.00) AND (ws_net_profit#7 <= 300.00))) OR ((ws_net_profit#7 >= 50.00) AND (ws_net_profit#7 <= 250.00))))
 
-(124) Exchange
+(122) Exchange
 Input [7]: [ws_sold_date_sk#1, ws_item_sk#2, ws_web_page_sk#3, ws_order_number#4, ws_quantity#5, ws_sales_price#6, ws_net_profit#7]
 Arguments: hashpartitioning(ws_item_sk#2, ws_order_number#4, 100), ENSURE_REQUIREMENTS, [plan_id=16]
 
-(125) Sort
+(123) Sort
 Input [7]: [ws_sold_date_sk#1, ws_item_sk#2, ws_web_page_sk#3, ws_order_number#4, ws_quantity#5, ws_sales_price#6, ws_net_profit#7]
 Arguments: [ws_item_sk#2 ASC NULLS FIRST, ws_order_number#4 ASC NULLS FIRST], false, 0
 
-(126) Scan parquet
+(124) Scan parquet
 Output [8]: [wr_item_sk#8, wr_refunded_cdemo_sk#9, wr_refunded_addr_sk#10, wr_returning_cdemo_sk#11, wr_reason_sk#12, wr_order_number#13, wr_fee#14, wr_refunded_cash#15]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(wr_item_sk), IsNotNull(wr_order_number), IsNotNull(wr_refunded_cdemo_sk), IsNotNull(wr_returning_cdemo_sk), IsNotNull(wr_refunded_addr_sk), IsNotNull(wr_reason_sk)]
 ReadSchema: struct<wr_item_sk:int,wr_refunded_cdemo_sk:int,wr_refunded_addr_sk:int,wr_returning_cdemo_sk:int,wr_reason_sk:int,wr_order_number:int,wr_fee:decimal(7,2),wr_refunded_cash:decimal(7,2)>
 
-(127) Filter
+(125) Filter
 Input [8]: [wr_item_sk#8, wr_refunded_cdemo_sk#9, wr_refunded_addr_sk#10, wr_returning_cdemo_sk#11, wr_reason_sk#12, wr_order_number#13, wr_fee#14, wr_refunded_cash#15]
 Condition : (((((isnotnull(wr_item_sk#8) AND isnotnull(wr_order_number#13)) AND isnotnull(wr_refunded_cdemo_sk#9)) AND isnotnull(wr_returning_cdemo_sk#11)) AND isnotnull(wr_refunded_addr_sk#10)) AND isnotnull(wr_reason_sk#12))
 
-(128) Exchange
+(126) Exchange
 Input [8]: [wr_item_sk#8, wr_refunded_cdemo_sk#9, wr_refunded_addr_sk#10, wr_returning_cdemo_sk#11, wr_reason_sk#12, wr_order_number#13, wr_fee#14, wr_refunded_cash#15]
 Arguments: hashpartitioning(wr_item_sk#8, wr_order_number#13, 100), ENSURE_REQUIREMENTS, [plan_id=17]
 
-(129) Sort
+(127) Sort
 Input [8]: [wr_item_sk#8, wr_refunded_cdemo_sk#9, wr_refunded_addr_sk#10, wr_returning_cdemo_sk#11, wr_reason_sk#12, wr_order_number#13, wr_fee#14, wr_refunded_cash#15]
 Arguments: [wr_item_sk#8 ASC NULLS FIRST, wr_order_number#13 ASC NULLS FIRST], false, 0
 
-(130) SortMergeJoin
+(128) SortMergeJoin
 Left keys [2]: [ws_item_sk#2, ws_order_number#4]
 Right keys [2]: [wr_item_sk#8, wr_order_number#13]
 Join type: Inner
 Join condition: None
 
-(131) Project
+(129) Project
 Output [11]: [ws_sold_date_sk#1, ws_web_page_sk#3, ws_quantity#5, ws_sales_price#6, ws_net_profit#7, wr_refunded_cdemo_sk#9, wr_refunded_addr_sk#10, wr_returning_cdemo_sk#11, wr_reason_sk#12, wr_fee#14, wr_refunded_cash#15]
 Input [15]: [ws_sold_date_sk#1, ws_item_sk#2, ws_web_page_sk#3, ws_order_number#4, ws_quantity#5, ws_sales_price#6, ws_net_profit#7, wr_item_sk#8, wr_refunded_cdemo_sk#9, wr_refunded_addr_sk#10, wr_returning_cdemo_sk#11, wr_reason_sk#12, wr_order_number#13, wr_fee#14, wr_refunded_cash#15]
 
-(132) Exchange
+(130) Exchange
 Input [11]: [ws_sold_date_sk#1, ws_web_page_sk#3, ws_quantity#5, ws_sales_price#6, ws_net_profit#7, wr_refunded_cdemo_sk#9, wr_refunded_addr_sk#10, wr_returning_cdemo_sk#11, wr_reason_sk#12, wr_fee#14, wr_refunded_cash#15]
 Arguments: hashpartitioning(ws_web_page_sk#3, 100), ENSURE_REQUIREMENTS, [plan_id=18]
 
-(133) Sort
+(131) Sort
 Input [11]: [ws_sold_date_sk#1, ws_web_page_sk#3, ws_quantity#5, ws_sales_price#6, ws_net_profit#7, wr_refunded_cdemo_sk#9, wr_refunded_addr_sk#10, wr_returning_cdemo_sk#11, wr_reason_sk#12, wr_fee#14, wr_refunded_cash#15]
 Arguments: [ws_web_page_sk#3 ASC NULLS FIRST], false, 0
 
-(134) Scan parquet
+(132) Scan parquet
 Output [1]: [wp_web_page_sk#16]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(wp_web_page_sk)]
 ReadSchema: struct<wp_web_page_sk:int>
 
-(135) Filter
+(133) Filter
 Input [1]: [wp_web_page_sk#16]
 Condition : isnotnull(wp_web_page_sk#16)
 
-(136) Exchange
+(134) Exchange
 Input [1]: [wp_web_page_sk#16]
 Arguments: hashpartitioning(wp_web_page_sk#16, 100), ENSURE_REQUIREMENTS, [plan_id=19]
 
-(137) Sort
+(135) Sort
 Input [1]: [wp_web_page_sk#16]
 Arguments: [wp_web_page_sk#16 ASC NULLS FIRST], false, 0
 
-(138) SortMergeJoin
+(136) SortMergeJoin
 Left keys [1]: [ws_web_page_sk#3]
 Right keys [1]: [wp_web_page_sk#16]
 Join type: Inner
 Join condition: None
 
-(139) Project
+(137) Project
 Output [10]: [ws_sold_date_sk#1, ws_quantity#5, ws_sales_price#6, ws_net_profit#7, wr_refunded_cdemo_sk#9, wr_refunded_addr_sk#10, wr_returning_cdemo_sk#11, wr_reason_sk#12, wr_fee#14, wr_refunded_cash#15]
 Input [12]: [ws_sold_date_sk#1, ws_web_page_sk#3, ws_quantity#5, ws_sales_price#6, ws_net_profit#7, wr_refunded_cdemo_sk#9, wr_refunded_addr_sk#10, wr_returning_cdemo_sk#11, wr_reason_sk#12, wr_fee#14, wr_refunded_cash#15, wp_web_page_sk#16]
 
-(140) Exchange
+(138) Exchange
 Input [10]: [ws_sold_date_sk#1, ws_quantity#5, ws_sales_price#6, ws_net_profit#7, wr_refunded_cdemo_sk#9, wr_refunded_addr_sk#10, wr_returning_cdemo_sk#11, wr_reason_sk#12, wr_fee#14, wr_refunded_cash#15]
 Arguments: hashpartitioning(wr_refunded_cdemo_sk#9, 100), ENSURE_REQUIREMENTS, [plan_id=20]
 
-(141) Sort
+(139) Sort
 Input [10]: [ws_sold_date_sk#1, ws_quantity#5, ws_sales_price#6, ws_net_profit#7, wr_refunded_cdemo_sk#9, wr_refunded_addr_sk#10, wr_returning_cdemo_sk#11, wr_reason_sk#12, wr_fee#14, wr_refunded_cash#15]
 Arguments: [wr_refunded_cdemo_sk#9 ASC NULLS FIRST], false, 0
 
-(142) Scan parquet
+(140) Scan parquet
 Output [3]: [cd_demo_sk#17, cd_marital_status#18, cd_education_status#19]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(cd_demo_sk), IsNotNull(cd_marital_status), IsNotNull(cd_education_status), Or(Or(And(EqualTo(cd_marital_status,M),EqualTo(cd_education_status,Advanced Degree)),And(EqualTo(cd_marital_status,S),EqualTo(cd_education_status,College))),And(EqualTo(cd_marital_status,W),EqualTo(cd_education_status,2 yr Degree)))]
 ReadSchema: struct<cd_demo_sk:int,cd_marital_status:string,cd_education_status:string>
 
-(143) Filter
+(141) Filter
 Input [3]: [cd_demo_sk#17, cd_marital_status#18, cd_education_status#19]
 Condition : (((isnotnull(cd_demo_sk#17) AND isnotnull(cd_marital_status#18)) AND isnotnull(cd_education_status#19)) AND ((((cd_marital_status#18 = M) AND (cd_education_status#19 = Advanced Degree)) OR ((cd_marital_status#18 = S) AND (cd_education_status#19 = College))) OR ((cd_marital_status#18 = W) AND (cd_education_status#19 = 2 yr Degree))))
 
-(144) Exchange
+(142) Exchange
 Input [3]: [cd_demo_sk#17, cd_marital_status#18, cd_education_status#19]
 Arguments: hashpartitioning(cd_demo_sk#17, 100), ENSURE_REQUIREMENTS, [plan_id=21]
 
-(145) Sort
+(143) Sort
 Input [3]: [cd_demo_sk#17, cd_marital_status#18, cd_education_status#19]
 Arguments: [cd_demo_sk#17 ASC NULLS FIRST], false, 0
 
-(146) SortMergeJoin
+(144) SortMergeJoin
 Left keys [1]: [wr_refunded_cdemo_sk#9]
 Right keys [1]: [cd_demo_sk#17]
 Join type: Inner
 Join condition: ((((((cd_marital_status#18 = M) AND (cd_education_status#19 = Advanced Degree)) AND (ws_sales_price#6 >= 100.00)) AND (ws_sales_price#6 <= 150.00)) OR ((((cd_marital_status#18 = S) AND (cd_education_status#19 = College)) AND (ws_sales_price#6 >= 50.00)) AND (ws_sales_price#6 <= 100.00))) OR ((((cd_marital_status#18 = W) AND (cd_education_status#19 = 2 yr Degree)) AND (ws_sales_price#6 >= 150.00)) AND (ws_sales_price#6 <= 200.00)))
 
-(147) Project
+(145) Project
 Output [10]: [ws_sold_date_sk#1, ws_quantity#5, ws_net_profit#7, wr_refunded_addr_sk#10, wr_returning_cdemo_sk#11, wr_reason_sk#12, wr_fee#14, wr_refunded_cash#15, cd_marital_status#18, cd_education_status#19]
 Input [13]: [ws_sold_date_sk#1, ws_quantity#5, ws_sales_price#6, ws_net_profit#7, wr_refunded_cdemo_sk#9, wr_refunded_addr_sk#10, wr_returning_cdemo_sk#11, wr_reason_sk#12, wr_fee#14, wr_refunded_cash#15, cd_demo_sk#17, cd_marital_status#18, cd_education_status#19]
 
-(148) Exchange
+(146) Exchange
 Input [10]: [ws_sold_date_sk#1, ws_quantity#5, ws_net_profit#7, wr_refunded_addr_sk#10, wr_returning_cdemo_sk#11, wr_reason_sk#12, wr_fee#14, wr_refunded_cash#15, cd_marital_status#18, cd_education_status#19]
 Arguments: hashpartitioning(wr_returning_cdemo_sk#11, cd_marital_status#18, cd_education_status#19, 100), ENSURE_REQUIREMENTS, [plan_id=22]
 
-(149) Sort
+(147) Sort
 Input [10]: [ws_sold_date_sk#1, ws_quantity#5, ws_net_profit#7, wr_refunded_addr_sk#10, wr_returning_cdemo_sk#11, wr_reason_sk#12, wr_fee#14, wr_refunded_cash#15, cd_marital_status#18, cd_education_status#19]
 Arguments: [wr_returning_cdemo_sk#11 ASC NULLS FIRST, cd_marital_status#18 ASC NULLS FIRST, cd_education_status#19 ASC NULLS FIRST], false, 0
 
-(150) Scan parquet
+(148) Scan parquet
 Output [3]: [cd_demo_sk#20, cd_marital_status#21, cd_education_status#22]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(cd_demo_sk), IsNotNull(cd_marital_status), IsNotNull(cd_education_status)]
 ReadSchema: struct<cd_demo_sk:int,cd_marital_status:string,cd_education_status:string>
 
-(151) Filter
+(149) Filter
 Input [3]: [cd_demo_sk#20, cd_marital_status#21, cd_education_status#22]
 Condition : ((isnotnull(cd_demo_sk#20) AND isnotnull(cd_marital_status#21)) AND isnotnull(cd_education_status#22))
 
-(152) Exchange
+(150) Exchange
 Input [3]: [cd_demo_sk#20, cd_marital_status#21, cd_education_status#22]
 Arguments: hashpartitioning(cd_demo_sk#20, cd_marital_status#21, cd_education_status#22, 100), ENSURE_REQUIREMENTS, [plan_id=23]
 
-(153) Sort
+(151) Sort
 Input [3]: [cd_demo_sk#20, cd_marital_status#21, cd_education_status#22]
 Arguments: [cd_demo_sk#20 ASC NULLS FIRST, cd_marital_status#21 ASC NULLS FIRST, cd_education_status#22 ASC NULLS FIRST], false, 0
 
-(154) SortMergeJoin
+(152) SortMergeJoin
 Left keys [3]: [wr_returning_cdemo_sk#11, cd_marital_status#18, cd_education_status#19]
 Right keys [3]: [cd_demo_sk#20, cd_marital_status#21, cd_education_status#22]
 Join type: Inner
 Join condition: None
 
-(155) Project
+(153) Project
 Output [7]: [ws_sold_date_sk#1, ws_quantity#5, ws_net_profit#7, wr_refunded_addr_sk#10, wr_reason_sk#12, wr_fee#14, wr_refunded_cash#15]
 Input [13]: [ws_sold_date_sk#1, ws_quantity#5, ws_net_profit#7, wr_refunded_addr_sk#10, wr_returning_cdemo_sk#11, wr_reason_sk#12, wr_fee#14, wr_refunded_cash#15, cd_marital_status#18, cd_education_status#19, cd_demo_sk#20, cd_marital_status#21, cd_education_status#22]
 
-(156) Exchange
+(154) Exchange
 Input [7]: [ws_sold_date_sk#1, ws_quantity#5, ws_net_profit#7, wr_refunded_addr_sk#10, wr_reason_sk#12, wr_fee#14, wr_refunded_cash#15]
 Arguments: hashpartitioning(wr_refunded_addr_sk#10, 100), ENSURE_REQUIREMENTS, [plan_id=24]
 
-(157) Sort
+(155) Sort
 Input [7]: [ws_sold_date_sk#1, ws_quantity#5, ws_net_profit#7, wr_refunded_addr_sk#10, wr_reason_sk#12, wr_fee#14, wr_refunded_cash#15]
 Arguments: [wr_refunded_addr_sk#10 ASC NULLS FIRST], false, 0
 
-(158) Scan parquet
+(156) Scan parquet
 Output [3]: [ca_address_sk#23, ca_state#24, ca_country#25]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(ca_country), EqualTo(ca_country,United States), IsNotNull(ca_address_sk), Or(Or(In(ca_state, [IN,NJ,OH]),In(ca_state, [CT,KY,WI])),In(ca_state, [AR,IA,LA]))]
 ReadSchema: struct<ca_address_sk:int,ca_state:string,ca_country:string>
 
-(159) Filter
+(157) Filter
 Input [3]: [ca_address_sk#23, ca_state#24, ca_country#25]
 Condition : (((isnotnull(ca_country#25) AND (ca_country#25 = United States)) AND isnotnull(ca_address_sk#23)) AND ((ca_state#24 IN (IN,OH,NJ) OR ca_state#24 IN (WI,CT,KY)) OR ca_state#24 IN (LA,IA,AR)))
 
-(160) Project
+(158) Project
 Output [2]: [ca_address_sk#23, ca_state#24]
 Input [3]: [ca_address_sk#23, ca_state#24, ca_country#25]
 
-(161) Exchange
+(159) Exchange
 Input [2]: [ca_address_sk#23, ca_state#24]
 Arguments: hashpartitioning(ca_address_sk#23, 100), ENSURE_REQUIREMENTS, [plan_id=25]
 
-(162) Sort
+(160) Sort
 Input [2]: [ca_address_sk#23, ca_state#24]
 Arguments: [ca_address_sk#23 ASC NULLS FIRST], false, 0
 
-(163) SortMergeJoin
+(161) SortMergeJoin
 Left keys [1]: [wr_refunded_addr_sk#10]
 Right keys [1]: [ca_address_sk#23]
 Join type: Inner
 Join condition: ((((ca_state#24 IN (IN,OH,NJ) AND (ws_net_profit#7 >= 100.00)) AND (ws_net_profit#7 <= 200.00)) OR ((ca_state#24 IN (WI,CT,KY) AND (ws_net_profit#7 >= 150.00)) AND (ws_net_profit#7 <= 300.00))) OR ((ca_state#24 IN (LA,IA,AR) AND (ws_net_profit#7 >= 50.00)) AND (ws_net_profit#7 <= 250.00)))
 
-(164) Project
+(162) Project
 Output [5]: [ws_sold_date_sk#1, ws_quantity#5, wr_reason_sk#12, wr_fee#14, wr_refunded_cash#15]
 Input [9]: [ws_sold_date_sk#1, ws_quantity#5, ws_net_profit#7, wr_refunded_addr_sk#10, wr_reason_sk#12, wr_fee#14, wr_refunded_cash#15, ca_address_sk#23, ca_state#24]
 
-(165) Exchange
+(163) Exchange
 Input [5]: [ws_sold_date_sk#1, ws_quantity#5, wr_reason_sk#12, wr_fee#14, wr_refunded_cash#15]
 Arguments: hashpartitioning(ws_sold_date_sk#1, 100), ENSURE_REQUIREMENTS, [plan_id=26]
 
-(166) Sort
+(164) Sort
 Input [5]: [ws_sold_date_sk#1, ws_quantity#5, wr_reason_sk#12, wr_fee#14, wr_refunded_cash#15]
 Arguments: [ws_sold_date_sk#1 ASC NULLS FIRST], false, 0
 
-(167) Scan parquet
+(165) Scan parquet
 Output [2]: [d_date_sk#26, d_year#27]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2000), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
-(168) Filter
+(166) Filter
 Input [2]: [d_date_sk#26, d_year#27]
 Condition : ((isnotnull(d_year#27) AND (d_year#27 = 2000)) AND isnotnull(d_date_sk#26))
 
-(169) Project
+(167) Project
 Output [1]: [d_date_sk#26]
 Input [2]: [d_date_sk#26, d_year#27]
 
-(170) Exchange
+(168) Exchange
 Input [1]: [d_date_sk#26]
 Arguments: hashpartitioning(d_date_sk#26, 100), ENSURE_REQUIREMENTS, [plan_id=27]
 
-(171) Sort
+(169) Sort
 Input [1]: [d_date_sk#26]
 Arguments: [d_date_sk#26 ASC NULLS FIRST], false, 0
 
-(172) SortMergeJoin
+(170) SortMergeJoin
 Left keys [1]: [ws_sold_date_sk#1]
 Right keys [1]: [d_date_sk#26]
 Join type: Inner
 Join condition: None
 
-(173) Project
+(171) Project
 Output [4]: [ws_quantity#5, wr_reason_sk#12, wr_fee#14, wr_refunded_cash#15]
 Input [6]: [ws_sold_date_sk#1, ws_quantity#5, wr_reason_sk#12, wr_fee#14, wr_refunded_cash#15, d_date_sk#26]
 
-(174) Exchange
+(172) Exchange
 Input [4]: [ws_quantity#5, wr_reason_sk#12, wr_fee#14, wr_refunded_cash#15]
 Arguments: hashpartitioning(wr_reason_sk#12, 100), ENSURE_REQUIREMENTS, [plan_id=28]
 
-(175) Sort
+(173) Sort
 Input [4]: [ws_quantity#5, wr_reason_sk#12, wr_fee#14, wr_refunded_cash#15]
 Arguments: [wr_reason_sk#12 ASC NULLS FIRST], false, 0
 
-(176) Scan parquet
+(174) Scan parquet
 Output [2]: [r_reason_sk#28, r_reason_desc#29]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(r_reason_sk)]
 ReadSchema: struct<r_reason_sk:int,r_reason_desc:string>
 
-(177) Filter
+(175) Filter
 Input [2]: [r_reason_sk#28, r_reason_desc#29]
 Condition : isnotnull(r_reason_sk#28)
 
-(178) Exchange
+(176) Exchange
 Input [2]: [r_reason_sk#28, r_reason_desc#29]
 Arguments: hashpartitioning(r_reason_sk#28, 100), ENSURE_REQUIREMENTS, [plan_id=29]
 
-(179) Sort
+(177) Sort
 Input [2]: [r_reason_sk#28, r_reason_desc#29]
 Arguments: [r_reason_sk#28 ASC NULLS FIRST], false, 0
 
-(180) SortMergeJoin
+(178) SortMergeJoin
 Left keys [1]: [wr_reason_sk#12]
 Right keys [1]: [r_reason_sk#28]
 Join type: Inner
 Join condition: None
 
-(181) Project
+(179) Project
 Output [4]: [ws_quantity#5, wr_fee#14, wr_refunded_cash#15, r_reason_desc#29]
 Input [6]: [ws_quantity#5, wr_reason_sk#12, wr_fee#14, wr_refunded_cash#15, r_reason_sk#28, r_reason_desc#29]
 
-(182) HashAggregate
+(180) HashAggregate
 Input [4]: [ws_quantity#5, wr_fee#14, wr_refunded_cash#15, r_reason_desc#29]
 Keys [1]: [r_reason_desc#29]
 Functions [3]: [partial_avg(ws_quantity#5), partial_avg(UnscaledValue(wr_refunded_cash#15)), partial_avg(UnscaledValue(wr_fee#14))]
 Aggregate Attributes [6]: [sum#33, count#34, sum#35, count#36, sum#37, count#38]
 Results [7]: [r_reason_desc#29, sum#48, count#49, sum#50, count#51, sum#52, count#53]
 
-(183) Exchange
+(181) Exchange
 Input [7]: [r_reason_desc#29, sum#48, count#49, sum#50, count#51, sum#52, count#53]
 Arguments: hashpartitioning(r_reason_desc#29, 100), ENSURE_REQUIREMENTS, [plan_id=30]
 
-(184) HashAggregate
+(182) HashAggregate
 Input [7]: [r_reason_desc#29, sum#48, count#49, sum#50, count#51, sum#52, count#53]
 Keys [1]: [r_reason_desc#29]
 Functions [3]: [avg(ws_quantity#5), avg(UnscaledValue(wr_refunded_cash#15)), avg(UnscaledValue(wr_fee#14))]
 Aggregate Attributes [3]: [avg(ws_quantity#5)#41, avg(UnscaledValue(wr_refunded_cash#15))#42, avg(UnscaledValue(wr_fee#14))#43]
 Results [4]: [substr(r_reason_desc#29, 1, 20) AS substr(r_reason_desc, 1, 20)#44, avg(ws_quantity#5)#41 AS avg(ws_quantity)#45, cast((avg(UnscaledValue(wr_refunded_cash#15))#42 / 100.0) as decimal(11,6)) AS avg(wr_refunded_cash)#46, cast((avg(UnscaledValue(wr_fee#14))#43 / 100.0) as decimal(11,6)) AS avg(wr_fee)#47]
 
-(185) TakeOrderedAndProject
+(183) TakeOrderedAndProject
 Input [4]: [substr(r_reason_desc, 1, 20)#44, avg(ws_quantity)#45, avg(wr_refunded_cash)#46, avg(wr_fee)#47]
 Arguments: X, [substr(r_reason_desc, 1, 20)#44 ASC NULLS FIRST, avg(ws_quantity)#45 ASC NULLS FIRST, avg(wr_refunded_cash)#46 ASC NULLS FIRST, avg(wr_fee)#47 ASC NULLS FIRST], [substr(r_reason_desc, 1, 20)#44, avg(ws_quantity)#45, avg(wr_refunded_cash)#46, avg(wr_fee)#47]
 
-(186) AdaptiveSparkPlan
+(184) AdaptiveSparkPlan
 Output [4]: [substr(r_reason_desc, 1, 20)#44, avg(ws_quantity)#45, avg(wr_refunded_cash)#46, avg(wr_fee)#47]
 Arguments: isFinalPlan=true
 

--- a/dev/auron-it/src/main/resources/tpcds-plan-stability/spark-3.5/q92.txt
+++ b/dev/auron-it/src/main/resources/tpcds-plan-stability/spark-3.5/q92.txt
@@ -1,121 +1,120 @@
 == Physical Plan ==
-AdaptiveSparkPlan (112)
+AdaptiveSparkPlan (111)
 +- == Final Plan ==
-   NativeProject (70)
-   +- NativeHashAggregate (69)
-      +- ShuffleQueryStage (68), Statistics(X)
-         +- NativeShuffleExchange (67)
-            +- NativeHashAggregate (66)
-               +- NativeProject (65)
-                  +- NativeProject (64)
-                     +- NativeSortMergeJoin Inner (63)
-                        :- NativeSort (56)
-                        :  +- InputAdapter (55)
-                        :     +- AQEShuffleRead (54)
-                        :        +- ShuffleQueryStage (53), Statistics(X)
-                        :           +- NativeShuffleExchange (52)
-                        :              +- ConvertToNative (51)
-                        :                 +- * Project (50)
-                        :                    +- * SortMergeJoin Inner (49)
-                        :                       :- NativeProject (19)
-                        :                       :  +- NativeSortMergeJoin Inner (18)
-                        :                       :     :- NativeSort (8)
-                        :                       :     :  +- InputAdapter (7)
-                        :                       :     :     +- AQEShuffleRead (6)
-                        :                       :     :        +- ShuffleQueryStage (5), Statistics(X)
-                        :                       :     :           +- NativeShuffleExchange (4)
-                        :                       :     :              +- NativeFilter (3)
-                        :                       :     :                 +- InputAdapter (2)
-                        :                       :     :                    +- NativeParquetScan  (1)
-                        :                       :     +- NativeSort (17)
-                        :                       :        +- InputAdapter (16)
-                        :                       :           +- AQEShuffleRead (15)
-                        :                       :              +- ShuffleQueryStage (14), Statistics(X)
-                        :                       :                 +- NativeShuffleExchange (13)
-                        :                       :                    +- NativeProject (12)
-                        :                       :                       +- NativeFilter (11)
-                        :                       :                          +- InputAdapter (10)
-                        :                       :                             +- NativeParquetScan  (9)
-                        :                       +- NativeSort (48)
-                        :                          +- NativeFilter (47)
-                        :                             +- NativeProject (46)
-                        :                                +- NativeHashAggregate (45)
-                        :                                   +- InputAdapter (44)
-                        :                                      +- AQEShuffleRead (43)
-                        :                                         +- ShuffleQueryStage (42), Statistics(X)
-                        :                                            +- NativeShuffleExchange (41)
-                        :                                               +- NativeHashAggregate (40)
-                        :                                                  +- NativeProject (39)
-                        :                                                     +- NativeProject (38)
-                        :                                                        +- NativeSortMergeJoin Inner (37)
-                        :                                                           :- NativeSort (27)
-                        :                                                           :  +- InputAdapter (26)
-                        :                                                           :     +- AQEShuffleRead (25)
-                        :                                                           :        +- ShuffleQueryStage (24), Statistics(X)
-                        :                                                           :           +- NativeShuffleExchange (23)
-                        :                                                           :              +- NativeFilter (22)
-                        :                                                           :                 +- InputAdapter (21)
-                        :                                                           :                    +- NativeParquetScan  (20)
-                        :                                                           +- NativeSort (36)
-                        :                                                              +- InputAdapter (35)
-                        :                                                                 +- AQEShuffleRead (34)
-                        :                                                                    +- ShuffleQueryStage (33), Statistics(X)
-                        :                                                                       +- NativeShuffleExchange (32)
-                        :                                                                          +- NativeProject (31)
-                        :                                                                             +- NativeFilter (30)
-                        :                                                                                +- InputAdapter (29)
-                        :                                                                                   +- NativeParquetScan  (28)
-                        +- NativeSort (62)
-                           +- InputAdapter (61)
-                              +- InputAdapter (60)
-                                 +- AQEShuffleRead (59)
-                                    +- ShuffleQueryStage (58), Statistics(X)
-                                       +- ReusedExchange (57)
+   NativeProject (69)
+   +- NativeHashAggregate (68)
+      +- ShuffleQueryStage (67), Statistics(X)
+         +- NativeShuffleExchange (66)
+            +- NativeHashAggregate (65)
+               +- NativeProject (64)
+                  +- NativeProject (63)
+                     +- NativeSortMergeJoin Inner (62)
+                        :- NativeSort (55)
+                        :  +- InputAdapter (54)
+                        :     +- AQEShuffleRead (53)
+                        :        +- ShuffleQueryStage (52), Statistics(X)
+                        :           +- NativeShuffleExchange (51)
+                        :              +- NativeProject (50)
+                        :                 +- NativeSortMergeJoin Inner (49)
+                        :                    :- NativeProject (19)
+                        :                    :  +- NativeSortMergeJoin Inner (18)
+                        :                    :     :- NativeSort (8)
+                        :                    :     :  +- InputAdapter (7)
+                        :                    :     :     +- AQEShuffleRead (6)
+                        :                    :     :        +- ShuffleQueryStage (5), Statistics(X)
+                        :                    :     :           +- NativeShuffleExchange (4)
+                        :                    :     :              +- NativeFilter (3)
+                        :                    :     :                 +- InputAdapter (2)
+                        :                    :     :                    +- NativeParquetScan  (1)
+                        :                    :     +- NativeSort (17)
+                        :                    :        +- InputAdapter (16)
+                        :                    :           +- AQEShuffleRead (15)
+                        :                    :              +- ShuffleQueryStage (14), Statistics(X)
+                        :                    :                 +- NativeShuffleExchange (13)
+                        :                    :                    +- NativeProject (12)
+                        :                    :                       +- NativeFilter (11)
+                        :                    :                          +- InputAdapter (10)
+                        :                    :                             +- NativeParquetScan  (9)
+                        :                    +- NativeSort (48)
+                        :                       +- NativeFilter (47)
+                        :                          +- NativeProject (46)
+                        :                             +- NativeHashAggregate (45)
+                        :                                +- InputAdapter (44)
+                        :                                   +- AQEShuffleRead (43)
+                        :                                      +- ShuffleQueryStage (42), Statistics(X)
+                        :                                         +- NativeShuffleExchange (41)
+                        :                                            +- NativeHashAggregate (40)
+                        :                                               +- NativeProject (39)
+                        :                                                  +- NativeProject (38)
+                        :                                                     +- NativeSortMergeJoin Inner (37)
+                        :                                                        :- NativeSort (27)
+                        :                                                        :  +- InputAdapter (26)
+                        :                                                        :     +- AQEShuffleRead (25)
+                        :                                                        :        +- ShuffleQueryStage (24), Statistics(X)
+                        :                                                        :           +- NativeShuffleExchange (23)
+                        :                                                        :              +- NativeFilter (22)
+                        :                                                        :                 +- InputAdapter (21)
+                        :                                                        :                    +- NativeParquetScan  (20)
+                        :                                                        +- NativeSort (36)
+                        :                                                           +- InputAdapter (35)
+                        :                                                              +- AQEShuffleRead (34)
+                        :                                                                 +- ShuffleQueryStage (33), Statistics(X)
+                        :                                                                    +- NativeShuffleExchange (32)
+                        :                                                                       +- NativeProject (31)
+                        :                                                                          +- NativeFilter (30)
+                        :                                                                             +- InputAdapter (29)
+                        :                                                                                +- NativeParquetScan  (28)
+                        +- NativeSort (61)
+                           +- InputAdapter (60)
+                              +- InputAdapter (59)
+                                 +- AQEShuffleRead (58)
+                                    +- ShuffleQueryStage (57), Statistics(X)
+                                       +- ReusedExchange (56)
 +- == Initial Plan ==
-   HashAggregate (111)
-   +- Exchange (110)
-      +- HashAggregate (109)
-         +- Project (108)
-            +- SortMergeJoin Inner (107)
-               :- Sort (101)
-               :  +- Exchange (100)
-               :     +- Project (99)
-               :        +- SortMergeJoin Inner (98)
-               :           :- Project (81)
-               :           :  +- SortMergeJoin Inner (80)
-               :           :     :- Sort (74)
-               :           :     :  +- Exchange (73)
-               :           :     :     +- Filter (72)
-               :           :     :        +- Scan parquet (71)
-               :           :     +- Sort (79)
-               :           :        +- Exchange (78)
-               :           :           +- Project (77)
-               :           :              +- Filter (76)
-               :           :                 +- Scan parquet (75)
-               :           +- Sort (97)
-               :              +- Filter (96)
-               :                 +- HashAggregate (95)
-               :                    +- Exchange (94)
-               :                       +- HashAggregate (93)
-               :                          +- Project (92)
-               :                             +- SortMergeJoin Inner (91)
-               :                                :- Sort (85)
-               :                                :  +- Exchange (84)
-               :                                :     +- Filter (83)
-               :                                :        +- Scan parquet (82)
-               :                                +- Sort (90)
-               :                                   +- Exchange (89)
-               :                                      +- Project (88)
-               :                                         +- Filter (87)
-               :                                            +- Scan parquet (86)
-               +- Sort (106)
-                  +- Exchange (105)
-                     +- Project (104)
-                        +- Filter (103)
-                           +- Scan parquet (102)
+   HashAggregate (110)
+   +- Exchange (109)
+      +- HashAggregate (108)
+         +- Project (107)
+            +- SortMergeJoin Inner (106)
+               :- Sort (100)
+               :  +- Exchange (99)
+               :     +- Project (98)
+               :        +- SortMergeJoin Inner (97)
+               :           :- Project (80)
+               :           :  +- SortMergeJoin Inner (79)
+               :           :     :- Sort (73)
+               :           :     :  +- Exchange (72)
+               :           :     :     +- Filter (71)
+               :           :     :        +- Scan parquet (70)
+               :           :     +- Sort (78)
+               :           :        +- Exchange (77)
+               :           :           +- Project (76)
+               :           :              +- Filter (75)
+               :           :                 +- Scan parquet (74)
+               :           +- Sort (96)
+               :              +- Filter (95)
+               :                 +- HashAggregate (94)
+               :                    +- Exchange (93)
+               :                       +- HashAggregate (92)
+               :                          +- Project (91)
+               :                             +- SortMergeJoin Inner (90)
+               :                                :- Sort (84)
+               :                                :  +- Exchange (83)
+               :                                :     +- Filter (82)
+               :                                :        +- Scan parquet (81)
+               :                                +- Sort (89)
+               :                                   +- Exchange (88)
+               :                                      +- Project (87)
+               :                                         +- Filter (86)
+               :                                            +- Scan parquet (85)
+               +- Sort (105)
+                  +- Exchange (104)
+                     +- Project (103)
+                        +- Filter (102)
+                           +- Scan parquet (101)
 
 
-(71) Scan parquet
+(70) Scan parquet
 Output [3]: [ws_sold_date_sk#1, ws_item_sk#2, ws_ext_discount_amt#3]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
@@ -149,7 +148,7 @@ Input [3]: [#1#1, #2#2, #3#3]
 Input [3]: [#1#1, #2#2, #3#3]
 Arguments: [ws_item_sk#2 ASC NULLS FIRST], false
 
-(75) Scan parquet
+(74) Scan parquet
 Output [2]: [i_item_sk#4, i_manufact_id#5]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
@@ -197,7 +196,7 @@ Join condition: None
 Output [3]: [ws_sold_date_sk#1, ws_ext_discount_amt#3, i_item_sk#4]
 Input [4]: [#1#1, #2#2, #3#3, i_item_sk#4]
 
-(82) Scan parquet
+(81) Scan parquet
 Output [3]: [ws_sold_date_sk#6, ws_item_sk#7, ws_ext_discount_amt#8]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
@@ -231,7 +230,7 @@ Input [3]: [#6#6, #7#7, #8#8]
 Input [3]: [#6#6, #7#7, #8#8]
 Arguments: [ws_sold_date_sk#6 ASC NULLS FIRST], false
 
-(86) Scan parquet
+(85) Scan parquet
 Output [2]: [d_date_sk#9, d_date#10]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
@@ -324,300 +323,297 @@ Condition : isnotnull((1.3 * avg(ws_ext_discount_amt))#17)
 Input [2]: [(1.3 * avg(ws_ext_discount_amt))#17, ws_item_sk#7]
 Arguments: [ws_item_sk#7 ASC NULLS FIRST], false
 
-(49) SortMergeJoin [codegen id : X]
+(49) NativeSortMergeJoin
 Left keys [1]: [i_item_sk#4]
 Right keys [1]: [ws_item_sk#7]
 Join type: Inner
 Join condition: (cast(ws_ext_discount_amt#3 as decimal(14,7)) > (1.3 * avg(ws_ext_discount_amt))#17)
 
-(50) Project [codegen id : X]
+(50) NativeProject
 Output [2]: [ws_sold_date_sk#1, ws_ext_discount_amt#3]
 Input [5]: [ws_sold_date_sk#1, ws_ext_discount_amt#3, i_item_sk#4, (1.3 * avg(ws_ext_discount_amt))#17, ws_item_sk#7]
 
-(51) ConvertToNative
-Input [2]: [ws_sold_date_sk#1, ws_ext_discount_amt#3]
-
-(52) NativeShuffleExchange
+(51) NativeShuffleExchange
 Input [2]: [ws_sold_date_sk#1, ws_ext_discount_amt#3]
 Arguments: hashpartitioning(ws_sold_date_sk#1, 100), ENSURE_REQUIREMENTS, [plan_id=6]
 
-(53) ShuffleQueryStage
+(52) ShuffleQueryStage
 Output [2]: [ws_sold_date_sk#1, ws_ext_discount_amt#3]
 Arguments: X
 
-(54) AQEShuffleRead
+(53) AQEShuffleRead
 Input [2]: [ws_sold_date_sk#1, ws_ext_discount_amt#3]
 Arguments: coalesced
 
-(55) InputAdapter
+(54) InputAdapter
 Input [2]: [ws_sold_date_sk#1, ws_ext_discount_amt#3]
 
-(56) NativeSort
+(55) NativeSort
 Input [2]: [ws_sold_date_sk#1, ws_ext_discount_amt#3]
 Arguments: [ws_sold_date_sk#1 ASC NULLS FIRST], false
 
-(57) ReusedExchange [Reuses operator id: 32]
+(56) ReusedExchange [Reuses operator id: 32]
 Output [1]: [d_date_sk#18]
 
-(58) ShuffleQueryStage
+(57) ShuffleQueryStage
 Output [1]: [d_date_sk#18]
 Arguments: X
 
-(59) AQEShuffleRead
+(58) AQEShuffleRead
 Input [1]: [d_date_sk#18]
 Arguments: coalesced
 
-(60) InputAdapter
+(59) InputAdapter
 Input [1]: [d_date_sk#18]
 Arguments: [#18]
 
-(61) InputAdapter
+(60) InputAdapter
 Input [1]: [#18#18]
 
-(62) NativeSort
+(61) NativeSort
 Input [1]: [#18#18]
 Arguments: [d_date_sk#18 ASC NULLS FIRST], false
 
-(63) NativeSortMergeJoin
+(62) NativeSortMergeJoin
 Left keys [1]: [ws_sold_date_sk#1]
 Right keys [1]: [d_date_sk#18]
 Join type: Inner
 Join condition: None
 
-(64) NativeProject
+(63) NativeProject
 Output [1]: [ws_ext_discount_amt#3]
 Input [3]: [ws_sold_date_sk#1, ws_ext_discount_amt#3, #18#18]
 
-(65) NativeProject
+(64) NativeProject
 Output [1]: [UnscaledValue(ws_ext_discount_amt#3) AS _c0#19]
 Input [1]: [ws_ext_discount_amt#3]
 
-(66) NativeHashAggregate
+(65) NativeHashAggregate
 Input [1]: [_c0#19]
 Keys: []
 Functions [1]: [partial_sum(_c0#19)]
 Aggregate Attributes [1]: [sum#20]
 Results [1]: [#15]
 
-(67) NativeShuffleExchange
+(66) NativeShuffleExchange
 Input [1]: [#15]
 Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=7]
 
-(68) ShuffleQueryStage
+(67) ShuffleQueryStage
 Output [1]: [#15]
 Arguments: X
 
-(69) NativeHashAggregate
+(68) NativeHashAggregate
 Input [1]: [#15]
 Keys: []
 Functions [1]: [sum(UnscaledValue(ws_ext_discount_amt#3))]
 Aggregate Attributes [1]: [sum(UnscaledValue(ws_ext_discount_amt#3))#21]
 Results [1]: [sum(UnscaledValue(ws_ext_discount_amt#3))#21]
 
-(70) NativeProject
+(69) NativeProject
 Output [1]: [MakeDecimal(sum(UnscaledValue(ws_ext_discount_amt#3))#21,17,2) AS Excess Discount Amount #22]
 Input [1]: [sum(UnscaledValue(ws_ext_discount_amt#3))#21]
 
-(71) Scan parquet
+(70) Scan parquet
 Output [3]: [ws_sold_date_sk#1, ws_item_sk#2, ws_ext_discount_amt#3]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(ws_item_sk), IsNotNull(ws_ext_discount_amt), IsNotNull(ws_sold_date_sk)]
 ReadSchema: struct<ws_sold_date_sk:int,ws_item_sk:int,ws_ext_discount_amt:decimal(7,2)>
 
-(72) Filter
+(71) Filter
 Input [3]: [ws_sold_date_sk#1, ws_item_sk#2, ws_ext_discount_amt#3]
 Condition : ((isnotnull(ws_item_sk#2) AND isnotnull(ws_ext_discount_amt#3)) AND isnotnull(ws_sold_date_sk#1))
 
-(73) Exchange
+(72) Exchange
 Input [3]: [ws_sold_date_sk#1, ws_item_sk#2, ws_ext_discount_amt#3]
 Arguments: hashpartitioning(ws_item_sk#2, 100), ENSURE_REQUIREMENTS, [plan_id=8]
 
-(74) Sort
+(73) Sort
 Input [3]: [ws_sold_date_sk#1, ws_item_sk#2, ws_ext_discount_amt#3]
 Arguments: [ws_item_sk#2 ASC NULLS FIRST], false, 0
 
-(75) Scan parquet
+(74) Scan parquet
 Output [2]: [i_item_sk#4, i_manufact_id#5]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(i_manufact_id), EqualTo(i_manufact_id,350), IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_manufact_id:int>
 
-(76) Filter
+(75) Filter
 Input [2]: [i_item_sk#4, i_manufact_id#5]
 Condition : ((isnotnull(i_manufact_id#5) AND (i_manufact_id#5 = 350)) AND isnotnull(i_item_sk#4))
 
-(77) Project
+(76) Project
 Output [1]: [i_item_sk#4]
 Input [2]: [i_item_sk#4, i_manufact_id#5]
 
-(78) Exchange
+(77) Exchange
 Input [1]: [i_item_sk#4]
 Arguments: hashpartitioning(i_item_sk#4, 100), ENSURE_REQUIREMENTS, [plan_id=9]
 
-(79) Sort
+(78) Sort
 Input [1]: [i_item_sk#4]
 Arguments: [i_item_sk#4 ASC NULLS FIRST], false, 0
 
-(80) SortMergeJoin
+(79) SortMergeJoin
 Left keys [1]: [ws_item_sk#2]
 Right keys [1]: [i_item_sk#4]
 Join type: Inner
 Join condition: None
 
-(81) Project
+(80) Project
 Output [3]: [ws_sold_date_sk#1, ws_ext_discount_amt#3, i_item_sk#4]
 Input [4]: [ws_sold_date_sk#1, ws_item_sk#2, ws_ext_discount_amt#3, i_item_sk#4]
 
-(82) Scan parquet
+(81) Scan parquet
 Output [3]: [ws_sold_date_sk#6, ws_item_sk#7, ws_ext_discount_amt#8]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(ws_sold_date_sk), IsNotNull(ws_item_sk)]
 ReadSchema: struct<ws_sold_date_sk:int,ws_item_sk:int,ws_ext_discount_amt:decimal(7,2)>
 
-(83) Filter
+(82) Filter
 Input [3]: [ws_sold_date_sk#6, ws_item_sk#7, ws_ext_discount_amt#8]
 Condition : (isnotnull(ws_sold_date_sk#6) AND isnotnull(ws_item_sk#7))
 
-(84) Exchange
+(83) Exchange
 Input [3]: [ws_sold_date_sk#6, ws_item_sk#7, ws_ext_discount_amt#8]
 Arguments: hashpartitioning(ws_sold_date_sk#6, 100), ENSURE_REQUIREMENTS, [plan_id=10]
 
-(85) Sort
+(84) Sort
 Input [3]: [ws_sold_date_sk#6, ws_item_sk#7, ws_ext_discount_amt#8]
 Arguments: [ws_sold_date_sk#6 ASC NULLS FIRST], false, 0
 
-(86) Scan parquet
+(85) Scan parquet
 Output [2]: [d_date_sk#9, d_date#10]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(d_date), GreaterThanOrEqual(d_date,2000-01-27), LessThanOrEqual(d_date,2000-04-26), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date>
 
-(87) Filter
+(86) Filter
 Input [2]: [d_date_sk#9, d_date#10]
 Condition : (((isnotnull(d_date#10) AND (d_date#10 >= 2000-01-27)) AND (d_date#10 <= 2000-04-26)) AND isnotnull(d_date_sk#9))
 
-(88) Project
+(87) Project
 Output [1]: [d_date_sk#9]
 Input [2]: [d_date_sk#9, d_date#10]
 
-(89) Exchange
+(88) Exchange
 Input [1]: [d_date_sk#9]
 Arguments: hashpartitioning(d_date_sk#9, 100), ENSURE_REQUIREMENTS, [plan_id=11]
 
-(90) Sort
+(89) Sort
 Input [1]: [d_date_sk#9]
 Arguments: [d_date_sk#9 ASC NULLS FIRST], false, 0
 
-(91) SortMergeJoin
+(90) SortMergeJoin
 Left keys [1]: [ws_sold_date_sk#6]
 Right keys [1]: [d_date_sk#9]
 Join type: Inner
 Join condition: None
 
-(92) Project
+(91) Project
 Output [2]: [ws_item_sk#7, ws_ext_discount_amt#8]
 Input [4]: [ws_sold_date_sk#6, ws_item_sk#7, ws_ext_discount_amt#8, d_date_sk#9]
 
-(93) HashAggregate
+(92) HashAggregate
 Input [2]: [ws_item_sk#7, ws_ext_discount_amt#8]
 Keys [1]: [ws_item_sk#7]
 Functions [1]: [partial_avg(UnscaledValue(ws_ext_discount_amt#8))]
 Aggregate Attributes [2]: [sum#12, count#13]
 Results [3]: [ws_item_sk#7, sum#23, count#24]
 
-(94) Exchange
+(93) Exchange
 Input [3]: [ws_item_sk#7, sum#23, count#24]
 Arguments: hashpartitioning(ws_item_sk#7, 100), ENSURE_REQUIREMENTS, [plan_id=12]
 
-(95) HashAggregate
+(94) HashAggregate
 Input [3]: [ws_item_sk#7, sum#23, count#24]
 Keys [1]: [ws_item_sk#7]
 Functions [1]: [avg(UnscaledValue(ws_ext_discount_amt#8))]
 Aggregate Attributes [1]: [avg(UnscaledValue(ws_ext_discount_amt#8))#16]
 Results [2]: [(1.3 * cast((avg(UnscaledValue(ws_ext_discount_amt#8))#16 / 100.0) as decimal(11,6))) AS (1.3 * avg(ws_ext_discount_amt))#17, ws_item_sk#7]
 
-(96) Filter
+(95) Filter
 Input [2]: [(1.3 * avg(ws_ext_discount_amt))#17, ws_item_sk#7]
 Condition : isnotnull((1.3 * avg(ws_ext_discount_amt))#17)
 
-(97) Sort
+(96) Sort
 Input [2]: [(1.3 * avg(ws_ext_discount_amt))#17, ws_item_sk#7]
 Arguments: [ws_item_sk#7 ASC NULLS FIRST], false, 0
 
-(98) SortMergeJoin
+(97) SortMergeJoin
 Left keys [1]: [i_item_sk#4]
 Right keys [1]: [ws_item_sk#7]
 Join type: Inner
 Join condition: (cast(ws_ext_discount_amt#3 as decimal(14,7)) > (1.3 * avg(ws_ext_discount_amt))#17)
 
-(99) Project
+(98) Project
 Output [2]: [ws_sold_date_sk#1, ws_ext_discount_amt#3]
 Input [5]: [ws_sold_date_sk#1, ws_ext_discount_amt#3, i_item_sk#4, (1.3 * avg(ws_ext_discount_amt))#17, ws_item_sk#7]
 
-(100) Exchange
+(99) Exchange
 Input [2]: [ws_sold_date_sk#1, ws_ext_discount_amt#3]
 Arguments: hashpartitioning(ws_sold_date_sk#1, 100), ENSURE_REQUIREMENTS, [plan_id=13]
 
-(101) Sort
+(100) Sort
 Input [2]: [ws_sold_date_sk#1, ws_ext_discount_amt#3]
 Arguments: [ws_sold_date_sk#1 ASC NULLS FIRST], false, 0
 
-(102) Scan parquet
+(101) Scan parquet
 Output [2]: [d_date_sk#18, d_date#25]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(d_date), GreaterThanOrEqual(d_date,2000-01-27), LessThanOrEqual(d_date,2000-04-26), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date>
 
-(103) Filter
+(102) Filter
 Input [2]: [d_date_sk#18, d_date#25]
 Condition : (((isnotnull(d_date#25) AND (d_date#25 >= 2000-01-27)) AND (d_date#25 <= 2000-04-26)) AND isnotnull(d_date_sk#18))
 
-(104) Project
+(103) Project
 Output [1]: [d_date_sk#18]
 Input [2]: [d_date_sk#18, d_date#25]
 
-(105) Exchange
+(104) Exchange
 Input [1]: [d_date_sk#18]
 Arguments: hashpartitioning(d_date_sk#18, 100), ENSURE_REQUIREMENTS, [plan_id=14]
 
-(106) Sort
+(105) Sort
 Input [1]: [d_date_sk#18]
 Arguments: [d_date_sk#18 ASC NULLS FIRST], false, 0
 
-(107) SortMergeJoin
+(106) SortMergeJoin
 Left keys [1]: [ws_sold_date_sk#1]
 Right keys [1]: [d_date_sk#18]
 Join type: Inner
 Join condition: None
 
-(108) Project
+(107) Project
 Output [1]: [ws_ext_discount_amt#3]
 Input [3]: [ws_sold_date_sk#1, ws_ext_discount_amt#3, d_date_sk#18]
 
-(109) HashAggregate
+(108) HashAggregate
 Input [1]: [ws_ext_discount_amt#3]
 Keys: []
 Functions [1]: [partial_sum(UnscaledValue(ws_ext_discount_amt#3))]
 Aggregate Attributes [1]: [sum#20]
 Results [1]: [sum#26]
 
-(110) Exchange
+(109) Exchange
 Input [1]: [sum#26]
 Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=15]
 
-(111) HashAggregate
+(110) HashAggregate
 Input [1]: [sum#26]
 Keys: []
 Functions [1]: [sum(UnscaledValue(ws_ext_discount_amt#3))]
 Aggregate Attributes [1]: [sum(UnscaledValue(ws_ext_discount_amt#3))#21]
 Results [1]: [MakeDecimal(sum(UnscaledValue(ws_ext_discount_amt#3))#21,17,2) AS Excess Discount Amount #22]
 
-(112) AdaptiveSparkPlan
+(111) AdaptiveSparkPlan
 Output [1]: [Excess Discount Amount #22]
 Arguments: isFinalPlan=true
 

--- a/dev/auron-it/src/main/resources/tpcds-plan-stability/spark-3.5/q95.txt
+++ b/dev/auron-it/src/main/resources/tpcds-plan-stability/spark-3.5/q95.txt
@@ -1,41 +1,41 @@
 == Physical Plan ==
-AdaptiveSparkPlan (178)
+AdaptiveSparkPlan (176)
 +- == Final Plan ==
-   NativeProject (112)
-   +- NativeHashAggregate (111)
-      +- ShuffleQueryStage (110), Statistics(X)
-         +- NativeShuffleExchange (109)
-            +- NativeHashAggregate (108)
-               +- NativeHashAggregate (107)
-                  +- InputAdapter (106)
-                     +- AQEShuffleRead (105)
-                        +- ShuffleQueryStage (104), Statistics(X)
-                           +- NativeShuffleExchange (103)
-                              +- NativeHashAggregate (102)
-                                 +- NativeProject (101)
-                                    +- NativeProject (100)
-                                       +- NativeSortMergeJoin Inner (99)
-                                          :- NativeSort (89)
-                                          :  +- InputAdapter (88)
-                                          :     +- AQEShuffleRead (87)
-                                          :        +- ShuffleQueryStage (86), Statistics(X)
-                                          :           +- NativeShuffleExchange (85)
-                                          :              +- NativeProject (84)
-                                          :                 +- NativeSortMergeJoin Inner (83)
-                                          :                    :- NativeSort (73)
-                                          :                    :  +- InputAdapter (72)
-                                          :                    :     +- AQEShuffleRead (71)
-                                          :                    :        +- ShuffleQueryStage (70), Statistics(X)
-                                          :                    :           +- NativeShuffleExchange (69)
-                                          :                    :              +- NativeProject (68)
-                                          :                    :                 +- NativeSortMergeJoin Inner (67)
-                                          :                    :                    :- NativeSort (57)
-                                          :                    :                    :  +- InputAdapter (56)
-                                          :                    :                    :     +- AQEShuffleRead (55)
-                                          :                    :                    :        +- ShuffleQueryStage (54), Statistics(X)
-                                          :                    :                    :           +- NativeShuffleExchange (53)
-                                          :                    :                    :              +- NativeSortMergeJoin LeftSemi (52)
-                                          :                    :                    :                 :- NativeSortMergeJoin LeftSemi (26)
+   NativeProject (110)
+   +- NativeHashAggregate (109)
+      +- ShuffleQueryStage (108), Statistics(X)
+         +- NativeShuffleExchange (107)
+            +- NativeHashAggregate (106)
+               +- NativeHashAggregate (105)
+                  +- InputAdapter (104)
+                     +- AQEShuffleRead (103)
+                        +- ShuffleQueryStage (102), Statistics(X)
+                           +- NativeShuffleExchange (101)
+                              +- NativeHashAggregate (100)
+                                 +- NativeProject (99)
+                                    +- NativeProject (98)
+                                       +- NativeSortMergeJoin Inner (97)
+                                          :- NativeSort (87)
+                                          :  +- InputAdapter (86)
+                                          :     +- AQEShuffleRead (85)
+                                          :        +- ShuffleQueryStage (84), Statistics(X)
+                                          :           +- NativeShuffleExchange (83)
+                                          :              +- NativeProject (82)
+                                          :                 +- NativeSortMergeJoin Inner (81)
+                                          :                    :- NativeSort (71)
+                                          :                    :  +- InputAdapter (70)
+                                          :                    :     +- AQEShuffleRead (69)
+                                          :                    :        +- ShuffleQueryStage (68), Statistics(X)
+                                          :                    :           +- NativeShuffleExchange (67)
+                                          :                    :              +- NativeProject (66)
+                                          :                    :                 +- NativeSortMergeJoin Inner (65)
+                                          :                    :                    :- NativeSort (55)
+                                          :                    :                    :  +- InputAdapter (54)
+                                          :                    :                    :     +- AQEShuffleRead (53)
+                                          :                    :                    :        +- ShuffleQueryStage (52), Statistics(X)
+                                          :                    :                    :           +- NativeShuffleExchange (51)
+                                          :                    :                    :              +- NativeSortMergeJoin LeftSemi (50)
+                                          :                    :                    :                 :- NativeSortMergeJoin LeftSemi (25)
                                           :                    :                    :                 :  :- NativeSort (8)
                                           :                    :                    :                 :  :  +- InputAdapter (7)
                                           :                    :                    :                 :  :     +- AQEShuffleRead (6)
@@ -44,144 +44,142 @@ AdaptiveSparkPlan (178)
                                           :                    :                    :                 :  :              +- NativeFilter (3)
                                           :                    :                    :                 :  :                 +- InputAdapter (2)
                                           :                    :                    :                 :  :                    +- NativeParquetScan  (1)
-                                          :                    :                    :                 :  +- ConvertToNative (25)
-                                          :                    :                    :                 :     +- * Project (24)
-                                          :                    :                    :                 :        +- * SortMergeJoin Inner (23)
-                                          :                    :                    :                 :           :- NativeSort (16)
-                                          :                    :                    :                 :           :  +- InputAdapter (15)
-                                          :                    :                    :                 :           :     +- AQEShuffleRead (14)
-                                          :                    :                    :                 :           :        +- ShuffleQueryStage (13), Statistics(X)
-                                          :                    :                    :                 :           :           +- NativeShuffleExchange (12)
-                                          :                    :                    :                 :           :              +- NativeFilter (11)
-                                          :                    :                    :                 :           :                 +- InputAdapter (10)
-                                          :                    :                    :                 :           :                    +- NativeParquetScan  (9)
-                                          :                    :                    :                 :           +- NativeSort (22)
-                                          :                    :                    :                 :              +- InputAdapter (21)
-                                          :                    :                    :                 :                 +- InputAdapter (20)
-                                          :                    :                    :                 :                    +- AQEShuffleRead (19)
-                                          :                    :                    :                 :                       +- ShuffleQueryStage (18), Statistics(X)
-                                          :                    :                    :                 :                          +- ReusedExchange (17)
-                                          :                    :                    :                 +- NativeProject (51)
-                                          :                    :                    :                    +- NativeSortMergeJoin Inner (50)
-                                          :                    :                    :                       :- NativeSort (34)
-                                          :                    :                    :                       :  +- InputAdapter (33)
-                                          :                    :                    :                       :     +- AQEShuffleRead (32)
-                                          :                    :                    :                       :        +- ShuffleQueryStage (31), Statistics(X)
-                                          :                    :                    :                       :           +- NativeShuffleExchange (30)
-                                          :                    :                    :                       :              +- NativeFilter (29)
-                                          :                    :                    :                       :                 +- InputAdapter (28)
-                                          :                    :                    :                       :                    +- NativeParquetScan  (27)
-                                          :                    :                    :                       +- ConvertToNative (49)
-                                          :                    :                    :                          +- * Project (48)
-                                          :                    :                    :                             +- * SortMergeJoin Inner (47)
-                                          :                    :                    :                                :- NativeSort (40)
-                                          :                    :                    :                                :  +- InputAdapter (39)
-                                          :                    :                    :                                :     +- InputAdapter (38)
-                                          :                    :                    :                                :        +- AQEShuffleRead (37)
-                                          :                    :                    :                                :           +- ShuffleQueryStage (36), Statistics(X)
-                                          :                    :                    :                                :              +- ReusedExchange (35)
-                                          :                    :                    :                                +- NativeSort (46)
-                                          :                    :                    :                                   +- InputAdapter (45)
-                                          :                    :                    :                                      +- InputAdapter (44)
-                                          :                    :                    :                                         +- AQEShuffleRead (43)
-                                          :                    :                    :                                            +- ShuffleQueryStage (42), Statistics(X)
-                                          :                    :                    :                                               +- ReusedExchange (41)
-                                          :                    :                    +- NativeSort (66)
-                                          :                    :                       +- InputAdapter (65)
-                                          :                    :                          +- AQEShuffleRead (64)
-                                          :                    :                             +- ShuffleQueryStage (63), Statistics(X)
-                                          :                    :                                +- NativeShuffleExchange (62)
-                                          :                    :                                   +- NativeProject (61)
-                                          :                    :                                      +- NativeFilter (60)
-                                          :                    :                                         +- InputAdapter (59)
-                                          :                    :                                            +- NativeParquetScan  (58)
-                                          :                    +- NativeSort (82)
-                                          :                       +- InputAdapter (81)
-                                          :                          +- AQEShuffleRead (80)
-                                          :                             +- ShuffleQueryStage (79), Statistics(X)
-                                          :                                +- NativeShuffleExchange (78)
-                                          :                                   +- NativeProject (77)
-                                          :                                      +- NativeFilter (76)
-                                          :                                         +- InputAdapter (75)
-                                          :                                            +- NativeParquetScan  (74)
-                                          +- NativeSort (98)
-                                             +- InputAdapter (97)
-                                                +- AQEShuffleRead (96)
-                                                   +- ShuffleQueryStage (95), Statistics(X)
-                                                      +- NativeShuffleExchange (94)
-                                                         +- NativeProject (93)
-                                                            +- NativeFilter (92)
-                                                               +- InputAdapter (91)
-                                                                  +- NativeParquetScan  (90)
+                                          :                    :                    :                 :  +- NativeProject (24)
+                                          :                    :                    :                 :     +- NativeSortMergeJoin Inner (23)
+                                          :                    :                    :                 :        :- NativeSort (16)
+                                          :                    :                    :                 :        :  +- InputAdapter (15)
+                                          :                    :                    :                 :        :     +- AQEShuffleRead (14)
+                                          :                    :                    :                 :        :        +- ShuffleQueryStage (13), Statistics(X)
+                                          :                    :                    :                 :        :           +- NativeShuffleExchange (12)
+                                          :                    :                    :                 :        :              +- NativeFilter (11)
+                                          :                    :                    :                 :        :                 +- InputAdapter (10)
+                                          :                    :                    :                 :        :                    +- NativeParquetScan  (9)
+                                          :                    :                    :                 :        +- NativeSort (22)
+                                          :                    :                    :                 :           +- InputAdapter (21)
+                                          :                    :                    :                 :              +- InputAdapter (20)
+                                          :                    :                    :                 :                 +- AQEShuffleRead (19)
+                                          :                    :                    :                 :                    +- ShuffleQueryStage (18), Statistics(X)
+                                          :                    :                    :                 :                       +- ReusedExchange (17)
+                                          :                    :                    :                 +- NativeProject (49)
+                                          :                    :                    :                    +- NativeSortMergeJoin Inner (48)
+                                          :                    :                    :                       :- NativeSort (33)
+                                          :                    :                    :                       :  +- InputAdapter (32)
+                                          :                    :                    :                       :     +- AQEShuffleRead (31)
+                                          :                    :                    :                       :        +- ShuffleQueryStage (30), Statistics(X)
+                                          :                    :                    :                       :           +- NativeShuffleExchange (29)
+                                          :                    :                    :                       :              +- NativeFilter (28)
+                                          :                    :                    :                       :                 +- InputAdapter (27)
+                                          :                    :                    :                       :                    +- NativeParquetScan  (26)
+                                          :                    :                    :                       +- NativeProject (47)
+                                          :                    :                    :                          +- NativeSortMergeJoin Inner (46)
+                                          :                    :                    :                             :- NativeSort (39)
+                                          :                    :                    :                             :  +- InputAdapter (38)
+                                          :                    :                    :                             :     +- InputAdapter (37)
+                                          :                    :                    :                             :        +- AQEShuffleRead (36)
+                                          :                    :                    :                             :           +- ShuffleQueryStage (35), Statistics(X)
+                                          :                    :                    :                             :              +- ReusedExchange (34)
+                                          :                    :                    :                             +- NativeSort (45)
+                                          :                    :                    :                                +- InputAdapter (44)
+                                          :                    :                    :                                   +- InputAdapter (43)
+                                          :                    :                    :                                      +- AQEShuffleRead (42)
+                                          :                    :                    :                                         +- ShuffleQueryStage (41), Statistics(X)
+                                          :                    :                    :                                            +- ReusedExchange (40)
+                                          :                    :                    +- NativeSort (64)
+                                          :                    :                       +- InputAdapter (63)
+                                          :                    :                          +- AQEShuffleRead (62)
+                                          :                    :                             +- ShuffleQueryStage (61), Statistics(X)
+                                          :                    :                                +- NativeShuffleExchange (60)
+                                          :                    :                                   +- NativeProject (59)
+                                          :                    :                                      +- NativeFilter (58)
+                                          :                    :                                         +- InputAdapter (57)
+                                          :                    :                                            +- NativeParquetScan  (56)
+                                          :                    +- NativeSort (80)
+                                          :                       +- InputAdapter (79)
+                                          :                          +- AQEShuffleRead (78)
+                                          :                             +- ShuffleQueryStage (77), Statistics(X)
+                                          :                                +- NativeShuffleExchange (76)
+                                          :                                   +- NativeProject (75)
+                                          :                                      +- NativeFilter (74)
+                                          :                                         +- InputAdapter (73)
+                                          :                                            +- NativeParquetScan  (72)
+                                          +- NativeSort (96)
+                                             +- InputAdapter (95)
+                                                +- AQEShuffleRead (94)
+                                                   +- ShuffleQueryStage (93), Statistics(X)
+                                                      +- NativeShuffleExchange (92)
+                                                         +- NativeProject (91)
+                                                            +- NativeFilter (90)
+                                                               +- InputAdapter (89)
+                                                                  +- NativeParquetScan  (88)
 +- == Initial Plan ==
-   HashAggregate (177)
-   +- Exchange (176)
-      +- HashAggregate (175)
-         +- HashAggregate (174)
-            +- Exchange (173)
-               +- HashAggregate (172)
-                  +- Project (171)
-                     +- SortMergeJoin Inner (170)
-                        :- Sort (164)
-                        :  +- Exchange (163)
-                        :     +- Project (162)
-                        :        +- SortMergeJoin Inner (161)
-                        :           :- Sort (155)
-                        :           :  +- Exchange (154)
-                        :           :     +- Project (153)
-                        :           :        +- SortMergeJoin Inner (152)
-                        :           :           :- Sort (146)
-                        :           :           :  +- Exchange (145)
-                        :           :           :     +- SortMergeJoin LeftSemi (144)
-                        :           :           :        :- SortMergeJoin LeftSemi (127)
-                        :           :           :        :  :- Sort (116)
-                        :           :           :        :  :  +- Exchange (115)
-                        :           :           :        :  :     +- Filter (114)
-                        :           :           :        :  :        +- Scan parquet (113)
-                        :           :           :        :  +- Project (126)
-                        :           :           :        :     +- SortMergeJoin Inner (125)
-                        :           :           :        :        :- Sort (120)
-                        :           :           :        :        :  +- Exchange (119)
-                        :           :           :        :        :     +- Filter (118)
-                        :           :           :        :        :        +- Scan parquet (117)
-                        :           :           :        :        +- Sort (124)
-                        :           :           :        :           +- Exchange (123)
-                        :           :           :        :              +- Filter (122)
-                        :           :           :        :                 +- Scan parquet (121)
-                        :           :           :        +- Project (143)
-                        :           :           :           +- SortMergeJoin Inner (142)
-                        :           :           :              :- Sort (131)
-                        :           :           :              :  +- Exchange (130)
-                        :           :           :              :     +- Filter (129)
-                        :           :           :              :        +- Scan parquet (128)
-                        :           :           :              +- Project (141)
-                        :           :           :                 +- SortMergeJoin Inner (140)
-                        :           :           :                    :- Sort (135)
-                        :           :           :                    :  +- Exchange (134)
-                        :           :           :                    :     +- Filter (133)
-                        :           :           :                    :        +- Scan parquet (132)
-                        :           :           :                    +- Sort (139)
-                        :           :           :                       +- Exchange (138)
-                        :           :           :                          +- Filter (137)
-                        :           :           :                             +- Scan parquet (136)
-                        :           :           +- Sort (151)
-                        :           :              +- Exchange (150)
-                        :           :                 +- Project (149)
-                        :           :                    +- Filter (148)
-                        :           :                       +- Scan parquet (147)
-                        :           +- Sort (160)
-                        :              +- Exchange (159)
-                        :                 +- Project (158)
-                        :                    +- Filter (157)
-                        :                       +- Scan parquet (156)
-                        +- Sort (169)
-                           +- Exchange (168)
-                              +- Project (167)
-                                 +- Filter (166)
-                                    +- Scan parquet (165)
+   HashAggregate (175)
+   +- Exchange (174)
+      +- HashAggregate (173)
+         +- HashAggregate (172)
+            +- Exchange (171)
+               +- HashAggregate (170)
+                  +- Project (169)
+                     +- SortMergeJoin Inner (168)
+                        :- Sort (162)
+                        :  +- Exchange (161)
+                        :     +- Project (160)
+                        :        +- SortMergeJoin Inner (159)
+                        :           :- Sort (153)
+                        :           :  +- Exchange (152)
+                        :           :     +- Project (151)
+                        :           :        +- SortMergeJoin Inner (150)
+                        :           :           :- Sort (144)
+                        :           :           :  +- Exchange (143)
+                        :           :           :     +- SortMergeJoin LeftSemi (142)
+                        :           :           :        :- SortMergeJoin LeftSemi (125)
+                        :           :           :        :  :- Sort (114)
+                        :           :           :        :  :  +- Exchange (113)
+                        :           :           :        :  :     +- Filter (112)
+                        :           :           :        :  :        +- Scan parquet (111)
+                        :           :           :        :  +- Project (124)
+                        :           :           :        :     +- SortMergeJoin Inner (123)
+                        :           :           :        :        :- Sort (118)
+                        :           :           :        :        :  +- Exchange (117)
+                        :           :           :        :        :     +- Filter (116)
+                        :           :           :        :        :        +- Scan parquet (115)
+                        :           :           :        :        +- Sort (122)
+                        :           :           :        :           +- Exchange (121)
+                        :           :           :        :              +- Filter (120)
+                        :           :           :        :                 +- Scan parquet (119)
+                        :           :           :        +- Project (141)
+                        :           :           :           +- SortMergeJoin Inner (140)
+                        :           :           :              :- Sort (129)
+                        :           :           :              :  +- Exchange (128)
+                        :           :           :              :     +- Filter (127)
+                        :           :           :              :        +- Scan parquet (126)
+                        :           :           :              +- Project (139)
+                        :           :           :                 +- SortMergeJoin Inner (138)
+                        :           :           :                    :- Sort (133)
+                        :           :           :                    :  +- Exchange (132)
+                        :           :           :                    :     +- Filter (131)
+                        :           :           :                    :        +- Scan parquet (130)
+                        :           :           :                    +- Sort (137)
+                        :           :           :                       +- Exchange (136)
+                        :           :           :                          +- Filter (135)
+                        :           :           :                             +- Scan parquet (134)
+                        :           :           +- Sort (149)
+                        :           :              +- Exchange (148)
+                        :           :                 +- Project (147)
+                        :           :                    +- Filter (146)
+                        :           :                       +- Scan parquet (145)
+                        :           +- Sort (158)
+                        :              +- Exchange (157)
+                        :                 +- Project (156)
+                        :                    +- Filter (155)
+                        :                       +- Scan parquet (154)
+                        +- Sort (167)
+                           +- Exchange (166)
+                              +- Project (165)
+                                 +- Filter (164)
+                                    +- Scan parquet (163)
 
 
-(113) Scan parquet
+(111) Scan parquet
 Output [6]: [ws_ship_date_sk#1, ws_ship_addr_sk#2, ws_web_site_sk#3, ws_order_number#4, ws_ext_ship_cost#5, ws_net_profit#6]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
@@ -215,7 +213,7 @@ Input [6]: [#1#1, #2#2, #3#3, #4#4, #5#5, #6#6]
 Input [6]: [#1#1, #2#2, #3#3, #4#4, #5#5, #6#6]
 Arguments: [ws_order_number#4 ASC NULLS FIRST], false
 
-(117) Scan parquet
+(115) Scan parquet
 Output [2]: [ws_warehouse_sk#7, ws_order_number#8]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
@@ -271,708 +269,702 @@ Input [2]: [#9#9, #10#10]
 Input [2]: [#9#9, #10#10]
 Arguments: [ws_order_number#10 ASC NULLS FIRST], false
 
-(23) SortMergeJoin [codegen id : X]
+(23) NativeSortMergeJoin
 Left keys [1]: [ws_order_number#8]
 Right keys [1]: [ws_order_number#10]
 Join type: Inner
 Join condition: NOT (ws_warehouse_sk#7 = ws_warehouse_sk#9)
 
-(24) Project [codegen id : X]
+(24) NativeProject
 Output [1]: [ws_order_number#8]
 Input [4]: [#7#7, #8#8, #9#9, #10#10]
 
-(25) ConvertToNative
-Input [1]: [ws_order_number#8]
-
-(26) NativeSortMergeJoin
+(25) NativeSortMergeJoin
 Left keys [1]: [ws_order_number#4]
 Right keys [1]: [ws_order_number#8]
 Join type: LeftSemi
 Join condition: None
 
-(128) Scan parquet
+(126) Scan parquet
 Output [1]: [wr_order_number#11]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(wr_order_number)]
 ReadSchema: struct<wr_order_number:int>
 
-(28) InputAdapter
+(27) InputAdapter
 Input [1]: [wr_order_number#11]
 Arguments: [#11]
 
-(29) NativeFilter
+(28) NativeFilter
 Input [1]: [#11#11]
 Condition : isnotnull(wr_order_number#11)
 
-(30) NativeShuffleExchange
+(29) NativeShuffleExchange
 Input [1]: [#11#11]
 Arguments: hashpartitioning(wr_order_number#11, 100), ENSURE_REQUIREMENTS, [plan_id=3]
 
-(31) ShuffleQueryStage
+(30) ShuffleQueryStage
 Output [1]: [#11#11]
 Arguments: X
 
-(32) AQEShuffleRead
+(31) AQEShuffleRead
 Input [1]: [#11#11]
 Arguments: coalesced
 
-(33) InputAdapter
+(32) InputAdapter
 Input [1]: [#11#11]
 
-(34) NativeSort
+(33) NativeSort
 Input [1]: [#11#11]
 Arguments: [wr_order_number#11 ASC NULLS FIRST], false
 
-(35) ReusedExchange [Reuses operator id: 12]
+(34) ReusedExchange [Reuses operator id: 12]
 Output [2]: [ws_warehouse_sk#12, ws_order_number#13]
 
-(36) ShuffleQueryStage
+(35) ShuffleQueryStage
 Output [2]: [ws_warehouse_sk#12, ws_order_number#13]
 Arguments: X
 
-(37) AQEShuffleRead
+(36) AQEShuffleRead
 Input [2]: [ws_warehouse_sk#12, ws_order_number#13]
 Arguments: coalesced
 
-(38) InputAdapter
+(37) InputAdapter
 Input [2]: [ws_warehouse_sk#12, ws_order_number#13]
 Arguments: [#12, #13]
 
-(39) InputAdapter
+(38) InputAdapter
 Input [2]: [#12#12, #13#13]
 
-(40) NativeSort
+(39) NativeSort
 Input [2]: [#12#12, #13#13]
 Arguments: [ws_order_number#13 ASC NULLS FIRST], false
 
-(41) ReusedExchange [Reuses operator id: 12]
+(40) ReusedExchange [Reuses operator id: 12]
 Output [2]: [ws_warehouse_sk#14, ws_order_number#15]
 
-(42) ShuffleQueryStage
+(41) ShuffleQueryStage
 Output [2]: [ws_warehouse_sk#14, ws_order_number#15]
 Arguments: X
 
-(43) AQEShuffleRead
+(42) AQEShuffleRead
 Input [2]: [ws_warehouse_sk#14, ws_order_number#15]
 Arguments: coalesced
 
-(44) InputAdapter
+(43) InputAdapter
 Input [2]: [ws_warehouse_sk#14, ws_order_number#15]
 Arguments: [#14, #15]
 
-(45) InputAdapter
+(44) InputAdapter
 Input [2]: [#14#14, #15#15]
 
-(46) NativeSort
+(45) NativeSort
 Input [2]: [#14#14, #15#15]
 Arguments: [ws_order_number#15 ASC NULLS FIRST], false
 
-(47) SortMergeJoin [codegen id : X]
+(46) NativeSortMergeJoin
 Left keys [1]: [ws_order_number#13]
 Right keys [1]: [ws_order_number#15]
 Join type: Inner
 Join condition: NOT (ws_warehouse_sk#12 = ws_warehouse_sk#14)
 
-(48) Project [codegen id : X]
+(47) NativeProject
 Output [1]: [ws_order_number#13]
 Input [4]: [#12#12, #13#13, #14#14, #15#15]
 
-(49) ConvertToNative
-Input [1]: [ws_order_number#13]
-
-(50) NativeSortMergeJoin
+(48) NativeSortMergeJoin
 Left keys [1]: [wr_order_number#11]
 Right keys [1]: [ws_order_number#13]
 Join type: Inner
 Join condition: None
 
-(51) NativeProject
+(49) NativeProject
 Output [1]: [wr_order_number#11]
 Input [2]: [#11#11, ws_order_number#13]
 
-(52) NativeSortMergeJoin
+(50) NativeSortMergeJoin
 Left keys [1]: [ws_order_number#4]
 Right keys [1]: [wr_order_number#11]
 Join type: LeftSemi
 Join condition: None
 
-(53) NativeShuffleExchange
+(51) NativeShuffleExchange
 Input [6]: [#1#1, #2#2, #3#3, #4#4, #5#5, #6#6]
 Arguments: hashpartitioning(ws_ship_date_sk#1, 100), ENSURE_REQUIREMENTS, [plan_id=4]
 
-(54) ShuffleQueryStage
+(52) ShuffleQueryStage
 Output [6]: [#1#1, #2#2, #3#3, #4#4, #5#5, #6#6]
 Arguments: X
 
-(55) AQEShuffleRead
+(53) AQEShuffleRead
 Input [6]: [#1#1, #2#2, #3#3, #4#4, #5#5, #6#6]
 Arguments: coalesced
 
-(56) InputAdapter
+(54) InputAdapter
 Input [6]: [#1#1, #2#2, #3#3, #4#4, #5#5, #6#6]
 
-(57) NativeSort
+(55) NativeSort
 Input [6]: [#1#1, #2#2, #3#3, #4#4, #5#5, #6#6]
 Arguments: [ws_ship_date_sk#1 ASC NULLS FIRST], false
 
-(147) Scan parquet
+(145) Scan parquet
 Output [2]: [d_date_sk#16, d_date#17]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(d_date), GreaterThanOrEqual(d_date,1999-02-01), LessThanOrEqual(d_date,1999-04-02), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date>
 
-(59) InputAdapter
+(57) InputAdapter
 Input [2]: [d_date_sk#16, d_date#17]
 Arguments: [#16, #17]
 
-(60) NativeFilter
+(58) NativeFilter
 Input [2]: [#16#16, #17#17]
 Condition : (((isnotnull(d_date#17) AND (d_date#17 >= 1999-02-01)) AND (d_date#17 <= 1999-04-02)) AND isnotnull(d_date_sk#16))
 
-(61) NativeProject
+(59) NativeProject
 Output [1]: [d_date_sk#16]
 Input [2]: [#16#16, #17#17]
 
-(62) NativeShuffleExchange
+(60) NativeShuffleExchange
 Input [1]: [d_date_sk#16]
 Arguments: hashpartitioning(d_date_sk#16, 100), ENSURE_REQUIREMENTS, [plan_id=5]
 
-(63) ShuffleQueryStage
+(61) ShuffleQueryStage
 Output [1]: [d_date_sk#16]
 Arguments: X
 
-(64) AQEShuffleRead
+(62) AQEShuffleRead
 Input [1]: [d_date_sk#16]
 Arguments: coalesced
 
-(65) InputAdapter
+(63) InputAdapter
 Input [1]: [d_date_sk#16]
 
-(66) NativeSort
+(64) NativeSort
 Input [1]: [d_date_sk#16]
 Arguments: [d_date_sk#16 ASC NULLS FIRST], false
 
-(67) NativeSortMergeJoin
+(65) NativeSortMergeJoin
 Left keys [1]: [ws_ship_date_sk#1]
 Right keys [1]: [d_date_sk#16]
 Join type: Inner
 Join condition: None
 
-(68) NativeProject
+(66) NativeProject
 Output [5]: [ws_ship_addr_sk#2, ws_web_site_sk#3, ws_order_number#4, ws_ext_ship_cost#5, ws_net_profit#6]
 Input [7]: [#1#1, #2#2, #3#3, #4#4, #5#5, #6#6, d_date_sk#16]
 
-(69) NativeShuffleExchange
+(67) NativeShuffleExchange
 Input [5]: [ws_ship_addr_sk#2, ws_web_site_sk#3, ws_order_number#4, ws_ext_ship_cost#5, ws_net_profit#6]
 Arguments: hashpartitioning(ws_ship_addr_sk#2, 100), ENSURE_REQUIREMENTS, [plan_id=6]
 
-(70) ShuffleQueryStage
+(68) ShuffleQueryStage
 Output [5]: [ws_ship_addr_sk#2, ws_web_site_sk#3, ws_order_number#4, ws_ext_ship_cost#5, ws_net_profit#6]
 Arguments: X
 
-(71) AQEShuffleRead
+(69) AQEShuffleRead
 Input [5]: [ws_ship_addr_sk#2, ws_web_site_sk#3, ws_order_number#4, ws_ext_ship_cost#5, ws_net_profit#6]
 Arguments: coalesced
 
-(72) InputAdapter
+(70) InputAdapter
 Input [5]: [ws_ship_addr_sk#2, ws_web_site_sk#3, ws_order_number#4, ws_ext_ship_cost#5, ws_net_profit#6]
 
-(73) NativeSort
+(71) NativeSort
 Input [5]: [ws_ship_addr_sk#2, ws_web_site_sk#3, ws_order_number#4, ws_ext_ship_cost#5, ws_net_profit#6]
 Arguments: [ws_ship_addr_sk#2 ASC NULLS FIRST], false
 
-(156) Scan parquet
+(154) Scan parquet
 Output [2]: [ca_address_sk#18, ca_state#19]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(ca_state), EqualTo(ca_state,IL), IsNotNull(ca_address_sk)]
 ReadSchema: struct<ca_address_sk:int,ca_state:string>
 
-(75) InputAdapter
+(73) InputAdapter
 Input [2]: [ca_address_sk#18, ca_state#19]
 Arguments: [#18, #19]
 
-(76) NativeFilter
+(74) NativeFilter
 Input [2]: [#18#18, #19#19]
 Condition : ((isnotnull(ca_state#19) AND (ca_state#19 = IL)) AND isnotnull(ca_address_sk#18))
 
-(77) NativeProject
+(75) NativeProject
 Output [1]: [ca_address_sk#18]
 Input [2]: [#18#18, #19#19]
 
-(78) NativeShuffleExchange
+(76) NativeShuffleExchange
 Input [1]: [ca_address_sk#18]
 Arguments: hashpartitioning(ca_address_sk#18, 100), ENSURE_REQUIREMENTS, [plan_id=7]
 
-(79) ShuffleQueryStage
+(77) ShuffleQueryStage
 Output [1]: [ca_address_sk#18]
 Arguments: X
 
-(80) AQEShuffleRead
+(78) AQEShuffleRead
 Input [1]: [ca_address_sk#18]
 Arguments: coalesced
 
-(81) InputAdapter
+(79) InputAdapter
 Input [1]: [ca_address_sk#18]
 
-(82) NativeSort
+(80) NativeSort
 Input [1]: [ca_address_sk#18]
 Arguments: [ca_address_sk#18 ASC NULLS FIRST], false
 
-(83) NativeSortMergeJoin
+(81) NativeSortMergeJoin
 Left keys [1]: [ws_ship_addr_sk#2]
 Right keys [1]: [ca_address_sk#18]
 Join type: Inner
 Join condition: None
 
-(84) NativeProject
+(82) NativeProject
 Output [4]: [ws_web_site_sk#3, ws_order_number#4, ws_ext_ship_cost#5, ws_net_profit#6]
 Input [6]: [ws_ship_addr_sk#2, ws_web_site_sk#3, ws_order_number#4, ws_ext_ship_cost#5, ws_net_profit#6, ca_address_sk#18]
 
-(85) NativeShuffleExchange
+(83) NativeShuffleExchange
 Input [4]: [ws_web_site_sk#3, ws_order_number#4, ws_ext_ship_cost#5, ws_net_profit#6]
 Arguments: hashpartitioning(ws_web_site_sk#3, 100), ENSURE_REQUIREMENTS, [plan_id=8]
 
-(86) ShuffleQueryStage
+(84) ShuffleQueryStage
 Output [4]: [ws_web_site_sk#3, ws_order_number#4, ws_ext_ship_cost#5, ws_net_profit#6]
 Arguments: X
 
-(87) AQEShuffleRead
+(85) AQEShuffleRead
 Input [4]: [ws_web_site_sk#3, ws_order_number#4, ws_ext_ship_cost#5, ws_net_profit#6]
 Arguments: coalesced
 
-(88) InputAdapter
+(86) InputAdapter
 Input [4]: [ws_web_site_sk#3, ws_order_number#4, ws_ext_ship_cost#5, ws_net_profit#6]
 
-(89) NativeSort
+(87) NativeSort
 Input [4]: [ws_web_site_sk#3, ws_order_number#4, ws_ext_ship_cost#5, ws_net_profit#6]
 Arguments: [ws_web_site_sk#3 ASC NULLS FIRST], false
 
-(165) Scan parquet
+(163) Scan parquet
 Output [2]: [web_site_sk#20, web_company_name#21]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(web_company_name), EqualTo(web_company_name,pri), IsNotNull(web_site_sk)]
 ReadSchema: struct<web_site_sk:int,web_company_name:string>
 
-(91) InputAdapter
+(89) InputAdapter
 Input [2]: [web_site_sk#20, web_company_name#21]
 Arguments: [#20, #21]
 
-(92) NativeFilter
+(90) NativeFilter
 Input [2]: [#20#20, #21#21]
 Condition : ((isnotnull(web_company_name#21) AND (web_company_name#21 = pri)) AND isnotnull(web_site_sk#20))
 
-(93) NativeProject
+(91) NativeProject
 Output [1]: [web_site_sk#20]
 Input [2]: [#20#20, #21#21]
 
-(94) NativeShuffleExchange
+(92) NativeShuffleExchange
 Input [1]: [web_site_sk#20]
 Arguments: hashpartitioning(web_site_sk#20, 100), ENSURE_REQUIREMENTS, [plan_id=9]
 
-(95) ShuffleQueryStage
+(93) ShuffleQueryStage
 Output [1]: [web_site_sk#20]
 Arguments: X
 
-(96) AQEShuffleRead
+(94) AQEShuffleRead
 Input [1]: [web_site_sk#20]
 Arguments: coalesced
 
-(97) InputAdapter
+(95) InputAdapter
 Input [1]: [web_site_sk#20]
 
-(98) NativeSort
+(96) NativeSort
 Input [1]: [web_site_sk#20]
 Arguments: [web_site_sk#20 ASC NULLS FIRST], false
 
-(99) NativeSortMergeJoin
+(97) NativeSortMergeJoin
 Left keys [1]: [ws_web_site_sk#3]
 Right keys [1]: [web_site_sk#20]
 Join type: Inner
 Join condition: None
 
-(100) NativeProject
+(98) NativeProject
 Output [3]: [ws_order_number#4, ws_ext_ship_cost#5, ws_net_profit#6]
 Input [5]: [ws_web_site_sk#3, ws_order_number#4, ws_ext_ship_cost#5, ws_net_profit#6, web_site_sk#20]
 
-(101) NativeProject
+(99) NativeProject
 Output [3]: [ws_order_number#4 AS ws_order_number#4, UnscaledValue(ws_ext_ship_cost#5) AS _c1#22, UnscaledValue(ws_net_profit#6) AS _c2#23]
 Input [3]: [ws_order_number#4, ws_ext_ship_cost#5, ws_net_profit#6]
 
-(102) NativeHashAggregate
+(100) NativeHashAggregate
 Input [3]: [ws_order_number#4, _c1#22, _c2#23]
 Keys [1]: [ws_order_number#4]
 Functions [2]: [partial_sum(_c1#22), partial_sum(_c2#23)]
 Aggregate Attributes [2]: [sum(UnscaledValue(ws_ext_ship_cost#5))#24, sum(UnscaledValue(ws_net_profit#6))#25]
 Results [3]: [ws_order_number#4, #26, #26]
 
-(103) NativeShuffleExchange
+(101) NativeShuffleExchange
 Input [3]: [ws_order_number#4, #26, #26]
 Arguments: hashpartitioning(ws_order_number#4, 100), ENSURE_REQUIREMENTS, [plan_id=10]
 
-(104) ShuffleQueryStage
+(102) ShuffleQueryStage
 Output [3]: [ws_order_number#4, #26, #26]
 Arguments: X
 
-(105) AQEShuffleRead
+(103) AQEShuffleRead
 Input [3]: [ws_order_number#4, #26, #26]
 Arguments: coalesced
 
-(106) InputAdapter
+(104) InputAdapter
 Input [3]: [ws_order_number#4, #26, #26]
 
-(107) NativeHashAggregate
+(105) NativeHashAggregate
 Input [3]: [ws_order_number#4, #26, #26]
 Keys [1]: [ws_order_number#4]
 Functions [2]: [merge_sum(UnscaledValue(ws_ext_ship_cost#5)), merge_sum(UnscaledValue(ws_net_profit#6))]
 Aggregate Attributes [2]: [sum(UnscaledValue(ws_ext_ship_cost#5))#24, sum(UnscaledValue(ws_net_profit#6))#25]
 Results [3]: [ws_order_number#4, #26, #26]
 
-(108) NativeHashAggregate
+(106) NativeHashAggregate
 Input [3]: [ws_order_number#4, #26, #26]
 Keys: []
 Functions [3]: [merge_sum(UnscaledValue(ws_ext_ship_cost#5)), merge_sum(UnscaledValue(ws_net_profit#6)), partial_count(distinct ws_order_number#4)]
 Aggregate Attributes [3]: [sum(UnscaledValue(ws_ext_ship_cost#5))#24, sum(UnscaledValue(ws_net_profit#6))#25, count(ws_order_number#4)#27]
 Results [3]: [#26, #26, #26]
 
-(109) NativeShuffleExchange
+(107) NativeShuffleExchange
 Input [3]: [#26, #26, #26]
 Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=11]
 
-(110) ShuffleQueryStage
+(108) ShuffleQueryStage
 Output [3]: [#26, #26, #26]
 Arguments: X
 
-(111) NativeHashAggregate
+(109) NativeHashAggregate
 Input [3]: [#26, #26, #26]
 Keys: []
 Functions [3]: [sum(UnscaledValue(ws_ext_ship_cost#5)), sum(UnscaledValue(ws_net_profit#6)), count(distinct ws_order_number#4)]
 Aggregate Attributes [3]: [sum(UnscaledValue(ws_ext_ship_cost#5))#24, sum(UnscaledValue(ws_net_profit#6))#25, count(ws_order_number#4)#27]
 Results [3]: [sum(UnscaledValue(ws_ext_ship_cost#5))#24, sum(UnscaledValue(ws_net_profit#6))#25, count(ws_order_number#4)#27]
 
-(112) NativeProject
+(110) NativeProject
 Output [3]: [count(ws_order_number#4)#27 AS order count #28, MakeDecimal(sum(UnscaledValue(ws_ext_ship_cost#5))#24,17,2) AS total shipping cost #29, MakeDecimal(sum(UnscaledValue(ws_net_profit#6))#25,17,2) AS total net profit #30]
 Input [3]: [sum(UnscaledValue(ws_ext_ship_cost#5))#24, sum(UnscaledValue(ws_net_profit#6))#25, count(ws_order_number#4)#27]
 
-(113) Scan parquet
+(111) Scan parquet
 Output [6]: [ws_ship_date_sk#1, ws_ship_addr_sk#2, ws_web_site_sk#3, ws_order_number#4, ws_ext_ship_cost#5, ws_net_profit#6]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(ws_ship_date_sk), IsNotNull(ws_ship_addr_sk), IsNotNull(ws_web_site_sk)]
 ReadSchema: struct<ws_ship_date_sk:int,ws_ship_addr_sk:int,ws_web_site_sk:int,ws_order_number:int,ws_ext_ship_cost:decimal(7,2),ws_net_profit:decimal(7,2)>
 
-(114) Filter
+(112) Filter
 Input [6]: [ws_ship_date_sk#1, ws_ship_addr_sk#2, ws_web_site_sk#3, ws_order_number#4, ws_ext_ship_cost#5, ws_net_profit#6]
 Condition : ((isnotnull(ws_ship_date_sk#1) AND isnotnull(ws_ship_addr_sk#2)) AND isnotnull(ws_web_site_sk#3))
 
-(115) Exchange
+(113) Exchange
 Input [6]: [ws_ship_date_sk#1, ws_ship_addr_sk#2, ws_web_site_sk#3, ws_order_number#4, ws_ext_ship_cost#5, ws_net_profit#6]
 Arguments: hashpartitioning(ws_order_number#4, 100), ENSURE_REQUIREMENTS, [plan_id=12]
 
-(116) Sort
+(114) Sort
 Input [6]: [ws_ship_date_sk#1, ws_ship_addr_sk#2, ws_web_site_sk#3, ws_order_number#4, ws_ext_ship_cost#5, ws_net_profit#6]
 Arguments: [ws_order_number#4 ASC NULLS FIRST], false, 0
 
-(117) Scan parquet
+(115) Scan parquet
 Output [2]: [ws_warehouse_sk#7, ws_order_number#8]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(ws_order_number), IsNotNull(ws_warehouse_sk)]
 ReadSchema: struct<ws_warehouse_sk:int,ws_order_number:int>
 
-(118) Filter
+(116) Filter
 Input [2]: [ws_warehouse_sk#7, ws_order_number#8]
 Condition : (isnotnull(ws_order_number#8) AND isnotnull(ws_warehouse_sk#7))
 
-(119) Exchange
+(117) Exchange
 Input [2]: [ws_warehouse_sk#7, ws_order_number#8]
 Arguments: hashpartitioning(ws_order_number#8, 100), ENSURE_REQUIREMENTS, [plan_id=13]
 
-(120) Sort
+(118) Sort
 Input [2]: [ws_warehouse_sk#7, ws_order_number#8]
 Arguments: [ws_order_number#8 ASC NULLS FIRST], false, 0
 
-(121) Scan parquet
+(119) Scan parquet
 Output [2]: [ws_warehouse_sk#9, ws_order_number#10]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(ws_order_number), IsNotNull(ws_warehouse_sk)]
 ReadSchema: struct<ws_warehouse_sk:int,ws_order_number:int>
 
-(122) Filter
+(120) Filter
 Input [2]: [ws_warehouse_sk#9, ws_order_number#10]
 Condition : (isnotnull(ws_order_number#10) AND isnotnull(ws_warehouse_sk#9))
 
-(123) Exchange
+(121) Exchange
 Input [2]: [ws_warehouse_sk#9, ws_order_number#10]
 Arguments: hashpartitioning(ws_order_number#10, 100), ENSURE_REQUIREMENTS, [plan_id=14]
 
-(124) Sort
+(122) Sort
 Input [2]: [ws_warehouse_sk#9, ws_order_number#10]
 Arguments: [ws_order_number#10 ASC NULLS FIRST], false, 0
 
-(125) SortMergeJoin
+(123) SortMergeJoin
 Left keys [1]: [ws_order_number#8]
 Right keys [1]: [ws_order_number#10]
 Join type: Inner
 Join condition: NOT (ws_warehouse_sk#7 = ws_warehouse_sk#9)
 
-(126) Project
+(124) Project
 Output [1]: [ws_order_number#8]
 Input [4]: [ws_warehouse_sk#7, ws_order_number#8, ws_warehouse_sk#9, ws_order_number#10]
 
-(127) SortMergeJoin
+(125) SortMergeJoin
 Left keys [1]: [ws_order_number#4]
 Right keys [1]: [ws_order_number#8]
 Join type: LeftSemi
 Join condition: None
 
-(128) Scan parquet
+(126) Scan parquet
 Output [1]: [wr_order_number#11]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(wr_order_number)]
 ReadSchema: struct<wr_order_number:int>
 
-(129) Filter
+(127) Filter
 Input [1]: [wr_order_number#11]
 Condition : isnotnull(wr_order_number#11)
 
-(130) Exchange
+(128) Exchange
 Input [1]: [wr_order_number#11]
 Arguments: hashpartitioning(wr_order_number#11, 100), ENSURE_REQUIREMENTS, [plan_id=15]
 
-(131) Sort
+(129) Sort
 Input [1]: [wr_order_number#11]
 Arguments: [wr_order_number#11 ASC NULLS FIRST], false, 0
 
-(132) Scan parquet
+(130) Scan parquet
 Output [2]: [ws_warehouse_sk#12, ws_order_number#13]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(ws_order_number), IsNotNull(ws_warehouse_sk)]
 ReadSchema: struct<ws_warehouse_sk:int,ws_order_number:int>
 
-(133) Filter
+(131) Filter
 Input [2]: [ws_warehouse_sk#12, ws_order_number#13]
 Condition : (isnotnull(ws_order_number#13) AND isnotnull(ws_warehouse_sk#12))
 
-(134) Exchange
+(132) Exchange
 Input [2]: [ws_warehouse_sk#12, ws_order_number#13]
 Arguments: hashpartitioning(ws_order_number#13, 100), ENSURE_REQUIREMENTS, [plan_id=16]
 
-(135) Sort
+(133) Sort
 Input [2]: [ws_warehouse_sk#12, ws_order_number#13]
 Arguments: [ws_order_number#13 ASC NULLS FIRST], false, 0
 
-(136) Scan parquet
+(134) Scan parquet
 Output [2]: [ws_warehouse_sk#14, ws_order_number#15]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(ws_order_number), IsNotNull(ws_warehouse_sk)]
 ReadSchema: struct<ws_warehouse_sk:int,ws_order_number:int>
 
-(137) Filter
+(135) Filter
 Input [2]: [ws_warehouse_sk#14, ws_order_number#15]
 Condition : (isnotnull(ws_order_number#15) AND isnotnull(ws_warehouse_sk#14))
 
-(138) Exchange
+(136) Exchange
 Input [2]: [ws_warehouse_sk#14, ws_order_number#15]
 Arguments: hashpartitioning(ws_order_number#15, 100), ENSURE_REQUIREMENTS, [plan_id=17]
 
-(139) Sort
+(137) Sort
 Input [2]: [ws_warehouse_sk#14, ws_order_number#15]
 Arguments: [ws_order_number#15 ASC NULLS FIRST], false, 0
 
-(140) SortMergeJoin
+(138) SortMergeJoin
 Left keys [1]: [ws_order_number#13]
 Right keys [1]: [ws_order_number#15]
 Join type: Inner
 Join condition: NOT (ws_warehouse_sk#12 = ws_warehouse_sk#14)
 
-(141) Project
+(139) Project
 Output [1]: [ws_order_number#13]
 Input [4]: [ws_warehouse_sk#12, ws_order_number#13, ws_warehouse_sk#14, ws_order_number#15]
 
-(142) SortMergeJoin
+(140) SortMergeJoin
 Left keys [1]: [wr_order_number#11]
 Right keys [1]: [ws_order_number#13]
 Join type: Inner
 Join condition: None
 
-(143) Project
+(141) Project
 Output [1]: [wr_order_number#11]
 Input [2]: [wr_order_number#11, ws_order_number#13]
 
-(144) SortMergeJoin
+(142) SortMergeJoin
 Left keys [1]: [ws_order_number#4]
 Right keys [1]: [wr_order_number#11]
 Join type: LeftSemi
 Join condition: None
 
-(145) Exchange
+(143) Exchange
 Input [6]: [ws_ship_date_sk#1, ws_ship_addr_sk#2, ws_web_site_sk#3, ws_order_number#4, ws_ext_ship_cost#5, ws_net_profit#6]
 Arguments: hashpartitioning(ws_ship_date_sk#1, 100), ENSURE_REQUIREMENTS, [plan_id=18]
 
-(146) Sort
+(144) Sort
 Input [6]: [ws_ship_date_sk#1, ws_ship_addr_sk#2, ws_web_site_sk#3, ws_order_number#4, ws_ext_ship_cost#5, ws_net_profit#6]
 Arguments: [ws_ship_date_sk#1 ASC NULLS FIRST], false, 0
 
-(147) Scan parquet
+(145) Scan parquet
 Output [2]: [d_date_sk#16, d_date#17]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(d_date), GreaterThanOrEqual(d_date,1999-02-01), LessThanOrEqual(d_date,1999-04-02), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date>
 
-(148) Filter
+(146) Filter
 Input [2]: [d_date_sk#16, d_date#17]
 Condition : (((isnotnull(d_date#17) AND (d_date#17 >= 1999-02-01)) AND (d_date#17 <= 1999-04-02)) AND isnotnull(d_date_sk#16))
 
-(149) Project
+(147) Project
 Output [1]: [d_date_sk#16]
 Input [2]: [d_date_sk#16, d_date#17]
 
-(150) Exchange
+(148) Exchange
 Input [1]: [d_date_sk#16]
 Arguments: hashpartitioning(d_date_sk#16, 100), ENSURE_REQUIREMENTS, [plan_id=19]
 
-(151) Sort
+(149) Sort
 Input [1]: [d_date_sk#16]
 Arguments: [d_date_sk#16 ASC NULLS FIRST], false, 0
 
-(152) SortMergeJoin
+(150) SortMergeJoin
 Left keys [1]: [ws_ship_date_sk#1]
 Right keys [1]: [d_date_sk#16]
 Join type: Inner
 Join condition: None
 
-(153) Project
+(151) Project
 Output [5]: [ws_ship_addr_sk#2, ws_web_site_sk#3, ws_order_number#4, ws_ext_ship_cost#5, ws_net_profit#6]
 Input [7]: [ws_ship_date_sk#1, ws_ship_addr_sk#2, ws_web_site_sk#3, ws_order_number#4, ws_ext_ship_cost#5, ws_net_profit#6, d_date_sk#16]
 
-(154) Exchange
+(152) Exchange
 Input [5]: [ws_ship_addr_sk#2, ws_web_site_sk#3, ws_order_number#4, ws_ext_ship_cost#5, ws_net_profit#6]
 Arguments: hashpartitioning(ws_ship_addr_sk#2, 100), ENSURE_REQUIREMENTS, [plan_id=20]
 
-(155) Sort
+(153) Sort
 Input [5]: [ws_ship_addr_sk#2, ws_web_site_sk#3, ws_order_number#4, ws_ext_ship_cost#5, ws_net_profit#6]
 Arguments: [ws_ship_addr_sk#2 ASC NULLS FIRST], false, 0
 
-(156) Scan parquet
+(154) Scan parquet
 Output [2]: [ca_address_sk#18, ca_state#19]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(ca_state), EqualTo(ca_state,IL), IsNotNull(ca_address_sk)]
 ReadSchema: struct<ca_address_sk:int,ca_state:string>
 
-(157) Filter
+(155) Filter
 Input [2]: [ca_address_sk#18, ca_state#19]
 Condition : ((isnotnull(ca_state#19) AND (ca_state#19 = IL)) AND isnotnull(ca_address_sk#18))
 
-(158) Project
+(156) Project
 Output [1]: [ca_address_sk#18]
 Input [2]: [ca_address_sk#18, ca_state#19]
 
-(159) Exchange
+(157) Exchange
 Input [1]: [ca_address_sk#18]
 Arguments: hashpartitioning(ca_address_sk#18, 100), ENSURE_REQUIREMENTS, [plan_id=21]
 
-(160) Sort
+(158) Sort
 Input [1]: [ca_address_sk#18]
 Arguments: [ca_address_sk#18 ASC NULLS FIRST], false, 0
 
-(161) SortMergeJoin
+(159) SortMergeJoin
 Left keys [1]: [ws_ship_addr_sk#2]
 Right keys [1]: [ca_address_sk#18]
 Join type: Inner
 Join condition: None
 
-(162) Project
+(160) Project
 Output [4]: [ws_web_site_sk#3, ws_order_number#4, ws_ext_ship_cost#5, ws_net_profit#6]
 Input [6]: [ws_ship_addr_sk#2, ws_web_site_sk#3, ws_order_number#4, ws_ext_ship_cost#5, ws_net_profit#6, ca_address_sk#18]
 
-(163) Exchange
+(161) Exchange
 Input [4]: [ws_web_site_sk#3, ws_order_number#4, ws_ext_ship_cost#5, ws_net_profit#6]
 Arguments: hashpartitioning(ws_web_site_sk#3, 100), ENSURE_REQUIREMENTS, [plan_id=22]
 
-(164) Sort
+(162) Sort
 Input [4]: [ws_web_site_sk#3, ws_order_number#4, ws_ext_ship_cost#5, ws_net_profit#6]
 Arguments: [ws_web_site_sk#3 ASC NULLS FIRST], false, 0
 
-(165) Scan parquet
+(163) Scan parquet
 Output [2]: [web_site_sk#20, web_company_name#21]
 Batched: true
 Location: InMemoryFileIndex [file:/<warehouse_dir>]
 PushedFilters: [IsNotNull(web_company_name), EqualTo(web_company_name,pri), IsNotNull(web_site_sk)]
 ReadSchema: struct<web_site_sk:int,web_company_name:string>
 
-(166) Filter
+(164) Filter
 Input [2]: [web_site_sk#20, web_company_name#21]
 Condition : ((isnotnull(web_company_name#21) AND (web_company_name#21 = pri)) AND isnotnull(web_site_sk#20))
 
-(167) Project
+(165) Project
 Output [1]: [web_site_sk#20]
 Input [2]: [web_site_sk#20, web_company_name#21]
 
-(168) Exchange
+(166) Exchange
 Input [1]: [web_site_sk#20]
 Arguments: hashpartitioning(web_site_sk#20, 100), ENSURE_REQUIREMENTS, [plan_id=23]
 
-(169) Sort
+(167) Sort
 Input [1]: [web_site_sk#20]
 Arguments: [web_site_sk#20 ASC NULLS FIRST], false, 0
 
-(170) SortMergeJoin
+(168) SortMergeJoin
 Left keys [1]: [ws_web_site_sk#3]
 Right keys [1]: [web_site_sk#20]
 Join type: Inner
 Join condition: None
 
-(171) Project
+(169) Project
 Output [3]: [ws_order_number#4, ws_ext_ship_cost#5, ws_net_profit#6]
 Input [5]: [ws_web_site_sk#3, ws_order_number#4, ws_ext_ship_cost#5, ws_net_profit#6, web_site_sk#20]
 
-(172) HashAggregate
+(170) HashAggregate
 Input [3]: [ws_order_number#4, ws_ext_ship_cost#5, ws_net_profit#6]
 Keys [1]: [ws_order_number#4]
 Functions [2]: [partial_sum(UnscaledValue(ws_ext_ship_cost#5)), partial_sum(UnscaledValue(ws_net_profit#6))]
 Aggregate Attributes [2]: [sum(UnscaledValue(ws_ext_ship_cost#5))#24, sum(UnscaledValue(ws_net_profit#6))#25]
 Results [3]: [ws_order_number#4, sum#31, sum#32]
 
-(173) Exchange
+(171) Exchange
 Input [3]: [ws_order_number#4, sum#31, sum#32]
 Arguments: hashpartitioning(ws_order_number#4, 100), ENSURE_REQUIREMENTS, [plan_id=24]
 
-(174) HashAggregate
+(172) HashAggregate
 Input [3]: [ws_order_number#4, sum#31, sum#32]
 Keys [1]: [ws_order_number#4]
 Functions [2]: [merge_sum(UnscaledValue(ws_ext_ship_cost#5)), merge_sum(UnscaledValue(ws_net_profit#6))]
 Aggregate Attributes [2]: [sum(UnscaledValue(ws_ext_ship_cost#5))#24, sum(UnscaledValue(ws_net_profit#6))#25]
 Results [3]: [ws_order_number#4, sum#31, sum#32]
 
-(175) HashAggregate
+(173) HashAggregate
 Input [3]: [ws_order_number#4, sum#31, sum#32]
 Keys: []
 Functions [3]: [merge_sum(UnscaledValue(ws_ext_ship_cost#5)), merge_sum(UnscaledValue(ws_net_profit#6)), partial_count(distinct ws_order_number#4)]
 Aggregate Attributes [3]: [sum(UnscaledValue(ws_ext_ship_cost#5))#24, sum(UnscaledValue(ws_net_profit#6))#25, count(ws_order_number#4)#27]
 Results [3]: [sum#31, sum#32, count#33]
 
-(176) Exchange
+(174) Exchange
 Input [3]: [sum#31, sum#32, count#33]
 Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=25]
 
-(177) HashAggregate
+(175) HashAggregate
 Input [3]: [sum#31, sum#32, count#33]
 Keys: []
 Functions [3]: [sum(UnscaledValue(ws_ext_ship_cost#5)), sum(UnscaledValue(ws_net_profit#6)), count(distinct ws_order_number#4)]
 Aggregate Attributes [3]: [sum(UnscaledValue(ws_ext_ship_cost#5))#24, sum(UnscaledValue(ws_net_profit#6))#25, count(ws_order_number#4)#27]
 Results [3]: [count(ws_order_number#4)#27 AS order count #28, MakeDecimal(sum(UnscaledValue(ws_ext_ship_cost#5))#24,17,2) AS total shipping cost #29, MakeDecimal(sum(UnscaledValue(ws_net_profit#6))#25,17,2) AS total net profit #30]
 
-(178) AdaptiveSparkPlan
+(176) AdaptiveSparkPlan
 Output [3]: [order count #28, total shipping cost #29, total net profit #30]
 Arguments: isFinalPlan=true
 

--- a/native-engine/auron-planner/proto/auron.proto
+++ b/native-engine/auron-planner/proto/auron.proto
@@ -458,6 +458,7 @@ message SortMergeJoinExecNode {
   repeated JoinOn on = 4;
   repeated SortOptions sort_options = 5;
   JoinType join_type = 6;
+  JoinFilter filter = 7;
 }
 
 message HashJoinExecNode {
@@ -467,6 +468,7 @@ message HashJoinExecNode {
   repeated JoinOn on = 4;
   JoinType join_type = 5;
   JoinSide build_side = 6;
+  JoinFilter filter = 7;
 }
 
 message BroadcastJoinBuildHashMapExecNode {

--- a/native-engine/auron-planner/src/planner.rs
+++ b/native-engine/auron-planner/src/planner.rs
@@ -77,6 +77,7 @@ use datafusion_ext_plans::{
     generate_exec::GenerateExec,
     ipc_reader_exec::IpcReaderExec,
     ipc_writer_exec::IpcWriterExec,
+    joins::{ColumnIndex, JoinFilter, join_utils::JoinType},
     limit_exec::LimitExec,
     orc_exec::OrcExec,
     parquet_exec::ParquetExec,
@@ -232,6 +233,13 @@ impl PhysicalPlanner {
 
                 let join_type =
                     protobuf::JoinType::try_from(hash_join.join_type).expect("invalid JoinType");
+                let join_type = JoinType::from(join_type);
+                let join_filter = self.parse_join_filter(hash_join.filter.as_ref())?;
+                if join_filter.is_some() && join_type != JoinType::Inner {
+                    return Err(proto_error(
+                        "hash join filter is only supported for inner join",
+                    ));
+                }
 
                 let build_side =
                     protobuf::JoinSide::try_from(hash_join.build_side).expect("invalid BuildSide");
@@ -241,15 +249,14 @@ impl PhysicalPlanner {
                     left,
                     right,
                     on,
-                    join_type
-                        .try_into()
-                        .map_err(|_| proto_error("invalid JoinType"))?,
+                    join_type,
                     build_side
                         .try_into()
                         .map_err(|_| proto_error("invalid BuildSide"))?,
                     false,
                     None,
                     false,
+                    join_filter,
                 )?))
             }
             PhysicalPlanType::SortMergeJoin(sort_merge_join) => {
@@ -289,15 +296,21 @@ impl PhysicalPlanner {
 
                 let join_type = protobuf::JoinType::try_from(sort_merge_join.join_type)
                     .expect("invalid JoinType");
+                let join_type = JoinType::from(join_type);
+                let join_filter = self.parse_join_filter(sort_merge_join.filter.as_ref())?;
+                if join_filter.is_some() && join_type != JoinType::Inner {
+                    return Err(proto_error(
+                        "sort-merge join filter is only supported for inner join",
+                    ));
+                }
 
                 Ok(Arc::new(SortMergeJoinExec::try_new(
                     schema,
                     left,
                     right,
                     on,
-                    join_type
-                        .try_into()
-                        .map_err(|_| proto_error("invalid JoinType"))?,
+                    join_type,
+                    join_filter,
                     sort_options,
                 )?))
             }
@@ -425,6 +438,7 @@ impl PhysicalPlanner {
                     true,
                     Some(cached_build_hash_map_id),
                     is_null_aware_anti_join,
+                    None,
                 )?))
             }
             PhysicalPlanType::Union(union) => {
@@ -824,6 +838,40 @@ impl PhysicalPlanner {
                 }
             }
         }
+    }
+
+    fn parse_join_filter(
+        &self,
+        filter: Option<&protobuf::JoinFilter>,
+    ) -> Result<Option<JoinFilter>, PlanSerDeError> {
+        let Some(filter) = filter else {
+            return Ok(None);
+        };
+
+        let schema: SchemaRef = Arc::new(convert_required!(filter.schema)?);
+        let expression = filter
+            .expression
+            .as_ref()
+            .ok_or_else(|| proto_error("join filter expression must be present"))
+            .and_then(|expr| self.try_parse_physical_expr(expr, &schema))?;
+        let column_indices = filter
+            .column_indices
+            .iter()
+            .map(|column_index| {
+                let side = protobuf::JoinSide::try_from(column_index.side)
+                    .map_err(|_| proto_error("invalid join filter column side"))?;
+                Ok(ColumnIndex {
+                    side: side.into(),
+                    index: column_index.index as usize,
+                })
+            })
+            .collect::<Result<Vec<_>, PlanSerDeError>>()?;
+
+        Ok(Some(JoinFilter {
+            expression,
+            column_indices,
+            schema,
+        }))
     }
 
     fn try_parse_physical_expr(

--- a/native-engine/auron-planner/src/planner.rs
+++ b/native-engine/auron-planner/src/planner.rs
@@ -234,6 +234,10 @@ impl PhysicalPlanner {
                 let join_type =
                     protobuf::JoinType::try_from(hash_join.join_type).expect("invalid JoinType");
                 let join_type = JoinType::from(join_type);
+                // Spark residual join conditions are evaluated after join key
+                // matching. Keep the native implementation limited to inner
+                // joins for now so filtering matched pairs cannot change outer
+                // join null-extension semantics.
                 let join_filter = self.parse_join_filter(hash_join.filter.as_ref())?;
                 if join_filter.is_some() && join_type != JoinType::Inner {
                     return Err(proto_error(
@@ -297,6 +301,10 @@ impl PhysicalPlanner {
                 let join_type = protobuf::JoinType::try_from(sort_merge_join.join_type)
                     .expect("invalid JoinType");
                 let join_type = JoinType::from(join_type);
+                // Spark residual join conditions are evaluated after join key
+                // matching. Keep the native implementation limited to inner
+                // joins for now so filtering matched pairs cannot change outer
+                // join null-extension semantics.
                 let join_filter = self.parse_join_filter(sort_merge_join.filter.as_ref())?;
                 if join_filter.is_some() && join_type != JoinType::Inner {
                     return Err(proto_error(
@@ -848,6 +856,9 @@ impl PhysicalPlanner {
             return Ok(None);
         };
 
+        // The filter expression is serialized against a compact schema made
+        // from only the referenced join-side columns. column_indices maps each
+        // compact filter input back to the original left/right child column.
         let schema: SchemaRef = Arc::new(convert_required!(filter.schema)?);
         let expression = filter
             .expression

--- a/native-engine/datafusion-ext-plans/src/broadcast_join_exec.rs
+++ b/native-engine/datafusion-ext-plans/src/broadcast_join_exec.rs
@@ -107,6 +107,10 @@ impl BroadcastJoinExec {
         is_null_aware_anti_join: bool,
         join_filter: Option<JoinFilter>,
     ) -> Result<Self> {
+        // A broadcast hash join may reuse a prebuilt hash map whose stored
+        // rows are not laid out for evaluating Spark's residual join condition.
+        // Only the shuffled hash join path builds both sides in-process and
+        // can filter candidate pairs before projection today.
         if join_filter.is_some() && (is_built || join_type != JoinType::Inner) {
             df_execution_err!("join filter is only supported for inner shuffled hash join")?;
         }

--- a/native-engine/datafusion-ext-plans/src/broadcast_join_exec.rs
+++ b/native-engine/datafusion-ext-plans/src/broadcast_join_exec.rs
@@ -58,7 +58,7 @@ use crate::{
         timer_helper::TimerHelper,
     },
     joins::{
-        JoinParams, JoinProjection,
+        JoinFilter, JoinParams, JoinProjection,
         bhj::{
             full_join::{
                 LProbedFullOuterJoiner, LProbedInnerJoiner, LProbedLeftJoiner, LProbedRightJoiner,
@@ -89,6 +89,7 @@ pub struct BroadcastJoinExec {
     is_built: bool, // true for BroadcastHashJoin, false for ShuffledHashJoin
     cached_build_hash_map_id: Option<String>,
     is_null_aware_anti_join: bool,
+    join_filter: Option<JoinFilter>,
     metrics: ExecutionPlanMetricsSet,
     props: OnceCell<PlanProperties>,
 }
@@ -104,7 +105,11 @@ impl BroadcastJoinExec {
         is_built: bool,
         cached_build_hash_map_id: Option<String>,
         is_null_aware_anti_join: bool,
+        join_filter: Option<JoinFilter>,
     ) -> Result<Self> {
+        if join_filter.is_some() && (is_built || join_type != JoinType::Inner) {
+            df_execution_err!("join filter is only supported for inner shuffled hash join")?;
+        }
         Ok(Self {
             left,
             right,
@@ -115,6 +120,7 @@ impl BroadcastJoinExec {
             is_built,
             cached_build_hash_map_id,
             is_null_aware_anti_join,
+            join_filter,
             metrics: ExecutionPlanMetricsSet::new(),
             props: OnceCell::new(),
         })
@@ -178,6 +184,7 @@ impl BroadcastJoinExec {
             batch_size: batch_size(),
             sort_options: vec![SortOptions::default(); self.on.len()],
             projection,
+            join_filter: self.join_filter.clone(),
             key_data_types,
             is_null_aware_anti_join: self.is_null_aware_anti_join,
         })
@@ -284,6 +291,7 @@ impl ExecutionPlan for BroadcastJoinExec {
             self.is_built,
             None,
             self.is_null_aware_anti_join,
+            self.join_filter.clone(),
         )?))
     }
 
@@ -453,6 +461,7 @@ async fn execute_join_with_smj_fallback(
             .zip(join_params.right_keys.to_vec())
             .collect(),
         join_params.join_type,
+        join_params.join_filter.clone(),
         vec![SortOptions::default(); join_params.left_keys.len()],
     )?);
     let mut join_output = smj_exec.execute(exec_ctx.partition_id(), exec_ctx.task_ctx())?;

--- a/native-engine/datafusion-ext-plans/src/joins/bhj/full_join.rs
+++ b/native-engine/datafusion-ext-plans/src/joins/bhj/full_join.rs
@@ -169,6 +169,10 @@ impl<const P: JoinerParams> FullJoiner<P> {
             if P.probe_side_outer || P.build_side_outer {
                 df_execution_err!("join filter is only supported for inner shuffled hash join")?;
             }
+            // Materialize candidate pairs from the hash lookup before
+            // evaluating the residual condition. This keeps the filter inside
+            // the join operator and avoids emitting rows that a parent filter
+            // would immediately discard.
             let pcols = if probe_indices.len() == probed_batch.num_rows()
                 && probe_indices
                     .iter()

--- a/native-engine/datafusion-ext-plans/src/joins/bhj/full_join.rs
+++ b/native-engine/datafusion-ext-plans/src/joins/bhj/full_join.rs
@@ -24,13 +24,14 @@ use std::{
 use arrow::{
     array::{Array, ArrayRef, RecordBatch, RecordBatchOptions, UInt32Array, new_null_array},
     buffer::NullBuffer,
+    compute::filter,
 };
 use async_trait::async_trait;
 use bitvec::{bitvec, prelude::BitVec};
 use datafusion::{common::Result, physical_plan::metrics::Time};
 use datafusion_ext_commons::{
     arrow::{eq_comparator::EqComparator, selection::take_cols},
-    likely,
+    df_execution_err, likely,
 };
 
 use crate::{
@@ -163,6 +164,51 @@ impl<const P: JoinerParams> FullJoiner<P> {
         let num_rows = probe_indices.len();
 
         assert_eq!(probe_indices.len(), build_indices.len());
+
+        if let Some(join_filter) = &self.join_params.join_filter {
+            if P.probe_side_outer || P.build_side_outer {
+                df_execution_err!("join filter is only supported for inner shuffled hash join")?;
+            }
+            let pcols = if probe_indices.len() == probed_batch.num_rows()
+                && probe_indices
+                    .iter()
+                    .zip(0..probed_batch.num_rows() as u32)
+                    .all(|(&idx, i)| idx == i)
+            {
+                probed_batch.columns().to_vec()
+            } else {
+                take_cols(probed_batch.columns(), probe_indices)?
+            };
+            let bcols = take_cols(self.map.data_batch().columns(), build_indices)?;
+
+            let (left_cols, right_cols) = match P.probe_side {
+                L => (&pcols, &bcols),
+                R => (&bcols, &pcols),
+            };
+            let selected = join_filter.evaluate(left_cols, right_cols, num_rows)?;
+            let num_rows = selected.iter().filter(|v| matches!(v, Some(true))).count();
+            let left_cols = left_cols
+                .iter()
+                .map(|col| Ok(filter(col, &selected)?))
+                .collect::<Result<Vec<_>>>()?;
+            let right_cols = right_cols
+                .iter()
+                .map(|col| Ok(filter(col, &selected)?))
+                .collect::<Result<Vec<_>>>()?;
+            let pcols = match P.probe_side {
+                L => self.join_params.projection.project_left(&left_cols),
+                R => self.join_params.projection.project_right(&right_cols),
+            };
+            let bcols = match P.probe_side {
+                L => self.join_params.projection.project_right(&right_cols),
+                R => self.join_params.projection.project_left(&left_cols),
+            };
+
+            build_output_time
+                .exclude_timer_async(self.flush(pcols, bcols, num_rows))
+                .await?;
+            return Ok(());
+        }
 
         let pprojected = match P.probe_side {
             L => self

--- a/native-engine/datafusion-ext-plans/src/joins/mod.rs
+++ b/native-engine/datafusion-ext-plans/src/joins/mod.rs
@@ -98,6 +98,9 @@ impl JoinFilter {
                 })
             })
             .collect::<Result<Vec<_>>>()?;
+        // Join filters are compiled against a compact schema containing only
+        // columns referenced by the residual condition. Build a temporary
+        // batch with those columns in the same order before evaluating it.
         let batch = RecordBatch::try_new_with_options(
             self.schema.clone(),
             cols,
@@ -110,6 +113,7 @@ impl JoinFilter {
             ColumnarValue::Scalar(_) => Ok(BooleanArray::from(vec![false; num_rows])),
             ColumnarValue::Array(selected) => {
                 let mut selected = as_boolean_array(&selected)?.clone();
+                // Spark treats a NULL residual predicate as not matched.
                 if selected.null_count() > 0 {
                     selected = prep_null_mask_filter(&selected);
                 }

--- a/native-engine/datafusion-ext-plans/src/joins/mod.rs
+++ b/native-engine/datafusion-ext-plans/src/joins/mod.rs
@@ -16,11 +16,16 @@
 use std::sync::Arc;
 
 use arrow::{
-    array::ArrayRef,
-    compute::SortOptions,
+    array::{Array, ArrayRef, BooleanArray, RecordBatch, RecordBatchOptions},
+    compute::{SortOptions, prep_null_mask_filter},
     datatypes::{DataType, SchemaRef},
 };
-use datafusion::{common::Result, physical_expr::PhysicalExprRef};
+use datafusion::{
+    common::{JoinSide, Result, ScalarValue, cast::as_boolean_array},
+    physical_expr::PhysicalExprRef,
+    physical_plan::ColumnarValue,
+};
+use datafusion_ext_commons::df_execution_err;
 use stream_cursor::StreamCursor;
 
 use crate::joins::join_utils::JoinType;
@@ -45,8 +50,73 @@ pub struct JoinParams {
     pub key_data_types: Vec<DataType>,
     pub sort_options: Vec<SortOptions>,
     pub projection: JoinProjection,
+    pub join_filter: Option<JoinFilter>,
     pub batch_size: usize,
     pub is_null_aware_anti_join: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct JoinFilter {
+    pub expression: PhysicalExprRef,
+    pub column_indices: Vec<ColumnIndex>,
+    pub schema: SchemaRef,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct ColumnIndex {
+    pub side: JoinSide,
+    pub index: usize,
+}
+
+impl JoinFilter {
+    pub fn evaluate(
+        &self,
+        left_cols: &[ArrayRef],
+        right_cols: &[ArrayRef],
+        num_rows: usize,
+    ) -> Result<BooleanArray> {
+        let cols = self
+            .column_indices
+            .iter()
+            .map(|col| {
+                Ok(match col.side {
+                    JoinSide::Left => left_cols.get(col.index).cloned().ok_or_else(|| {
+                        datafusion::common::DataFusionError::Execution(format!(
+                            "join filter left column index out of range: {}",
+                            col.index
+                        ))
+                    })?,
+                    JoinSide::Right => right_cols.get(col.index).cloned().ok_or_else(|| {
+                        datafusion::common::DataFusionError::Execution(format!(
+                            "join filter right column index out of range: {}",
+                            col.index
+                        ))
+                    })?,
+                    JoinSide::None => {
+                        df_execution_err!("join filter column side must be left or right")?
+                    }
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let batch = RecordBatch::try_new_with_options(
+            self.schema.clone(),
+            cols,
+            &RecordBatchOptions::new().with_row_count(Some(num_rows)),
+        )?;
+        match self.expression.evaluate(&batch)? {
+            ColumnarValue::Scalar(ScalarValue::Boolean(Some(true))) => {
+                Ok(BooleanArray::from(vec![true; num_rows]))
+            }
+            ColumnarValue::Scalar(_) => Ok(BooleanArray::from(vec![false; num_rows])),
+            ColumnarValue::Array(selected) => {
+                let mut selected = as_boolean_array(&selected)?.clone();
+                if selected.null_count() > 0 {
+                    selected = prep_null_mask_filter(&selected);
+                }
+                Ok(selected)
+            }
+        }
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/native-engine/datafusion-ext-plans/src/joins/smj/full_join.rs
+++ b/native-engine/datafusion-ext-plans/src/joins/smj/full_join.rs
@@ -79,6 +79,9 @@ impl<const L_OUTER: bool, const R_OUTER: bool> FullJoiner<L_OUTER, R_OUTER> {
         let rcols = rbatch_interleaver(&rindices)?;
         let (output_cols, num_rows): (Vec<ArrayRef>, usize) =
             if let Some(join_filter) = &self.join_params.join_filter {
+                // lindices/rindices already represent key-equal candidate
+                // pairs. Evaluate the residual condition here so SMJ applies
+                // Spark's join condition before output projection.
                 let selected = join_filter.evaluate(lcols.columns(), rcols.columns(), num_rows)?;
                 let lcols = lcols
                     .columns()

--- a/native-engine/datafusion-ext-plans/src/joins/smj/full_join.rs
+++ b/native-engine/datafusion-ext-plans/src/joins/smj/full_join.rs
@@ -15,7 +15,10 @@
 
 use std::{cmp::Ordering, pin::Pin, sync::Arc};
 
-use arrow::array::{RecordBatch, RecordBatchOptions};
+use arrow::{
+    array::{ArrayRef, RecordBatch, RecordBatchOptions},
+    compute::filter,
+};
 use async_trait::async_trait;
 use datafusion::common::Result;
 use datafusion_ext_commons::arrow::selection::create_batch_interleaver;
@@ -74,10 +77,35 @@ impl<const L_OUTER: bool, const R_OUTER: bool> FullJoiner<L_OUTER, R_OUTER> {
         let rbatch_interleaver = create_batch_interleaver(cur2.batches(), false)?;
         let lcols = lbatch_interleaver(&lindices)?;
         let rcols = rbatch_interleaver(&rindices)?;
+        let (output_cols, num_rows): (Vec<ArrayRef>, usize) =
+            if let Some(join_filter) = &self.join_params.join_filter {
+                let selected = join_filter.evaluate(lcols.columns(), rcols.columns(), num_rows)?;
+                let lcols = lcols
+                    .columns()
+                    .iter()
+                    .map(|col| Ok(filter(col, &selected)?))
+                    .collect::<Result<Vec<_>>>()?;
+                let rcols = rcols
+                    .columns()
+                    .iter()
+                    .map(|col| Ok(filter(col, &selected)?))
+                    .collect::<Result<Vec<_>>>()?;
+                let num_rows = selected.iter().filter(|v| matches!(v, Some(true))).count();
+                (
+                    [
+                        self.join_params.projection.project_left(&lcols),
+                        self.join_params.projection.project_right(&rcols),
+                    ]
+                    .concat(),
+                    num_rows,
+                )
+            } else {
+                ([lcols.columns(), rcols.columns()].concat(), num_rows)
+            };
 
         let output_batch = RecordBatch::try_new_with_options(
             self.join_params.projection.schema.clone(),
-            [lcols.columns(), rcols.columns()].concat(),
+            output_cols,
             &RecordBatchOptions::new().with_row_count(Some(num_rows)),
         )?;
 

--- a/native-engine/datafusion-ext-plans/src/joins/test.rs
+++ b/native-engine/datafusion-ext-plans/src/joins/test.rs
@@ -217,6 +217,7 @@ mod tests {
                     right,
                     on,
                     join_type,
+                    None,
                     sort_options,
                 )?)
             }
@@ -235,6 +236,7 @@ mod tests {
                     true,
                     None,
                     false,
+                    None,
                 )?)
             }
             BHJRightProbed => {
@@ -252,6 +254,7 @@ mod tests {
                     true,
                     None,
                     false,
+                    None,
                 )?)
             }
             SHJLeftProbed => Arc::new(BroadcastJoinExec::try_new(
@@ -264,6 +267,7 @@ mod tests {
                 false,
                 None,
                 false,
+                None,
             )?),
             SHJRightProbed => Arc::new(BroadcastJoinExec::try_new(
                 schema,
@@ -275,6 +279,7 @@ mod tests {
                 false,
                 None,
                 false,
+                None,
             )?),
         };
         let columns = columns(&join.schema());
@@ -306,6 +311,7 @@ mod tests {
                     right,
                     on,
                     join_type,
+                    None,
                     sort_options,
                 )?)
             }
@@ -324,6 +330,7 @@ mod tests {
                     true,
                     None,
                     false,
+                    None,
                 )?)
             }
             BHJRightProbed => {
@@ -341,6 +348,7 @@ mod tests {
                     true,
                     None,
                     false,
+                    None,
                 )?)
             }
             SHJLeftProbed => Arc::new(BroadcastJoinExec::try_new(
@@ -353,6 +361,7 @@ mod tests {
                 false,
                 None,
                 false,
+                None,
             )?),
             SHJRightProbed => Arc::new(BroadcastJoinExec::try_new(
                 schema,
@@ -364,6 +373,7 @@ mod tests {
                 false,
                 None,
                 false,
+                None,
             )?),
         };
         let columns = columns(&join.schema());

--- a/native-engine/datafusion-ext-plans/src/sort_merge_join_exec.rs
+++ b/native-engine/datafusion-ext-plans/src/sort_merge_join_exec.rs
@@ -159,6 +159,9 @@ impl SortMergeJoinExec {
         let poll_time = Time::new();
         let left_projection;
         let right_projection;
+        // The residual join condition may reference columns that are not part
+        // of the final projection. Keep full child rows while matching, then
+        // apply the output projection after the filter has selected rows.
         let (left_output_projection, right_output_projection) = if join_params.join_filter.is_some()
         {
             left_projection = (0..join_params.left_schema.fields().len()).collect::<Vec<_>>();

--- a/native-engine/datafusion-ext-plans/src/sort_merge_join_exec.rs
+++ b/native-engine/datafusion-ext-plans/src/sort_merge_join_exec.rs
@@ -42,7 +42,7 @@ use crate::{
     },
     cur_forward,
     joins::{
-        JoinParams, JoinProjection,
+        JoinFilter, JoinParams, JoinProjection,
         join_utils::{JoinType, JoinType::*},
         smj::{
             existence_join::ExistenceJoiner,
@@ -60,6 +60,7 @@ pub struct SortMergeJoinExec {
     on: JoinOn,
     join_type: JoinType,
     sort_options: Vec<SortOptions>,
+    join_filter: Option<JoinFilter>,
     join_params: OnceCell<JoinParams>,
     schema: SchemaRef,
     metrics: ExecutionPlanMetricsSet,
@@ -73,8 +74,12 @@ impl SortMergeJoinExec {
         right: Arc<dyn ExecutionPlan>,
         on: JoinOn,
         join_type: JoinType,
+        join_filter: Option<JoinFilter>,
         sort_options: Vec<SortOptions>,
     ) -> Result<Self> {
+        if join_filter.is_some() && join_type != JoinType::Inner {
+            df_execution_err!("join filter is only supported for inner sort-merge join")?;
+        }
         Ok(Self {
             schema,
             left,
@@ -82,6 +87,7 @@ impl SortMergeJoinExec {
             on,
             join_type,
             sort_options,
+            join_filter,
             join_params: OnceCell::new(),
             metrics: ExecutionPlanMetricsSet::new(),
             props: OnceCell::new(),
@@ -127,6 +133,7 @@ impl SortMergeJoinExec {
             key_data_types,
             sort_options: self.sort_options.clone(),
             projection,
+            join_filter: self.join_filter.clone(),
             batch_size: batch_size(),
             is_null_aware_anti_join: false,
         })
@@ -150,6 +157,16 @@ impl SortMergeJoinExec {
         );
 
         let poll_time = Time::new();
+        let left_projection;
+        let right_projection;
+        let (left_output_projection, right_output_projection) = if join_params.join_filter.is_some()
+        {
+            left_projection = (0..join_params.left_schema.fields().len()).collect::<Vec<_>>();
+            right_projection = (0..join_params.right_schema.fields().len()).collect::<Vec<_>>();
+            (&left_projection, &right_projection)
+        } else {
+            (&join_params.projection.left, &join_params.projection.right)
+        };
         let left = exec_ctx.execute_projected_with_key_rows_output(
             &self.left,
             &join_params
@@ -158,7 +175,7 @@ impl SortMergeJoinExec {
                 .zip(&join_params.sort_options)
                 .map(|(k, s)| PhysicalSortExpr::new(k.clone(), s.clone()))
                 .collect::<Vec<_>>(),
-            &join_params.projection.left,
+            left_output_projection,
         )?;
         let right = exec_ctx.execute_projected_with_key_rows_output(
             &self.right,
@@ -168,7 +185,7 @@ impl SortMergeJoinExec {
                 .zip(&join_params.sort_options)
                 .map(|(k, s)| PhysicalSortExpr::new(k.clone(), s.clone()))
                 .collect::<Vec<_>>(),
-            &join_params.projection.right,
+            right_output_projection,
         )?;
 
         let left = StreamCursor::try_new(left, poll_time.clone(), &join_params.key_data_types)?;
@@ -269,6 +286,7 @@ impl ExecutionPlan for SortMergeJoinExec {
             children[1].clone(),
             self.on.clone(),
             self.join_type,
+            self.join_filter.clone(),
             self.sort_options.clone(),
         )?))
     }

--- a/spark-extension-shims-spark/src/main/scala/org/apache/spark/sql/auron/ShimsImpl.scala
+++ b/spark-extension-shims-spark/src/main/scala/org/apache/spark/sql/auron/ShimsImpl.scala
@@ -248,6 +248,7 @@ class ShimsImpl extends Shims with Logging {
       leftKeys: Seq[Expression],
       rightKeys: Seq[Expression],
       joinType: JoinType,
+      condition: Option[Expression],
       isSkewJoin: Boolean): NativeSortMergeJoinBase =
     NativeSortMergeJoinExecProvider.provide(
       left,
@@ -255,6 +256,7 @@ class ShimsImpl extends Shims with Logging {
       leftKeys,
       rightKeys,
       joinType,
+      condition,
       isSkewJoin)
 
   override def createNativeShuffledHashJoinExec(
@@ -263,6 +265,7 @@ class ShimsImpl extends Shims with Logging {
       leftKeys: Seq[Expression],
       rightKeys: Seq[Expression],
       joinType: JoinType,
+      condition: Option[Expression],
       buildSide: JoinBuildSide,
       isSkewJoin: Boolean): SparkPlan =
     NativeShuffledHashJoinExecProvider.provide(
@@ -271,6 +274,7 @@ class ShimsImpl extends Shims with Logging {
       leftKeys,
       rightKeys,
       joinType,
+      condition,
       buildSide,
       isSkewJoin)
 

--- a/spark-extension-shims-spark/src/main/scala/org/apache/spark/sql/execution/joins/auron/plan/NativeShuffledHashJoinExecProvider.scala
+++ b/spark-extension-shims-spark/src/main/scala/org/apache/spark/sql/execution/joins/auron/plan/NativeShuffledHashJoinExecProvider.scala
@@ -36,6 +36,7 @@ case object NativeShuffledHashJoinExecProvider {
       leftKeys: Seq[Expression],
       rightKeys: Seq[Expression],
       joinType: JoinType,
+      condition: Option[Expression],
       buildSide: JoinBuildSide,
       isSkewJoin: Boolean): NativeShuffledHashJoinBase = {
 
@@ -49,12 +50,18 @@ case object NativeShuffledHashJoinExecProvider {
         override val leftKeys: Seq[Expression],
         override val rightKeys: Seq[Expression],
         override val joinType: JoinType,
+        override val condition: Option[Expression],
         buildSide: JoinBuildSide,
         skewJoin: Boolean)
-        extends NativeShuffledHashJoinBase(left, right, leftKeys, rightKeys, joinType, buildSide)
+        extends NativeShuffledHashJoinBase(
+          left,
+          right,
+          leftKeys,
+          rightKeys,
+          joinType,
+          condition,
+          buildSide)
         with org.apache.spark.sql.execution.joins.ShuffledJoin {
-
-      override def condition: Option[Expression] = None
 
       override def isSkewJoin: Boolean = false
 
@@ -79,7 +86,15 @@ case object NativeShuffledHashJoinExecProvider {
       override def nodeName: String =
         "NativeShuffledHashJoin" + (if (skewJoin) "(skew=true)" else "")
     }
-    NativeShuffledHashJoinExec(left, right, leftKeys, rightKeys, joinType, buildSide, isSkewJoin)
+    NativeShuffledHashJoinExec(
+      left,
+      right,
+      leftKeys,
+      rightKeys,
+      joinType,
+      condition,
+      buildSide,
+      isSkewJoin)
   }
 
   @nowarn("cat=unused") // Some params temporarily unused
@@ -90,6 +105,7 @@ case object NativeShuffledHashJoinExecProvider {
       leftKeys: Seq[Expression],
       rightKeys: Seq[Expression],
       joinType: JoinType,
+      condition: Option[Expression],
       buildSide: JoinBuildSide,
       isSkewJoin: Boolean): NativeShuffledHashJoinBase = {
 
@@ -103,11 +119,17 @@ case object NativeShuffledHashJoinExecProvider {
         leftKeys: Seq[Expression],
         rightKeys: Seq[Expression],
         joinType: JoinType,
+        override val condition: Option[Expression],
         buildSide: JoinBuildSide)
-        extends NativeShuffledHashJoinBase(left, right, leftKeys, rightKeys, joinType, buildSide)
+        extends NativeShuffledHashJoinBase(
+          left,
+          right,
+          leftKeys,
+          rightKeys,
+          joinType,
+          condition,
+          buildSide)
         with org.apache.spark.sql.execution.joins.ShuffledJoin {
-
-      override def condition: Option[Expression] = None
 
       override def rewriteKeyExprToLong(exprs: Seq[Expression]): Seq[Expression] =
         HashJoin.rewriteKeyExpr(exprs)
@@ -118,7 +140,14 @@ case object NativeShuffledHashJoinExecProvider {
           case JoinBuildRight => org.apache.spark.sql.catalyst.optimizer.BuildRight
         }
         val shj =
-          ShuffledHashJoinExec(leftKeys, rightKeys, joinType, sparkBuildSide, None, left, right)
+          ShuffledHashJoinExec(
+            leftKeys,
+            rightKeys,
+            joinType,
+            sparkBuildSide,
+            condition,
+            left,
+            right)
         shj.outputOrdering
       }
 
@@ -127,7 +156,7 @@ case object NativeShuffledHashJoinExecProvider {
 
       override def nodeName: String = "NativeShuffledHashJoin"
     }
-    NativeShuffledHashJoinExec(left, right, leftKeys, rightKeys, joinType, buildSide)
+    NativeShuffledHashJoinExec(left, right, leftKeys, rightKeys, joinType, condition, buildSide)
   }
 
   @nowarn("cat=unused") // Some params temporarily unused
@@ -138,6 +167,7 @@ case object NativeShuffledHashJoinExecProvider {
       leftKeys: Seq[Expression],
       rightKeys: Seq[Expression],
       joinType: JoinType,
+      condition: Option[Expression],
       buildSide: JoinBuildSide,
       isSkewJoin: Boolean): NativeShuffledHashJoinBase = {
 
@@ -151,6 +181,7 @@ case object NativeShuffledHashJoinExecProvider {
         leftKeys: Seq[Expression],
         rightKeys: Seq[Expression],
         joinType: JoinType,
+        condition: Option[Expression],
         buildSide: JoinBuildSide)
         extends NativeShuffledHashJoinBase(
           left,
@@ -158,6 +189,7 @@ case object NativeShuffledHashJoinExecProvider {
           leftKeys,
           rightKeys,
           joinType,
+          condition,
           buildSide) {
 
       private def shj: ShuffledHashJoinExec = {
@@ -165,7 +197,14 @@ case object NativeShuffledHashJoinExecProvider {
           case JoinBuildLeft => org.apache.spark.sql.execution.joins.BuildLeft
           case JoinBuildRight => org.apache.spark.sql.execution.joins.BuildRight
         }
-        ShuffledHashJoinExec(leftKeys, rightKeys, joinType, sparkBuildSide, None, left, right)
+        ShuffledHashJoinExec(
+          leftKeys,
+          rightKeys,
+          joinType,
+          sparkBuildSide,
+          condition,
+          left,
+          right)
       }
 
       override def output: Seq[Attribute] = shj.output
@@ -181,6 +220,6 @@ case object NativeShuffledHashJoinExecProvider {
 
       override def nodeName: String = "NativeShuffledHashJoin"
     }
-    NativeShuffledHashJoinExec(left, right, leftKeys, rightKeys, joinType, buildSide)
+    NativeShuffledHashJoinExec(left, right, leftKeys, rightKeys, joinType, condition, buildSide)
   }
 }

--- a/spark-extension-shims-spark/src/main/scala/org/apache/spark/sql/execution/joins/auron/plan/NativeSortMergeJoinExecProvider.scala
+++ b/spark-extension-shims-spark/src/main/scala/org/apache/spark/sql/execution/joins/auron/plan/NativeSortMergeJoinExecProvider.scala
@@ -32,6 +32,7 @@ case object NativeSortMergeJoinExecProvider {
       leftKeys: Seq[Expression],
       rightKeys: Seq[Expression],
       joinType: JoinType,
+      condition: Option[Expression],
       skewJoin: Boolean): NativeSortMergeJoinBase = {
 
     import org.apache.spark.rdd.RDD
@@ -44,11 +45,10 @@ case object NativeSortMergeJoinExecProvider {
         override val leftKeys: Seq[Expression],
         override val rightKeys: Seq[Expression],
         override val joinType: JoinType,
+        override val condition: Option[Expression],
         skewJoin: Boolean)
-        extends NativeSortMergeJoinBase(left, right, leftKeys, rightKeys, joinType)
+        extends NativeSortMergeJoinBase(left, right, leftKeys, rightKeys, joinType, condition)
         with org.apache.spark.sql.execution.joins.ShuffledJoin {
-
-      override def condition: Option[Expression] = None
 
       override def isSkewJoin: Boolean = false
 
@@ -70,7 +70,7 @@ case object NativeSortMergeJoinExecProvider {
       override def nodeName: String =
         "NativeSortMergeJoin" + (if (skewJoin) "(skew=true)" else "")
     }
-    NativeSortMergeJoinExec(left, right, leftKeys, rightKeys, joinType, skewJoin)
+    NativeSortMergeJoinExec(left, right, leftKeys, rightKeys, joinType, condition, skewJoin)
   }
 
   @sparkver("3.0 / 3.1")
@@ -80,6 +80,7 @@ case object NativeSortMergeJoinExecProvider {
       leftKeys: Seq[Expression],
       rightKeys: Seq[Expression],
       joinType: JoinType,
+      condition: Option[Expression],
       skewJoin: Boolean): NativeSortMergeJoinBase = {
 
     import org.apache.spark.sql.catalyst.expressions.Attribute
@@ -91,11 +92,19 @@ case object NativeSortMergeJoinExecProvider {
         leftKeys: Seq[Expression],
         rightKeys: Seq[Expression],
         joinType: JoinType,
+        condition: Option[Expression],
         skewJoin: Boolean)
-        extends NativeSortMergeJoinBase(left, right, leftKeys, rightKeys, joinType) {
+        extends NativeSortMergeJoinBase(left, right, leftKeys, rightKeys, joinType, condition) {
 
       private def smj: SortMergeJoinExec =
-        SortMergeJoinExec(leftKeys, rightKeys, joinType, None, left, right, isSkewJoin = false)
+        SortMergeJoinExec(
+          leftKeys,
+          rightKeys,
+          joinType,
+          condition,
+          left,
+          right,
+          isSkewJoin = false)
 
       override def output: Seq[Attribute] = smj.output
 
@@ -108,6 +117,6 @@ case object NativeSortMergeJoinExecProvider {
       override def nodeName: String =
         "NativeSortMergeJoin" + (if (skewJoin) "(skew=true)" else "")
     }
-    NativeSortMergeJoinExec(left, right, leftKeys, rightKeys, joinType, skewJoin)
+    NativeSortMergeJoinExec(left, right, leftKeys, rightKeys, joinType, condition, skewJoin)
   }
 }

--- a/spark-extension-shims-spark/src/test/scala/org/apache/auron/AuronQuerySuite.scala
+++ b/spark-extension-shims-spark/src/test/scala/org/apache/auron/AuronQuerySuite.scala
@@ -17,6 +17,9 @@
 package org.apache.auron
 
 import org.apache.spark.sql.{AuronQueryTest, Row}
+import org.apache.spark.sql.execution.auron.plan.NativeFilterBase
+import org.apache.spark.sql.execution.auron.plan.NativeShuffledHashJoinBase
+import org.apache.spark.sql.execution.auron.plan.NativeSortMergeJoinBase
 import org.apache.spark.sql.execution.joins.auron.plan.NativeBroadcastJoinExec
 
 import org.apache.auron.spark.configuration.SparkAuronConfiguration
@@ -609,6 +612,105 @@ class AuronQuerySuite extends AuronQueryTest with BaseAuronSQLSuite with AuronSQ
       // Expected: (1, 2.0), (1, 2.0), (null, null), (null, 5.0)
       checkSparkAnswer(
         "SELECT * FROM left_table LEFT ANTI JOIN right_table ON left_table.a = right_table.c")
+    }
+  }
+
+  test("native sort merge join supports inner residual condition") {
+    withSparkConf("spark.auron.forceShuffledHashJoin" -> "false") {
+      withSQLConf(
+        "spark.sql.adaptive.enabled" -> "false",
+        "spark.sql.autoBroadcastJoinThreshold" -> "-1",
+        "spark.sql.join.preferSortMergeJoin" -> "true") {
+        withTable("smj_left", "smj_right") {
+          sql("""
+                |CREATE TABLE smj_left USING parquet AS
+                |SELECT * FROM VALUES
+                |  (1, 1),
+                |  (2, 5),
+                |  (3, 7),
+                |  (4, 9)
+                |AS t(id, lv)
+                |""".stripMargin)
+
+          sql("""
+                |CREATE TABLE smj_right USING parquet AS
+                |SELECT * FROM VALUES
+                |  (1, 2),
+                |  (2, 4),
+                |  (3, 8),
+                |  (4, 9)
+                |AS t(id, rv)
+                |""".stripMargin)
+
+          val df = checkSparkAnswerAndOperator("""
+                |SELECT /*+ MERGE(l, r) */ l.id, l.lv, r.rv
+                |FROM smj_left l
+                |JOIN smj_right r
+                |  ON l.id = r.id AND l.lv < r.rv
+                |ORDER BY l.id
+                |""".stripMargin)
+
+          val plan = stripAQEPlan(df.queryExecution.executedPlan)
+          assert(
+            plan.collectFirst { case _: NativeSortMergeJoinBase => true }.isDefined,
+            s"expected NativeSortMergeJoinBase in executed plan, but got:\n$plan")
+          assert(
+            plan.collectFirst {
+              case filter: NativeFilterBase
+                  if filter.child.isInstanceOf[NativeSortMergeJoinBase] =>
+                true
+            }.isEmpty,
+            s"expected residual condition to be evaluated by native SMJ, but got:\n$plan")
+        }
+      }
+    }
+  }
+
+  test(
+    "native shuffled hash join supports inner residual condition in forceShuffledHashJoin mode") {
+    withSparkConf("spark.auron.forceShuffledHashJoin" -> "true") {
+      withSQLConf(
+        "spark.sql.adaptive.enabled" -> "false",
+        "spark.sql.autoBroadcastJoinThreshold" -> "-1",
+        "spark.sql.join.preferSortMergeJoin" -> "true") {
+        withTable("shj_left", "shj_right") {
+          sql("""
+                |CREATE TABLE shj_left USING parquet AS
+                |SELECT id, cast(id % 4 as int) AS lv
+                |FROM range(0, 1000)
+                |""".stripMargin)
+
+          sql("""
+                |CREATE TABLE shj_right USING parquet AS
+                |SELECT * FROM VALUES
+                |  (1L, 2),
+                |  (2L, 1),
+                |  (3L, 5),
+                |  (10L, 4)
+                |AS t(id, rv)
+                |""".stripMargin)
+
+          val df = checkSparkAnswerAndOperator("""
+                |SELECT /*+ MERGE(l, r) */ l.id, l.lv, r.rv
+                |FROM shj_left l
+                |JOIN shj_right r
+                |  ON l.id = r.id AND l.lv < r.rv
+                |ORDER BY l.id
+                |""".stripMargin)
+
+          val plan = stripAQEPlan(df.queryExecution.executedPlan)
+          assert(
+            plan.collectFirst { case _: NativeShuffledHashJoinBase => true }.isDefined,
+            s"expected NativeShuffledHashJoinBase in executed plan, but got:\n$plan")
+          assert(
+            plan.collectFirst {
+              case filter: NativeFilterBase
+                  if filter.child.isInstanceOf[NativeShuffledHashJoinBase] =>
+                true
+            }.isEmpty,
+            s"expected residual condition to be evaluated by native SHJ, but got:\n$plan")
+        }
+      }
     }
   }
 

--- a/spark-extension-shims-spark/src/test/scala/org/apache/auron/AuronQuerySuite.scala
+++ b/spark-extension-shims-spark/src/test/scala/org/apache/auron/AuronQuerySuite.scala
@@ -666,6 +666,49 @@ class AuronQuerySuite extends AuronQueryTest with BaseAuronSQLSuite with AuronSQ
     }
   }
 
+  test("native residual join condition can be disabled") {
+    withSparkConf("spark.auron.forceShuffledHashJoin" -> "false") {
+      withSQLConf(
+        "spark.auron.enable.native.join.condition" -> "false",
+        "spark.sql.adaptive.enabled" -> "false",
+        "spark.sql.autoBroadcastJoinThreshold" -> "-1",
+        "spark.sql.join.preferSortMergeJoin" -> "true") {
+        withTable("smj_disabled_left", "smj_disabled_right") {
+          sql("""
+                |CREATE TABLE smj_disabled_left USING parquet AS
+                |SELECT * FROM VALUES
+                |  (1, 1),
+                |  (2, 5),
+                |  (3, 7)
+                |AS t(id, lv)
+                |""".stripMargin)
+
+          sql("""
+                |CREATE TABLE smj_disabled_right USING parquet AS
+                |SELECT * FROM VALUES
+                |  (1, 2),
+                |  (2, 4),
+                |  (3, 8)
+                |AS t(id, rv)
+                |""".stripMargin)
+
+          val df = checkSparkAnswer("""
+                |SELECT /*+ MERGE(l, r) */ l.id, l.lv, r.rv
+                |FROM smj_disabled_left l
+                |JOIN smj_disabled_right r
+                |  ON l.id = r.id AND l.lv < r.rv
+                |ORDER BY l.id
+                |""".stripMargin)
+
+          val plan = stripAQEPlan(df.queryExecution.executedPlan)
+          assert(
+            plan.collectFirst { case _: NativeSortMergeJoinBase => true }.isEmpty,
+            s"expected native residual join condition to be disabled, but got:\n$plan")
+        }
+      }
+    }
+  }
+
   test(
     "native shuffled hash join supports inner residual condition in forceShuffledHashJoin mode") {
     withSparkConf("spark.auron.forceShuffledHashJoin" -> "true") {

--- a/spark-extension-shims-spark/src/test/scala/org/apache/auron/AuronSQLTestHelper.scala
+++ b/spark-extension-shims-spark/src/test/scala/org/apache/auron/AuronSQLTestHelper.scala
@@ -16,9 +16,12 @@
  */
 package org.apache.auron
 
+import org.apache.spark.SparkEnv
 import org.apache.spark.sql.internal.SQLConf
 
 trait AuronSQLTestHelper {
+  self: BaseAuronSQLSuite =>
+
   def withEnvConf(pairs: (String, String)*)(f: => Unit): Unit = {
     val conf = SQLConf.get
     val (keys, values) = pairs.unzip
@@ -29,7 +32,7 @@ trait AuronSQLTestHelper {
         None
       }
     }
-    (keys, values).zipped.foreach { (k, v) =>
+    keys.zip(values).foreach { case (k, v) =>
       conf.setConfString(k, v)
     }
     try f
@@ -37,6 +40,28 @@ trait AuronSQLTestHelper {
       keys.zip(currentValues).foreach {
         case (key, Some(value)) => conf.setConfString(key, value)
         case (key, None) => conf.unsetConf(key)
+      }
+    }
+  }
+
+  def withSparkConf(pairs: (String, String)*)(f: => Unit): Unit = {
+    val confs = Seq(spark.sparkContext.getConf, SparkEnv.get.conf).distinct
+    val (keys, values) = pairs.unzip
+    val currentValuesByConf = confs.map(conf => conf -> keys.map(conf.getOption))
+
+    confs.foreach { conf =>
+      keys.zip(values).foreach { case (k, v) =>
+        conf.set(k, v)
+      }
+    }
+
+    try f
+    finally {
+      currentValuesByConf.foreach { case (conf, currentValues) =>
+        keys.zip(currentValues).foreach {
+          case (key, Some(value)) => conf.set(key, value)
+          case (key, None) => conf.remove(key)
+        }
       }
     }
   }

--- a/spark-extension/src/main/java/org/apache/auron/spark/configuration/SparkAuronConfiguration.java
+++ b/spark-extension/src/main/java/org/apache/auron/spark/configuration/SparkAuronConfiguration.java
@@ -369,6 +369,14 @@ public class SparkAuronConfiguration extends AuronConfiguration {
             .withDescription("Enable ShuffledHashJoinExec operation conversion to native Auron implementations.")
             .withDefaultValue(true);
 
+    public static final ConfigOption<Boolean> ENABLE_NATIVE_JOIN_CONDITION = new SQLConfOption<>(Boolean.class)
+            .withKey("auron.enable.native.join.condition")
+            .withCategory("Operator Supports")
+            .withDescription(
+                    "Enable native SMJ/SHJ residual join condition evaluation. Disable this to fall back to Spark "
+                            + "for joins with residual conditions when native evaluation is not desirable.")
+            .withDefaultValue(true);
+
     public static final ConfigOption<Boolean> ENABLE_BHJ = new SQLConfOption<>(Boolean.class)
             .withKey("auron.enable.bhj")
             .withCategory("Operator Supports")

--- a/spark-extension/src/main/scala/org/apache/spark/sql/auron/AuronConverters.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/auron/AuronConverters.scala
@@ -622,6 +622,9 @@ object AuronConverters extends Logging {
       joinType: JoinType,
       condition: Option[Expression]): Unit = {
     condition.foreach { expr =>
+      assert(
+        SparkAuronConfiguration.ENABLE_NATIVE_JOIN_CONDITION.get(),
+        "native join condition is disabled")
       assert(joinType.isInstanceOf[InnerLike], "join condition is not supported")
       validateNativeInnerJoinConditionExpr(expr)
     }

--- a/spark-extension/src/main/scala/org/apache/spark/sql/auron/AuronConverters.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/auron/AuronConverters.scala
@@ -46,6 +46,8 @@ import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
 import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateFunction
 import org.apache.spark.sql.catalyst.expressions.aggregate.Final
 import org.apache.spark.sql.catalyst.expressions.aggregate.Partial
+import org.apache.spark.sql.catalyst.plans.InnerLike
+import org.apache.spark.sql.catalyst.plans.JoinType
 import org.apache.spark.sql.catalyst.plans.physical.HashPartitioning
 import org.apache.spark.sql.catalyst.plans.physical.Partitioning
 import org.apache.spark.sql.catalyst.plans.physical.RangePartitioning
@@ -506,7 +508,6 @@ object AuronConverters extends Logging {
           "rightKeys" -> rightKeys,
           "joinType" -> joinType,
           "condition" -> condition))
-      assert(condition.isEmpty, "join condition is not supported")
 
       val buildSide = exec
         .getTagValue(joinSmallerSideTag)
@@ -516,12 +517,14 @@ object AuronConverters extends Logging {
           JoinBuildRight
         }
 
+      validateNativeInnerJoinCondition(joinType, condition)
       return Shims.get.createNativeShuffledHashJoinExec(
         addRenameColumnsExec(convertToNative(left.children(0))),
         addRenameColumnsExec(convertToNative(right.children(0))),
         leftKeys,
         rightKeys,
         joinType,
+        condition,
         buildSide,
         isSkewJoin)
     }
@@ -542,14 +545,15 @@ object AuronConverters extends Logging {
         "rightKeys" -> rightKeys,
         "joinType" -> joinType,
         "condition" -> condition))
-    assert(condition.isEmpty, "join condition is not supported")
 
+    validateNativeInnerJoinCondition(joinType, condition)
     Shims.get.createNativeSortMergeJoinExec(
       addRenameColumnsExec(convertToNative(left)),
       addRenameColumnsExec(convertToNative(right)),
       leftKeys,
       rightKeys,
       joinType,
+      condition,
       isSkewJoin)
   }
 
@@ -566,13 +570,14 @@ object AuronConverters extends Logging {
         "condition" -> condition,
         "buildSide" -> buildSide))
     try {
-      assert(condition.isEmpty, "join condition is not supported")
+      validateNativeInnerJoinCondition(joinType, condition)
       Shims.get.createNativeShuffledHashJoinExec(
         addRenameColumnsExec(convertToNative(left)),
         addRenameColumnsExec(convertToNative(right)),
         leftKeys,
         rightKeys,
         joinType,
+        condition,
         buildSide,
         Shims.get.getIsSkewJoinFromSHJ(exec))
     } catch {
@@ -610,6 +615,26 @@ object AuronConverters extends Logging {
           SortMergeJoinExec(leftKeys, rightKeys, joinType, condition, leftSorted, rightSorted)
         smj.setTagValue(convertToNonNativeTag, true)
         smj
+    }
+  }
+
+  private def validateNativeInnerJoinCondition(
+      joinType: JoinType,
+      condition: Option[Expression]): Unit = {
+    condition.foreach { expr =>
+      assert(joinType.isInstanceOf[InnerLike], "join condition is not supported")
+      validateNativeInnerJoinConditionExpr(expr)
+    }
+  }
+
+  private def validateNativeInnerJoinConditionExpr(condition: Expression): Unit = {
+    Shims.get.shimVersion match {
+      case "spark-3.0" | "spark-3.1" =>
+        NativeConverters.convertExprWithFallback(
+          condition,
+          isPruningExpr = false,
+          expr => throw new NotImplementedError(s"unsupported join condition expression: $expr"))
+      case _ =>
     }
   }
 

--- a/spark-extension/src/main/scala/org/apache/spark/sql/auron/NativeConverters.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/auron/NativeConverters.scala
@@ -252,7 +252,7 @@ object NativeConverters extends Logging {
             .setIndex(rightOutput.indexWhere(_.exprId == attr.exprId))
             .build()
         case _ =>
-          columnIndices += pb.ColumnIndex.newBuilder().buildPartial()
+          throw new IllegalArgumentException(s"cannot resolve join filter attribute: $attr")
       }
     }
     pb.JoinFilter

--- a/spark-extension/src/main/scala/org/apache/spark/sql/auron/Shims.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/auron/Shims.scala
@@ -98,6 +98,7 @@ abstract class Shims {
       leftKeys: Seq[Expression],
       rightKeys: Seq[Expression],
       joinType: JoinType,
+      condition: Option[Expression],
       isSkewJoin: Boolean): NativeSortMergeJoinBase
 
   def createNativeShuffledHashJoinExec(
@@ -106,6 +107,7 @@ abstract class Shims {
       leftKeys: Seq[Expression],
       rightKeys: Seq[Expression],
       joinType: JoinType,
+      condition: Option[Expression],
       buildSide: JoinBuildSide,
       isSkewJoin: Boolean): SparkPlan
 

--- a/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeShuffledHashJoinBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeShuffledHashJoinBase.scala
@@ -26,6 +26,7 @@ import org.apache.spark.sql.auron.NativeRDD
 import org.apache.spark.sql.auron.NativeSupports
 import org.apache.spark.sql.auron.join.JoinBuildSides.{JoinBuildLeft, JoinBuildRight, JoinBuildSide}
 import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.catalyst.plans.InnerLike
 import org.apache.spark.sql.catalyst.plans.JoinType
 import org.apache.spark.sql.catalyst.plans.RightOuter
 import org.apache.spark.sql.execution.BinaryExecNode
@@ -41,6 +42,7 @@ abstract class NativeShuffledHashJoinBase(
     leftKeys: Seq[Expression],
     rightKeys: Seq[Expression],
     joinType: JoinType,
+    condition: Option[Expression],
     buildSide: JoinBuildSide)
     extends BinaryExecNode
     with NativeSupports {
@@ -79,6 +81,9 @@ abstract class NativeShuffledHashJoinBase(
 
   private def nativeJoinType = NativeConverters.convertJoinType(joinType)
 
+  private def nativeJoinFilter =
+    condition.map(NativeConverters.convertJoinFilter(_, left.output, right.output))
+
   private def nativeBuildSide = buildSide match {
     case JoinBuildLeft => pb.JoinSide.LEFT_SIDE
     case JoinBuildRight => pb.JoinSide.RIGHT_SIDE
@@ -89,6 +94,7 @@ abstract class NativeShuffledHashJoinBase(
   protected def rewriteKeyExprToLong(exprs: Seq[Expression]): Seq[Expression]
 
   // check whether native converting is supported
+  assert(condition.isEmpty || joinType.isInstanceOf[InnerLike], "join condition is not supported")
   nativeSchema
   nativeJoinOn
   nativeJoinType
@@ -100,6 +106,7 @@ abstract class NativeShuffledHashJoinBase(
     val nativeMetrics = SparkMetricNode(metrics, leftRDD.metrics :: rightRDD.metrics :: Nil)
     val nativeJoinOn = this.nativeJoinOn
     val nativeJoinType = this.nativeJoinType
+    val nativeJoinFilter = this.nativeJoinFilter
     val nativeBuildSide = this.nativeBuildSide
 
     val (partitions, partitioner) = if (joinType != RightOuter) {
@@ -131,6 +138,7 @@ abstract class NativeShuffledHashJoinBase(
           .setJoinType(nativeJoinType)
           .addAllOn(nativeJoinOn.asJava)
           .setBuildSide(nativeBuildSide)
+        nativeJoinFilter.foreach(hashJoinExec.setFilter)
         pb.PhysicalPlanNode.newBuilder().setHashJoin(hashJoinExec).build()
       },
       friendlyName = "NativeRDD.ShuffledHashJoin")

--- a/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeSortMergeJoinBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeSortMergeJoinBase.scala
@@ -48,7 +48,8 @@ abstract class NativeSortMergeJoinBase(
     override val right: SparkPlan,
     leftKeys: Seq[Expression],
     rightKeys: Seq[Expression],
-    joinType: JoinType)
+    joinType: JoinType,
+    condition: Option[Expression])
     extends BinaryExecNode
     with NativeSupports {
 
@@ -95,7 +96,11 @@ abstract class NativeSortMergeJoinBase(
 
   private def nativeJoinType = NativeConverters.convertJoinType(joinType)
 
+  private def nativeJoinFilter =
+    condition.map(NativeConverters.convertJoinFilter(_, left.output, right.output))
+
   // check whether native converting is supported
+  assert(condition.isEmpty || joinType.isInstanceOf[InnerLike], "join condition is not supported")
   nativeSchema
   nativeSortOptions
   nativeJoinOn
@@ -108,6 +113,7 @@ abstract class NativeSortMergeJoinBase(
     val nativeSortOptions = this.nativeSortOptions
     val nativeJoinOn = this.nativeJoinOn
     val nativeJoinType = this.nativeJoinType
+    val nativeJoinFilter = this.nativeJoinFilter
 
     val (partitions, partitioner) = if (joinType != RightOuter) {
       (leftRDD.partitions, leftRDD.partitioner)
@@ -150,6 +156,7 @@ abstract class NativeSortMergeJoinBase(
           .setJoinType(nativeJoinType)
           .addAllOn(nativeJoinOn.asJava)
           .addAllSortOptions(nativeSortOptions.asJava)
+        nativeJoinFilter.foreach(sortMergeJoinExec.setFilter)
         PhysicalPlanNode.newBuilder().setSortMergeJoin(sortMergeJoinExec).build()
       },
       friendlyName = "NativeRDD.SortMergeJoin")


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2193 

# Rationale for this change
Auron currently only converts SMJ/SHJ joins when the join condition is empty. As a result, inner joins that contain both equi-join keys and a residual predicate fall back to Spark even though the equi-join part is already native-compatible.

The native join plan only models equi-join keys today, so this change keeps the native join focused on the equi-join portion and evaluates the residual predicate with a native filter above the join output.

# What changes are included in this PR?

- Allow native conversion of SortMergeJoinExec and ShuffledHashJoinExec when an InnerLike join has a residual condition.
- Keep native join conversion based on equi-join keys only.
- Apply the residual predicate as a native filter on top of the native join output.
- Continue to reject residual join conditions for non-inner join types.
- Add query tests for:
    - native SMJ with an inner residual condition
    - native SHJ with an inner residual condition in force-SHJ mode
- Add a small test helper for Auron configs that are read from SparkEnv/SparkContext.

# Are there any user-facing changes?
Yes. Inner joins with equi-join keys plus a residual predicate can now remain on the native SMJ/SHJ path instead of falling back entirely to Spark.


# How was this patch tested?
CI.