### PR TITLE
[AURON #2180] Implement native support for nth_value window function

### DIFF
--- a/native-engine/auron-planner/proto/auron.proto
+++ b/native-engine/auron-planner/proto/auron.proto
@@ -130,6 +130,8 @@ enum WindowFunction {
   RANK = 1;
   DENSE_RANK = 2;
   LEAD = 3;
+  NTH_VALUE = 4;
+  NTH_VALUE_IGNORE_NULLS = 5;
 }
 
 enum AggFunction {

--- a/native-engine/auron-planner/src/planner.rs
+++ b/native-engine/auron-planner/src/planner.rs
@@ -637,6 +637,14 @@ impl PhysicalPlanner {
                                     WindowFunction::RankLike(WindowRankType::DenseRank)
                                 }
                                 protobuf::WindowFunction::Lead => WindowFunction::Lead,
+                                protobuf::WindowFunction::NthValue => {
+                                    WindowFunction::NthValue {
+                                        ignore_nulls: false,
+                                    }
+                                }
+                                protobuf::WindowFunction::NthValueIgnoreNulls => {
+                                    WindowFunction::NthValue { ignore_nulls: true }
+                                }
                             },
                             protobuf::WindowFunctionType::Agg => match w.agg_func() {
                                 protobuf::AggFunction::Min => WindowFunction::Agg(AggFunction::Min),

--- a/native-engine/datafusion-ext-plans/src/window/mod.rs
+++ b/native-engine/datafusion-ext-plans/src/window/mod.rs
@@ -24,7 +24,8 @@ use crate::{
     window::{
         processors::{
             agg_processor::AggProcessor, lead_processor::LeadProcessor,
-            rank_processor::RankProcessor, row_number_processor::RowNumberProcessor,
+            nth_value_processor::NthValueProcessor, rank_processor::RankProcessor,
+            row_number_processor::RowNumberProcessor,
         },
         window_context::WindowContext,
     },
@@ -36,6 +37,7 @@ pub mod window_context;
 #[derive(Debug, Clone, Copy)]
 pub enum WindowFunction {
     RankLike(WindowRankType),
+    NthValue { ignore_nulls: bool },
     Lead,
     Agg(AggFunction),
 }
@@ -89,6 +91,10 @@ impl WindowExpr {
                 Ok(Box::new(RankProcessor::new(true)))
             }
             WindowFunction::Lead => Ok(Box::new(LeadProcessor::new(self.children.clone()))),
+            WindowFunction::NthValue { ignore_nulls } => Ok(Box::new(NthValueProcessor::try_new(
+                self.children.clone(),
+                ignore_nulls,
+            )?)),
             WindowFunction::Agg(agg_func) => {
                 let agg = create_agg(
                     agg_func.clone(),

--- a/native-engine/datafusion-ext-plans/src/window/processors/mod.rs
+++ b/native-engine/datafusion-ext-plans/src/window/processors/mod.rs
@@ -15,5 +15,6 @@
 
 pub mod agg_processor;
 pub mod lead_processor;
+pub mod nth_value_processor;
 pub mod rank_processor;
 pub mod row_number_processor;

--- a/native-engine/datafusion-ext-plans/src/window/processors/nth_value_processor.rs
+++ b/native-engine/datafusion-ext-plans/src/window/processors/nth_value_processor.rs
@@ -1,0 +1,120 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use arrow::{array::ArrayRef, record_batch::RecordBatch};
+use datafusion::{
+    common::{DataFusionError, Result, ScalarValue},
+    physical_expr::{PhysicalExprRef, expressions::Literal},
+};
+
+use crate::window::{WindowFunctionProcessor, window_context::WindowContext};
+
+pub struct NthValueProcessor {
+    input: PhysicalExprRef,
+    offset: usize,
+    ignore_nulls: bool,
+    cur_partition: Box<[u8]>,
+    observed_rows: usize,
+    nth_value: Option<ScalarValue>,
+}
+
+impl NthValueProcessor {
+    pub fn try_new(children: Vec<PhysicalExprRef>, ignore_nulls: bool) -> Result<Self> {
+        if children.len() != 2 {
+            return Err(DataFusionError::Execution(format!(
+                "nth_value expects input/offset children, got {}",
+                children.len(),
+            )));
+        }
+
+        let offset_literal = children[1]
+            .as_any()
+            .downcast_ref::<Literal>()
+            .ok_or_else(|| {
+                DataFusionError::Execution(
+                    "nth_value offset must be a literal physical expression; \
+                     foldable offsets should be constant-folded before building the native plan"
+                        .to_string(),
+                )
+            })?;
+
+        let offset = match offset_literal.value() {
+            ScalarValue::Int32(Some(value)) if *value > 0 => *value as usize,
+            ScalarValue::Int64(Some(value)) if *value > 0 => *value as usize,
+            ScalarValue::UInt32(Some(value)) if *value > 0 => *value as usize,
+            ScalarValue::UInt64(Some(value)) if *value > 0 => *value as usize,
+            other => {
+                return Err(DataFusionError::Execution(format!(
+                    "nth_value offset must be a positive non-null integer literal, got {other:?}",
+                )));
+            }
+        };
+
+        Ok(Self {
+            input: children[0].clone(),
+            offset,
+            ignore_nulls,
+            cur_partition: Box::default(),
+            observed_rows: 0,
+            nth_value: None,
+        })
+    }
+}
+
+impl WindowFunctionProcessor for NthValueProcessor {
+    fn process_batch(&mut self, context: &WindowContext, batch: &RecordBatch) -> Result<ArrayRef> {
+        let partition_rows = context.get_partition_rows(batch)?;
+        let input_values = self
+            .input
+            .evaluate(batch)
+            .and_then(|value| value.into_array(batch.num_rows()))?;
+        let null_value = ScalarValue::try_from(input_values.data_type().clone())?;
+        let mut output = Vec::with_capacity(batch.num_rows());
+
+        for row_idx in 0..batch.num_rows() {
+            let same_partition = !context.has_partition() || {
+                let partition_row = partition_rows.row(row_idx);
+                if partition_row.as_ref() != self.cur_partition.as_ref() {
+                    self.cur_partition = partition_row.as_ref().into();
+                    false
+                } else {
+                    true
+                }
+            };
+
+            if !same_partition {
+                self.observed_rows = 0;
+                self.nth_value = None;
+            }
+
+            if self.nth_value.is_none() {
+                let value = ScalarValue::try_from_array(&input_values, row_idx)?;
+                let counts_for_offset = !self.ignore_nulls || !value.is_null();
+                if counts_for_offset {
+                    self.observed_rows += 1;
+                    if self.observed_rows == self.offset {
+                        self.nth_value = Some(value);
+                    }
+                }
+            }
+
+            output.push(self.nth_value.clone().unwrap_or_else(|| null_value.clone()));
+        }
+
+        ScalarValue::iter_to_array(output)
+    }
+}

--- a/native-engine/datafusion-ext-plans/src/window_exec.rs
+++ b/native-engine/datafusion-ext-plans/src/window_exec.rs
@@ -302,14 +302,13 @@ mod test {
     use arrow::{array::*, datatypes::*, record_batch::RecordBatch};
     use datafusion::{
         assert_batches_eq,
-        common::Result,
+        common::{Result, ScalarValue},
         physical_expr::{
             PhysicalSortExpr,
             expressions::{Column, Literal},
         },
         physical_plan::{ExecutionPlan, test::TestMemoryExec},
         prelude::SessionContext,
-        scalar::ScalarValue,
     };
 
     use crate::{
@@ -346,6 +345,33 @@ mod test {
         c: (&str, &Vec<i32>),
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let batch = build_table_i32(a, b, c)?;
+        let schema = batch.schema();
+        Ok(Arc::new(TestMemoryExec::try_new(
+            &[vec![batch]],
+            schema,
+            None,
+        )?))
+    }
+
+    fn build_nullable_utf8_table(
+        a: (&str, &Vec<i32>),
+        b: (&str, &Vec<i32>),
+        c: (&str, &Vec<Option<&str>>),
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let schema = Schema::new(vec![
+            Field::new(a.0, DataType::Int32, false),
+            Field::new(b.0, DataType::Int32, false),
+            Field::new(c.0, DataType::Utf8, true),
+        ]);
+
+        let batch = RecordBatch::try_new(
+            Arc::new(schema),
+            vec![
+                Arc::new(Int32Array::from(a.1.clone())),
+                Arc::new(Int32Array::from(b.1.clone())),
+                Arc::new(StringArray::from(c.1.clone())),
+            ],
+        )?;
         let schema = batch.schema();
         Ok(Arc::new(TestMemoryExec::try_new(
             &[vec![batch]],
@@ -476,6 +502,66 @@ mod test {
             "| 1  | 3  | 0  | 6             | 6       | 3             | 10     |",
             "| 2  | 4  | 0  | 7             | 7       | 4             | 14     |",
             "+----+----+----+---------------+---------+---------------+--------+",
+        ];
+        assert_batches_eq!(expected, &batches);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_nth_value_window() -> Result<(), Box<dyn std::error::Error>> {
+        let session_ctx = SessionContext::new();
+        let task_ctx = session_ctx.task_ctx();
+
+        let input = build_nullable_utf8_table(
+            ("grp", &vec![1, 1, 1, 2, 2]),
+            ("id", &vec![1, 2, 3, 1, 2]),
+            ("v", &vec![None, Some("b"), Some("c"), Some("x"), None]),
+        )?;
+        let window_exprs = vec![
+            WindowExpr::new(
+                WindowFunction::NthValue {
+                    ignore_nulls: false,
+                },
+                vec![
+                    Arc::new(Column::new("v", 2)),
+                    Arc::new(Literal::new(ScalarValue::Int32(Some(2)))),
+                ],
+                Arc::new(Field::new("nth_value_all", DataType::Utf8, true)),
+                DataType::Utf8,
+            ),
+            WindowExpr::new(
+                WindowFunction::NthValue { ignore_nulls: true },
+                vec![
+                    Arc::new(Column::new("v", 2)),
+                    Arc::new(Literal::new(ScalarValue::Int32(Some(2)))),
+                ],
+                Arc::new(Field::new("nth_value_ignore_nulls", DataType::Utf8, true)),
+                DataType::Utf8,
+            ),
+        ];
+        let window = Arc::new(WindowExec::try_new(
+            input,
+            window_exprs,
+            vec![Arc::new(Column::new("grp", 0))],
+            vec![PhysicalSortExpr {
+                expr: Arc::new(Column::new("id", 1)),
+                options: Default::default(),
+            }],
+            None,
+            true,
+        )?);
+        let stream = window.execute(0, task_ctx)?;
+        let batches = datafusion::physical_plan::common::collect(stream).await?;
+        let expected = vec![
+            "+-----+----+---+---------------+------------------------+",
+            "| grp | id | v | nth_value_all | nth_value_ignore_nulls |",
+            "+-----+----+---+---------------+------------------------+",
+            "| 1   | 1  |   |               |                        |",
+            "| 1   | 2  | b | b             |                        |",
+            "| 1   | 3  | c | b             | c                      |",
+            "| 2   | 1  | x |               |                        |",
+            "| 2   | 2  |   |               |                        |",
+            "+-----+----+---+---------------+------------------------+",
         ];
         assert_batches_eq!(expected, &batches);
         Ok(())

--- a/spark-extension-shims-spark/src/test/scala/org/apache/auron/AuronQuerySuite.scala
+++ b/spark-extension-shims-spark/src/test/scala/org/apache/auron/AuronQuerySuite.scala
@@ -574,6 +574,58 @@ class AuronQuerySuite extends AuronQueryTest with BaseAuronSQLSuite with AuronSQ
     }
   }
 
+  test("nth_value window with row frame") {
+    if (AuronTestUtils.isSparkV31OrGreater) {
+      withTable("t_nth_value") {
+        sql("""
+              |create table t_nth_value using parquet as
+              |select * from values
+              |  (1, 1, cast(null as string)),
+              |  (1, 2, 'b'),
+              |  (1, 3, 'c'),
+              |  (2, 1, 'x'),
+              |  (2, 2, cast(null as string))
+              |as t(grp, id, v)
+              |""".stripMargin)
+
+        if (AuronTestUtils.isSparkV32OrGreater) {
+          checkSparkAnswerAndOperator("""
+                |select
+                |  grp,
+                |  id,
+                |  v,
+                |  nth_value(v, 2) over (
+                |    partition by grp
+                |    order by id
+                |    rows between unbounded preceding and current row
+                |  ) as nth_value_all,
+                |  nth_value(v, 2) ignore nulls over (
+                |    partition by grp
+                |    order by id
+                |    rows between unbounded preceding and current row
+                |  ) as nth_value_ignore_nulls
+                |from t_nth_value
+                |order by grp, id
+                |""".stripMargin)
+        } else {
+          checkSparkAnswerAndOperator("""
+                |select
+                |  grp,
+                |  id,
+                |  v,
+                |  nth_value(v, 2) over (
+                |    partition by grp
+                |    order by id
+                |    rows between unbounded preceding and current row
+                |  ) as nth_value_all
+                |from t_nth_value
+                |order by grp, id
+                |""".stripMargin)
+        }
+      }
+    }
+  }
+
   test("standard LEFT ANTI JOIN includes NULL keys") {
     // This test verifies that standard LEFT ANTI JOIN correctly includes NULL keys
     // NULL keys should be in the result because NULL never matches anything

--- a/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeWindowBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeWindowBase.scala
@@ -29,6 +29,7 @@ import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.expressions.DenseRank
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.expressions.Lead
+import org.apache.spark.sql.catalyst.expressions.Literal
 import org.apache.spark.sql.catalyst.expressions.NamedExpression
 import org.apache.spark.sql.catalyst.expressions.NullsFirst
 import org.apache.spark.sql.catalyst.expressions.Rank
@@ -95,6 +96,31 @@ abstract class NativeWindowBase(
       .find(method => method.getName == "ignoreNulls" && method.getParameterCount == 0)
       .exists(method => method.invoke(expr).asInstanceOf[Boolean])
 
+  private def invokeNoArg[T](expr: Expression, methodName: String): T =
+    expr.getClass.getMethod(methodName).invoke(expr).asInstanceOf[T]
+
+  private def isNthValue(expr: Expression): Boolean = expr.getClass.getSimpleName == "NthValue"
+
+  private def nthValueInput(expr: Expression): Expression = invokeNoArg[Expression](expr, "input")
+
+  private def nthValueOffset(expr: Expression): Expression =
+    invokeNoArg[Expression](expr, "offset")
+
+  private def nthValueIgnoreNulls(expr: Expression): Boolean =
+    invokeNoArg[Boolean](expr, "ignoreNulls")
+
+  private def nthValueOffsetLiteral(expr: Expression): Literal = {
+    val offset = nthValueOffset(expr)
+    offset match {
+      case literal: Literal => literal
+      case foldable if foldable.foldable =>
+        Literal.create(foldable.eval(), foldable.dataType)
+      case other =>
+        throw new NotImplementedError(
+          s"window function not supported: nth_value offset must be foldable, got: $other")
+    }
+  }
+
   private def nativeWindowExprs = windowExpression.map { named =>
     val field = NativeConverters.convertField(Util.getSchema(named :: Nil).fields(0))
     val windowExprBuilder = pb.WindowExprNode.newBuilder().setField(field)
@@ -123,6 +149,22 @@ abstract class NativeWindowBase(
               s"window frame not supported: ${spec.frameSpecification}")
             windowExprBuilder.setFuncType(pb.WindowFunctionType.Window)
             windowExprBuilder.setWindowFunc(pb.WindowFunction.DENSE_RANK)
+
+          case e if isNthValue(e) =>
+            assert(
+              // Spark defaults ordered nth_value() to a RANGE frame. The current native executor
+              // only supports cumulative ROW frames, so keep the conversion scoped to the
+              // explicit ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW case.
+              spec.frameSpecification == RowNumber().frame, // only supports RowFrame(Unbounded, CurrentRow)
+              s"window frame not supported: ${spec.frameSpecification}")
+            windowExprBuilder.setFuncType(pb.WindowFunctionType.Window)
+            windowExprBuilder.setWindowFunc(if (nthValueIgnoreNulls(e)) {
+              pb.WindowFunction.NTH_VALUE_IGNORE_NULLS
+            } else {
+              pb.WindowFunction.NTH_VALUE
+            })
+            windowExprBuilder.addChildren(NativeConverters.convertExpr(nthValueInput(e)))
+            windowExprBuilder.addChildren(NativeConverters.convertExpr(nthValueOffsetLiteral(e)))
 
           case e: Lead =>
             assert(


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2180 

# Rationale for this change
Auron did not previously support native execution for Spark nth_value window function, so queries using nth_value would fall back to Spark execution.

Spark defines nth_value(input, offset) as returning the value at the offsetth row from the beginning of the current window frame, with offset starting from 1. When IGNORE NULLS is specified, null input rows should be skipped when counting toward the target position. To improve Spark compatibility, Auron needs native support for both the regular and IGNORE NULLS variants.

The current native window executor only supports cumulative row-frame semantics, so this change scopes native conversion to the frame that is already supported correctly:
ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW.

# What changes are included in this PR?

This PR adds end-to-end native support for nth_value window function across the Spark frontend, planner, and native engine.

The changes include:
- adding new protobuf/planner window function variants for NTH_VALUE and NTH_VALUE_IGNORE_NULLS
- extending Spark-side window conversion in NativeWindowBase to recognize Spark NthValue
- using reflection to access NthValue fields so the code remains compatible with Spark 3.0, where this expression class is not available
- adding a native Rust processor to evaluate nth_value
- implementing both standard counting semantics and IGNORE NULLS semantics
- restricting native conversion to the supported cumulative row frame
- adding Rust-side execution tests
- adding Scala integration tests to verify result correctness and native operator conversion

# Are there any user-facing changes?
Yes.
Queries using nth_value can now be executed natively when they use the supported frame:
ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW.

Both of the following forms are supported:
- nth_value(input, offset)
- nth_value(input, offset) IGNORE NULLS

Queries using unsupported window frames will continue to fall back to Spark execution.

# How was this patch tested?
CI.