### PR TITLE
[AURON #2182] Implement native support for percent_rank window function

### DIFF
--- a/native-engine/auron-planner/proto/auron.proto
+++ b/native-engine/auron-planner/proto/auron.proto
@@ -132,6 +132,7 @@ enum WindowFunction {
   LEAD = 3;
   NTH_VALUE = 4;
   NTH_VALUE_IGNORE_NULLS = 5;
+  PERCENT_RANK = 6;
 }
 
 enum AggFunction {

--- a/native-engine/auron-planner/src/planner.rs
+++ b/native-engine/auron-planner/src/planner.rs
@@ -645,6 +645,9 @@ impl PhysicalPlanner {
                                 protobuf::WindowFunction::NthValueIgnoreNulls => {
                                     WindowFunction::NthValue { ignore_nulls: true }
                                 }
+                                protobuf::WindowFunction::PercentRank => {
+                                    WindowFunction::PercentRank
+                                }
                             },
                             protobuf::WindowFunctionType::Agg => match w.agg_func() {
                                 protobuf::AggFunction::Min => WindowFunction::Agg(AggFunction::Min),

--- a/native-engine/datafusion-ext-plans/src/window/mod.rs
+++ b/native-engine/datafusion-ext-plans/src/window/mod.rs
@@ -24,8 +24,8 @@ use crate::{
     window::{
         processors::{
             agg_processor::AggProcessor, lead_processor::LeadProcessor,
-            nth_value_processor::NthValueProcessor, rank_processor::RankProcessor,
-            row_number_processor::RowNumberProcessor,
+            nth_value_processor::NthValueProcessor, percent_rank_processor::PercentRankProcessor,
+            rank_processor::RankProcessor, row_number_processor::RowNumberProcessor,
         },
         window_context::WindowContext,
     },
@@ -37,6 +37,7 @@ pub mod window_context;
 #[derive(Debug, Clone, Copy)]
 pub enum WindowFunction {
     RankLike(WindowRankType),
+    PercentRank,
     NthValue { ignore_nulls: bool },
     Lead,
     Agg(AggFunction),
@@ -90,6 +91,7 @@ impl WindowExpr {
             WindowFunction::RankLike(WindowRankType::DenseRank) => {
                 Ok(Box::new(RankProcessor::new(true)))
             }
+            WindowFunction::PercentRank => Ok(Box::new(PercentRankProcessor::new())),
             WindowFunction::Lead => Ok(Box::new(LeadProcessor::new(self.children.clone()))),
             WindowFunction::NthValue { ignore_nulls } => Ok(Box::new(NthValueProcessor::try_new(
                 self.children.clone(),
@@ -108,6 +110,9 @@ impl WindowExpr {
     }
 
     pub fn requires_full_partition(&self) -> bool {
-        matches!(self.func, WindowFunction::Lead)
+        matches!(
+            self.func,
+            WindowFunction::PercentRank | WindowFunction::Lead
+        )
     }
 }

--- a/native-engine/datafusion-ext-plans/src/window/processors/mod.rs
+++ b/native-engine/datafusion-ext-plans/src/window/processors/mod.rs
@@ -16,5 +16,6 @@
 pub mod agg_processor;
 pub mod lead_processor;
 pub mod nth_value_processor;
+pub mod percent_rank_processor;
 pub mod rank_processor;
 pub mod row_number_processor;

--- a/native-engine/datafusion-ext-plans/src/window/processors/percent_rank_processor.rs
+++ b/native-engine/datafusion-ext-plans/src/window/processors/percent_rank_processor.rs
@@ -1,0 +1,86 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use arrow::{
+    array::{ArrayRef, Float64Builder},
+    record_batch::RecordBatch,
+};
+use datafusion::common::Result;
+
+use crate::window::{WindowFunctionProcessor, window_context::WindowContext};
+
+pub struct PercentRankProcessor;
+
+impl PercentRankProcessor {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for PercentRankProcessor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl WindowFunctionProcessor for PercentRankProcessor {
+    fn process_batch(&mut self, context: &WindowContext, batch: &RecordBatch) -> Result<ArrayRef> {
+        let partition_rows = context.get_partition_rows(batch)?;
+        let order_rows = context.get_order_rows(batch)?;
+        let mut builder = Float64Builder::with_capacity(batch.num_rows());
+
+        let mut row_idx = 0usize;
+        while row_idx < batch.num_rows() {
+            let partition_start = row_idx;
+            row_idx += 1;
+            while row_idx < batch.num_rows()
+                && (!context.has_partition()
+                    || partition_rows.row(row_idx).as_ref()
+                        == partition_rows.row(partition_start).as_ref())
+            {
+                row_idx += 1;
+            }
+
+            let partition_end = row_idx;
+            let partition_size = partition_end - partition_start;
+            let denominator = (partition_size.saturating_sub(1)) as f64;
+
+            let mut rank = 1usize;
+            let mut peer_group_size = 1usize;
+            for current_idx in partition_start..partition_end {
+                if current_idx > partition_start {
+                    let prev_idx = current_idx - 1;
+                    if order_rows.row(current_idx).as_ref() == order_rows.row(prev_idx).as_ref() {
+                        peer_group_size += 1;
+                    } else {
+                        rank += peer_group_size;
+                        peer_group_size = 1;
+                    }
+                }
+
+                let percent_rank = if partition_size <= 1 {
+                    0.0
+                } else {
+                    (rank - 1) as f64 / denominator
+                };
+                builder.append_value(percent_rank);
+            }
+        }
+
+        Ok(Arc::new(builder.finish()))
+    }
+}

--- a/native-engine/datafusion-ext-plans/src/window_exec.rs
+++ b/native-engine/datafusion-ext-plans/src/window_exec.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{any::Any, fmt::Formatter, sync::Arc};
+use std::{any::Any, fmt::Formatter, mem, sync::Arc};
 
 use arrow::{
     array::{Array, ArrayRef, Int32Array},
@@ -29,7 +29,7 @@ use datafusion::{
         DisplayAs, DisplayFormatType, ExecutionPlan, ExecutionPlanProperties, PlanProperties,
         SendableRecordBatchStream,
         execution_plan::{Boundedness, EmissionType},
-        metrics::{ExecutionPlanMetricsSet, MetricsSet},
+        metrics::{ExecutionPlanMetricsSet, MetricsSet, Time},
     },
 };
 use datafusion_ext_commons::{arrow::cast::cast, downcast_any};
@@ -37,7 +37,7 @@ use futures::StreamExt;
 use once_cell::sync::OnceCell;
 
 use crate::{
-    common::execution_context::ExecutionContext,
+    common::execution_context::{ExecutionContext, WrappedRecordBatchSender},
     window::{WindowExpr, WindowFunctionProcessor, window_context::WindowContext},
 };
 
@@ -220,21 +220,73 @@ fn execute_window(
                 .collect::<Result<Vec<_>>>()?;
 
             if window_ctx.requires_full_partition() {
-                let mut staging_batches = vec![];
-                while let Some(batch) = input.next().await.transpose()? {
-                    staging_batches.push(batch);
+                // Functions like percent_rank/lead need a complete window partition,
+                // but can still stream partition-by-partition when partition_spec exists.
+                if !window_ctx.has_partition() {
+                    let mut staging_batches = vec![];
+                    while let Some(batch) = input.next().await.transpose()? {
+                        staging_batches.push(batch);
+                    }
+
+                    flush_window_batches(
+                        &mut staging_batches,
+                        &window_ctx,
+                        &exec_ctx,
+                        &elapsed_compute,
+                        processors.as_mut_slice(),
+                        &sender,
+                    )
+                    .await?;
+                    return Ok(());
                 }
 
-                if !staging_batches.is_empty() {
-                    let _timer = elapsed_compute.timer();
-                    let batch = concat_batches(&window_ctx.input_schema, &staging_batches)?;
-                    let output_batch =
-                        process_window_batch(batch, &window_ctx, processors.as_mut_slice())?;
-                    exec_ctx
-                        .baseline_metrics()
-                        .record_output(output_batch.num_rows());
-                    sender.send(output_batch).await;
+                let mut staging_batches = vec![];
+                let mut current_partition: Option<Box<[u8]>> = None;
+                while let Some(batch) = input.next().await.transpose()? {
+                    if batch.num_rows() == 0 {
+                        continue;
+                    }
+
+                    let partition_rows = window_ctx.get_partition_rows(&batch)?;
+                    let mut partition_start = 0usize;
+                    while partition_start < batch.num_rows() {
+                        let partition_key: Box<[u8]> =
+                            partition_rows.row(partition_start).as_ref().into();
+                        let mut partition_end = partition_start + 1;
+                        while partition_end < batch.num_rows()
+                            && partition_rows.row(partition_end).as_ref() == partition_key.as_ref()
+                        {
+                            partition_end += 1;
+                        }
+
+                        if current_partition.as_deref() != Some(partition_key.as_ref()) {
+                            flush_window_batches(
+                                &mut staging_batches,
+                                &window_ctx,
+                                &exec_ctx,
+                                &elapsed_compute,
+                                processors.as_mut_slice(),
+                                &sender,
+                            )
+                            .await?;
+                            current_partition = Some(partition_key);
+                        }
+
+                        staging_batches
+                            .push(batch.slice(partition_start, partition_end - partition_start));
+                        partition_start = partition_end;
+                    }
                 }
+
+                flush_window_batches(
+                    &mut staging_batches,
+                    &window_ctx,
+                    &exec_ctx,
+                    &elapsed_compute,
+                    processors.as_mut_slice(),
+                    &sender,
+                )
+                .await?;
                 return Ok(());
             }
 
@@ -249,6 +301,29 @@ fn execute_window(
             }
             Ok(())
         }))
+}
+
+async fn flush_window_batches(
+    staging_batches: &mut Vec<RecordBatch>,
+    window_ctx: &WindowContext,
+    exec_ctx: &ExecutionContext,
+    elapsed_compute: &Time,
+    processors: &mut [Box<dyn WindowFunctionProcessor>],
+    sender: &Arc<WrappedRecordBatchSender>,
+) -> Result<()> {
+    if staging_batches.is_empty() {
+        return Ok(());
+    }
+
+    let _timer = elapsed_compute.timer();
+    let input_batches = mem::take(staging_batches);
+    let batch = concat_batches(&window_ctx.input_schema, &input_batches)?;
+    let output_batch = process_window_batch(batch, window_ctx, processors)?;
+    exec_ctx
+        .baseline_metrics()
+        .record_output(output_batch.num_rows());
+    sender.send(output_batch).await;
+    Ok(())
 }
 
 fn process_window_batch(
@@ -562,6 +637,107 @@ mod test {
             "| 2   | 1  | x |               |                        |",
             "| 2   | 2  |   |               |                        |",
             "+-----+----+---+---------------+------------------------+",
+        ];
+        assert_batches_eq!(expected, &batches);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_percent_rank_window() -> Result<(), Box<dyn std::error::Error>> {
+        let session_ctx = SessionContext::new();
+        let task_ctx = session_ctx.task_ctx();
+
+        let input = build_table(
+            ("grp", &vec![1, 1, 1, 2]),
+            ("id", &vec![1, 1, 2, 5]),
+            ("v", &vec![10, 20, 30, 40]),
+        )?;
+        let window_exprs = vec![WindowExpr::new(
+            WindowFunction::PercentRank,
+            vec![],
+            Arc::new(Field::new("percent_rank", DataType::Float64, false)),
+            DataType::Float64,
+        )];
+        let window = Arc::new(WindowExec::try_new(
+            input,
+            window_exprs,
+            vec![Arc::new(Column::new("grp", 0))],
+            vec![PhysicalSortExpr {
+                expr: Arc::new(Column::new("id", 1)),
+                options: Default::default(),
+            }],
+            None,
+            true,
+        )?);
+        let stream = window.execute(0, task_ctx)?;
+        let batches = datafusion::physical_plan::common::collect(stream).await?;
+        let expected = vec![
+            "+-----+----+----+--------------+",
+            "| grp | id | v  | percent_rank |",
+            "+-----+----+----+--------------+",
+            "| 1   | 1  | 10 | 0.0          |",
+            "| 1   | 1  | 20 | 0.0          |",
+            "| 1   | 2  | 30 | 1.0          |",
+            "| 2   | 5  | 40 | 0.0          |",
+            "+-----+----+----+--------------+",
+        ];
+        assert_batches_eq!(expected, &batches);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_percent_rank_window_across_batches() -> Result<(), Box<dyn std::error::Error>> {
+        let session_ctx = SessionContext::new();
+        let task_ctx = session_ctx.task_ctx();
+
+        let batch1 = build_table_i32(
+            ("grp", &vec![1, 1]),
+            ("id", &vec![1, 2]),
+            ("v", &vec![10, 20]),
+        )?;
+        let batch2 = build_table_i32(
+            ("grp", &vec![1, 1, 1, 2]),
+            ("id", &vec![3, 4, 5, 1]),
+            ("v", &vec![30, 40, 50, 60]),
+        )?;
+        let schema = batch1.schema();
+        let input = Arc::new(TestMemoryExec::try_new(
+            &[vec![batch1, batch2]],
+            schema,
+            None,
+        )?);
+
+        let window_exprs = vec![WindowExpr::new(
+            WindowFunction::PercentRank,
+            vec![],
+            Arc::new(Field::new("percent_rank", DataType::Float64, false)),
+            DataType::Float64,
+        )];
+        let window = Arc::new(WindowExec::try_new(
+            input,
+            window_exprs,
+            vec![Arc::new(Column::new("grp", 0))],
+            vec![PhysicalSortExpr {
+                expr: Arc::new(Column::new("id", 1)),
+                options: Default::default(),
+            }],
+            None,
+            true,
+        )?);
+
+        let stream = window.execute(0, task_ctx)?;
+        let batches = datafusion::physical_plan::common::collect(stream).await?;
+        let expected = vec![
+            "+-----+----+----+--------------+",
+            "| grp | id | v  | percent_rank |",
+            "+-----+----+----+--------------+",
+            "| 1   | 1  | 10 | 0.0          |",
+            "| 1   | 2  | 20 | 0.25         |",
+            "| 1   | 3  | 30 | 0.5          |",
+            "| 1   | 4  | 40 | 0.75         |",
+            "| 1   | 5  | 50 | 1.0          |",
+            "| 2   | 1  | 60 | 0.0          |",
+            "+-----+----+----+--------------+",
         ];
         assert_batches_eq!(expected, &batches);
         Ok(())

--- a/spark-extension-shims-spark/src/test/scala/org/apache/auron/AuronQuerySuite.scala
+++ b/spark-extension-shims-spark/src/test/scala/org/apache/auron/AuronQuerySuite.scala
@@ -626,6 +626,32 @@ class AuronQuerySuite extends AuronQueryTest with BaseAuronSQLSuite with AuronSQ
     }
   }
 
+  test("percent_rank window function") {
+    withTable("t_percent_rank") {
+      sql("""
+            |create table t_percent_rank using parquet as
+            |select * from values
+            |  (1, 1, 10),
+            |  (1, 1, 20),
+            |  (1, 2, 30),
+            |  (2, 5, 40)
+            |as t(grp, id, v)
+            |""".stripMargin)
+
+      checkSparkAnswerAndOperator("""
+            |select
+            |  grp,
+            |  id,
+            |  v,
+            |  percent_rank() over (
+            |    partition by grp
+            |    order by id
+            |  ) as percent_rank_v
+            |from t_percent_rank
+            |order by grp, id, v
+            |""".stripMargin)
+    }
+  }
   test("standard LEFT ANTI JOIN includes NULL keys") {
     // This test verifies that standard LEFT ANTI JOIN correctly includes NULL keys
     // NULL keys should be in the result because NULL never matches anything

--- a/spark-extension-shims-spark/src/test/scala/org/apache/auron/exec/AuronExecSuite.scala
+++ b/spark-extension-shims-spark/src/test/scala/org/apache/auron/exec/AuronExecSuite.scala
@@ -17,7 +17,13 @@
 package org.apache.auron.exec
 
 import org.apache.spark.sql.AuronQueryTest
+import org.apache.spark.sql.catalyst.expressions.Alias
+import org.apache.spark.sql.catalyst.expressions.PercentRank
+import org.apache.spark.sql.catalyst.expressions.SortOrder
+import org.apache.spark.sql.catalyst.expressions.WindowExpression
+import org.apache.spark.sql.catalyst.expressions.WindowSpecDefinition
 import org.apache.spark.sql.execution.auron.plan.{NativeCollectLimitExec, NativeGlobalLimitExec, NativeLocalLimitExec, NativeTakeOrderedExec}
+import org.apache.spark.sql.execution.auron.plan.NativeWindowExec
 
 import org.apache.auron.BaseAuronSQLSuite
 import org.apache.auron.util.AuronTestUtils
@@ -126,5 +132,21 @@ class AuronExecSuite extends AuronQueryTest with BaseAuronSQLSuite {
         }
       }
     }
+  }
+
+  test("NativeWindowExec percent_rank requires ORDER BY") {
+    val child = spark.range(1).queryExecution.executedPlan
+    val percentRank = PercentRank(Seq.empty)
+    val windowExpr = Alias(
+      WindowExpression(
+        percentRank,
+        WindowSpecDefinition(Seq.empty, Seq.empty[SortOrder], percentRank.frame)),
+      "percent_rank_without_order")()
+
+    val err = intercept[AssertionError] {
+      NativeWindowExec(Seq(windowExpr), Seq.empty, Seq.empty, None, child)
+    }
+
+    assert(err.getMessage.contains("percent_rank requires ORDER BY"))
   }
 }

--- a/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeWindowBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeWindowBase.scala
@@ -32,6 +32,7 @@ import org.apache.spark.sql.catalyst.expressions.Lead
 import org.apache.spark.sql.catalyst.expressions.Literal
 import org.apache.spark.sql.catalyst.expressions.NamedExpression
 import org.apache.spark.sql.catalyst.expressions.NullsFirst
+import org.apache.spark.sql.catalyst.expressions.PercentRank
 import org.apache.spark.sql.catalyst.expressions.Rank
 import org.apache.spark.sql.catalyst.expressions.RowNumber
 import org.apache.spark.sql.catalyst.expressions.SortOrder
@@ -150,6 +151,15 @@ abstract class NativeWindowBase(
             windowExprBuilder.setFuncType(pb.WindowFunctionType.Window)
             windowExprBuilder.setWindowFunc(pb.WindowFunction.DENSE_RANK)
 
+          case e: PercentRank =>
+            assert(
+              spec.frameSpecification == e.frame,
+              s"window frame not supported: ${spec.frameSpecification}")
+            assert(
+              spec.orderSpec.nonEmpty,
+              "window function not supported: percent_rank requires ORDER BY")
+            windowExprBuilder.setFuncType(pb.WindowFunctionType.Window)
+            windowExprBuilder.setWindowFunc(pb.WindowFunction.PERCENT_RANK)
           case e if isNthValue(e) =>
             assert(
               // Spark defaults ordered nth_value() to a RANGE frame. The current native executor


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2182

# Rationale for this change
Auron does not currently support `percent_rank()` in native window execution, so queries using this function fall back to Spark. This leaves a gap in native window function coverage.

`percent_rank()` cannot be implemented with the existing streaming-style window processors alone, because its result depends on both the row rank and the total number of rows in the partition. To match Spark semantics, the native engine needs to evaluate it with full-partition context.

# What changes are included in this PR?
This PR adds native support for `percent_rank()` window function end to end.
The main changes are:
- Add `PERCENT_RANK` to the window function protobuf and planner conversion path so Spark plans can be serialized into native plans correctly.
- Extend `NativeWindowBase` to recognize Spark's `PercentRank` expression and convert it to the native window function enum.
- Introduce a native `PercentRankProcessor` that computes percent rank with Spark-compatible semantics:
  - rows in the same peer group share the same rank
  - the result is `(rank - 1) / (partition_size - 1)`
  - single-row partitions return `0.0`
- Add a full-partition execution path in native window execution for functions that require complete partition context, and use that path for `percent_rank()`.
- Add tests on both the native execution side and the Spark SQL side to verify correctness.


# Are there any user-facing changes?
Yes.

Queries using `percent_rank()` window function can now stay on the native execution path instead of falling back to Spark, as long as the rest of the plan is supported by Auron. No user-facing configuration changes are introduced.


# How was this patch tested?
CI.