### PR TITLE
[AURON #2211] Bump Celeborn 0.6.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1295,7 +1295,7 @@
         <module>thirdparty/auron-celeborn-0.6</module>
       </modules>
       <properties>
-        <celebornVersion>0.6.2</celebornVersion>
+        <celebornVersion>0.6.3</celebornVersion>
       </properties>
     </profile>
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2211

# Rationale for this change

Celeborn `0.6.3` has been released, so Auron's Celeborn `0.6` profile should be aligned with the latest patch release.

# What changes are included in this PR?

Update `celebornVersion` in the `celeborn-0.6` profile from `0.6.2` to `0.6.3`.

# Are there any user-facing changes?

No.

# How was this patch tested?

Verified the `celeborn-0.6` profile resolves `celebornVersion` to `0.6.3`.
