### PR TITLE
[AURON #2181] Implement native support for cume_dist window function

### DIFF
--- a/native-engine/auron-planner/proto/auron.proto
+++ b/native-engine/auron-planner/proto/auron.proto
@@ -133,6 +133,7 @@ enum WindowFunction {
   NTH_VALUE = 4;
   NTH_VALUE_IGNORE_NULLS = 5;
   PERCENT_RANK = 6;
+  CUME_DIST = 7;
 }
 
 enum AggFunction {

--- a/native-engine/auron-planner/src/planner.rs
+++ b/native-engine/auron-planner/src/planner.rs
@@ -648,6 +648,9 @@ impl PhysicalPlanner {
                                 protobuf::WindowFunction::PercentRank => {
                                     WindowFunction::PercentRank
                                 }
+                                protobuf::WindowFunction::CumeDist => {
+                                    WindowFunction::CumeDist
+                                }
                             },
                             protobuf::WindowFunctionType::Agg => match w.agg_func() {
                                 protobuf::AggFunction::Min => WindowFunction::Agg(AggFunction::Min),

--- a/native-engine/datafusion-ext-plans/src/window/mod.rs
+++ b/native-engine/datafusion-ext-plans/src/window/mod.rs
@@ -23,9 +23,10 @@ use crate::{
     agg::{AggFunction, agg::create_agg},
     window::{
         processors::{
-            agg_processor::AggProcessor, lead_processor::LeadProcessor,
-            nth_value_processor::NthValueProcessor, percent_rank_processor::PercentRankProcessor,
-            rank_processor::RankProcessor, row_number_processor::RowNumberProcessor,
+            agg_processor::AggProcessor, cume_dist_processor::CumeDistProcessor,
+            lead_processor::LeadProcessor, nth_value_processor::NthValueProcessor,
+            percent_rank_processor::PercentRankProcessor, rank_processor::RankProcessor,
+            row_number_processor::RowNumberProcessor,
         },
         window_context::WindowContext,
     },
@@ -40,6 +41,7 @@ pub enum WindowFunction {
     PercentRank,
     NthValue { ignore_nulls: bool },
     Lead,
+    CumeDist,
     Agg(AggFunction),
 }
 
@@ -97,6 +99,7 @@ impl WindowExpr {
                 self.children.clone(),
                 ignore_nulls,
             )?)),
+            WindowFunction::CumeDist => Ok(Box::new(CumeDistProcessor::new())),
             WindowFunction::Agg(agg_func) => {
                 let agg = create_agg(
                     agg_func.clone(),
@@ -112,7 +115,7 @@ impl WindowExpr {
     pub fn requires_full_partition(&self) -> bool {
         matches!(
             self.func,
-            WindowFunction::PercentRank | WindowFunction::Lead
+            WindowFunction::PercentRank | WindowFunction::Lead | WindowFunction::CumeDist
         )
     }
 }

--- a/native-engine/datafusion-ext-plans/src/window/processors/cume_dist_processor.rs
+++ b/native-engine/datafusion-ext-plans/src/window/processors/cume_dist_processor.rs
@@ -1,0 +1,81 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use arrow::{
+    array::{ArrayRef, Float64Builder},
+    record_batch::RecordBatch,
+};
+use datafusion::common::Result;
+
+use crate::window::{WindowFunctionProcessor, window_context::WindowContext};
+
+pub struct CumeDistProcessor;
+
+impl CumeDistProcessor {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for CumeDistProcessor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl WindowFunctionProcessor for CumeDistProcessor {
+    fn process_batch(&mut self, context: &WindowContext, batch: &RecordBatch) -> Result<ArrayRef> {
+        let partition_rows = context.get_partition_rows(batch)?;
+        let order_rows = context.get_order_rows(batch)?;
+        let mut builder = Float64Builder::with_capacity(batch.num_rows());
+
+        let mut partition_start = 0usize;
+        while partition_start < batch.num_rows() {
+            let partition_start_row = partition_rows.row(partition_start);
+            let mut partition_end = partition_start + 1;
+            while partition_end < batch.num_rows()
+                && (!context.has_partition()
+                    || partition_rows.row(partition_end).as_ref() == partition_start_row.as_ref())
+            {
+                partition_end += 1;
+            }
+
+            let partition_size = (partition_end - partition_start) as f64;
+            let mut peer_start = partition_start;
+            while peer_start < partition_end {
+                let peer_start_row = order_rows.row(peer_start);
+                let mut peer_end = peer_start + 1;
+                while peer_end < partition_end
+                    && order_rows.row(peer_end).as_ref() == peer_start_row.as_ref()
+                {
+                    peer_end += 1;
+                }
+
+                let cume_dist = (peer_end - partition_start) as f64 / partition_size;
+                for _ in peer_start..peer_end {
+                    builder.append_value(cume_dist);
+                }
+
+                peer_start = peer_end;
+            }
+
+            partition_start = partition_end;
+        }
+
+        Ok(Arc::new(builder.finish()))
+    }
+}

--- a/native-engine/datafusion-ext-plans/src/window/processors/mod.rs
+++ b/native-engine/datafusion-ext-plans/src/window/processors/mod.rs
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 pub mod agg_processor;
+pub mod cume_dist_processor;
 pub mod lead_processor;
 pub mod nth_value_processor;
 pub mod percent_rank_processor;

--- a/native-engine/datafusion-ext-plans/src/window_exec.rs
+++ b/native-engine/datafusion-ext-plans/src/window_exec.rs
@@ -184,7 +184,9 @@ impl ExecutionPlan for WindowExec {
             return combined.execute(partition, context);
         }
 
-        // at this moment only supports ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        // Streaming rank-like/agg windows are evaluated batch by batch. Functions that
+        // need complete partition context, such as cume_dist, are handled in
+        // execute_window().
         let exec_ctx = ExecutionContext::new(context, partition, self.schema(), &self.metrics);
         let input = exec_ctx.execute_with_input_stats(&self.input)?;
         let coalesced = exec_ctx.coalesce_with_default_batch_size(input);
@@ -844,6 +846,49 @@ mod test {
             "| 1  | 30 | 0  | -1      |",
             "| 2  | 40 | 0  | -1      |",
             "+----+----+----+---------+",
+        ];
+        assert_batches_eq!(expected, &batches);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_cume_dist_window() -> Result<(), Box<dyn std::error::Error>> {
+        let session_ctx = SessionContext::new();
+        let task_ctx = session_ctx.task_ctx();
+
+        let input = build_table(
+            ("grp", &vec![1, 1, 1, 2]),
+            ("id", &vec![1, 1, 2, 5]),
+            ("v", &vec![10, 20, 30, 40]),
+        )?;
+        let window_exprs = vec![WindowExpr::new(
+            WindowFunction::CumeDist,
+            vec![],
+            Arc::new(Field::new("cume_dist", DataType::Float64, false)),
+            DataType::Float64,
+        )];
+        let window = Arc::new(WindowExec::try_new(
+            input,
+            window_exprs,
+            vec![Arc::new(Column::new("grp", 0))],
+            vec![PhysicalSortExpr {
+                expr: Arc::new(Column::new("id", 1)),
+                options: Default::default(),
+            }],
+            None,
+            true,
+        )?);
+        let stream = window.execute(0, task_ctx)?;
+        let batches = datafusion::physical_plan::common::collect(stream).await?;
+        let expected = vec![
+            "+-----+----+----+--------------------+",
+            "| grp | id | v  | cume_dist          |",
+            "+-----+----+----+--------------------+",
+            "| 1   | 1  | 10 | 0.6666666666666666 |",
+            "| 1   | 1  | 20 | 0.6666666666666666 |",
+            "| 1   | 2  | 30 | 1.0                |",
+            "| 2   | 5  | 40 | 1.0                |",
+            "+-----+----+----+--------------------+",
         ];
         assert_batches_eq!(expected, &batches);
         Ok(())

--- a/spark-extension-shims-spark/src/test/scala/org/apache/auron/AuronQuerySuite.scala
+++ b/spark-extension-shims-spark/src/test/scala/org/apache/auron/AuronQuerySuite.scala
@@ -574,6 +574,33 @@ class AuronQuerySuite extends AuronQueryTest with BaseAuronSQLSuite with AuronSQ
     }
   }
 
+  test("cume_dist window") {
+    withTable("t_cume_dist") {
+      sql("""
+            |create table t_cume_dist using parquet as
+            |select * from values
+            |  (1, 1, 10),
+            |  (1, 1, 20),
+            |  (1, 2, 30),
+            |  (2, 5, 40)
+            |as t(grp, id, v)
+            |""".stripMargin)
+
+      checkSparkAnswerAndOperator("""
+            |select
+            |  grp,
+            |  id,
+            |  v,
+            |  cume_dist() over (
+            |    partition by grp
+            |    order by id
+            |  ) as cume_dist_v
+            |from t_cume_dist
+            |order by grp, id, v
+            |""".stripMargin)
+    }
+  }
+
   test("nth_value window with row frame") {
     if (AuronTestUtils.isSparkV31OrGreater) {
       withTable("t_nth_value") {

--- a/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeWindowBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeWindowBase.scala
@@ -26,6 +26,7 @@ import org.apache.spark.sql.auron.NativeRDD
 import org.apache.spark.sql.auron.NativeSupports
 import org.apache.spark.sql.catalyst.expressions.Ascending
 import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.expressions.CumeDist
 import org.apache.spark.sql.catalyst.expressions.DenseRank
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.expressions.Lead
@@ -186,6 +187,13 @@ abstract class NativeWindowBase(
             windowExprBuilder.addChildren(NativeConverters.convertExpr(e.input))
             windowExprBuilder.addChildren(NativeConverters.convertExpr(e.offset))
             windowExprBuilder.addChildren(NativeConverters.convertExpr(e.default))
+
+          case e: CumeDist =>
+            assert(
+              spec.frameSpecification == e.frame,
+              s"window frame not supported: ${spec.frameSpecification}")
+            windowExprBuilder.setFuncType(pb.WindowFunctionType.Window)
+            windowExprBuilder.setWindowFunc(pb.WindowFunction.CUME_DIST)
 
           case e: Sum =>
             assert(


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2181 

# Rationale for this change
Auron does not currently support the `cume_dist()` window function in native execution, so queries using it fall back to Spark.

`cume_dist()` must follow Spark semantics exactly: it returns the number of rows preceding or equal to the current row within the partition ordering, divided by the total number of rows in the partition, and rows in the same peer group must return the same value. Because this depends on the full partition size and peer group boundaries, it cannot be implemented correctly with the existing purely streaming window path.


# What changes are included in this PR?
This PR adds native support for `cume_dist()` window function end to end.

The main changes are:

- Add `CUME_DIST` to the window function protobuf and planner conversion path.
- Extend `NativeWindowBase` to recognize Spark's `CumeDist` expression and serialize it into the native window plan.
- Add a native `CumeDistProcessor` that computes `cume_dist()` with Spark-compatible semantics:
  - rows in the same peer group produce the same value
  - the result is `(peer_group_end_position) / (partition_size)`
  - single-row partitions return `1.0`
- Extend native window execution with a full-partition processing path for window functions that require complete partition context.
- Use that full-partition path for `cume_dist()` to ensure correctness.
- Add regression tests on both the native execution side and the Spark SQL side.


# Are there any user-facing changes?
Yes.

Queries using `cume_dist()` window function can now stay on the native execution path instead of falling back to Spark, as long as the rest of the plan is supported by Auron. No new user-facing configuration is introduced.

# How was this patch tested?
CI.