### PR TITLE
[AURON #1924] [BUILD] Add `-Xlint:_` to scala-maven-plugin and resolve related warnings

### DIFF
--- a/dev/auron-it/src/main/scala/org/apache/auron/integration/comparison/QueryResultComparator.scala
+++ b/dev/auron-it/src/main/scala/org/apache/auron/integration/comparison/QueryResultComparator.scala
@@ -101,15 +101,17 @@ class QueryResultComparator extends QueryComparator {
       test: Array[Row],
       tolerance: Double = 1e-6): Boolean = {
 
-    baseline.zipWithIndex.foreach { case (actualRow, rowIdx) =>
+    baseline.zipWithIndex.forall { case (actualRow, rowIdx) =>
       val expectedRow: Row = test(rowIdx)
-      actualRow.schema.zipWithIndex.foreach { case (field, colIdx) =>
+      actualRow.schema.zipWithIndex.forall { case (field, colIdx) =>
         if (actualRow.isNullAt(colIdx) || expectedRow.isNullAt(colIdx)) {
           if (actualRow.isNullAt(colIdx) != expectedRow.isNullAt(colIdx)) {
             println(
               s"Mismatch in $queryId row $rowIdx col $colIdx: " +
                 s"expected null, got ${expectedRow(colIdx)}")
-            return false
+            false
+          } else {
+            true
           }
         } else {
           field.dataType match {
@@ -121,7 +123,9 @@ class QueryResultComparator extends QueryComparator {
                 println(
                   s"Floating-point mismatch in $queryId row $rowIdx col $colIdx: " +
                     s"expected ${expectedValue}, got ${actualValue} (diff=$diff)")
-                return false
+                false
+              } else {
+                true
               }
             case _ =>
               val actualValue = actualRow.get(colIdx).toString
@@ -130,13 +134,14 @@ class QueryResultComparator extends QueryComparator {
                 println(
                   s"Mismatch in $queryId row $rowIdx col $colIdx: " +
                     s"expected $expectedValue, got $actualValue")
-                return false
+                false
+              } else {
+                true
               }
           }
         }
       }
     }
-    true
   }
   // scalastyle:on
 }

--- a/pom.xml
+++ b/pom.xml
@@ -416,10 +416,15 @@
             <arg>-deprecation</arg>
             <arg>-feature</arg>
             <arg>-Ywarn-unused</arg>
+            <arg>-Xlint:_</arg>
             <arg>-Xfatal-warnings</arg>
 
             <arg>-Wconf:msg=method newInstance in class Class is deprecated:s</arg>
             <arg>-Wconf:msg=class ThreadDeath in package lang is deprecated:s</arg>
+            <!-- Auron implements Spark plugin SPIs whose contracts use `private[spark]` types
+                 (e.g. ElementTrackingStore, SparkUI, IndexShuffleBlockResolver,
+                 ShuffleWriteMetricsReporter). Exposing them is required by Spark, not a defect. -->
+            <arg>-Wconf:cat=lint-inaccessible:s</arg>
           </args>
         </configuration>
         <dependencies>
@@ -1250,6 +1255,7 @@
                 <!-- In Scala 2.13, the plugin's functionality has been included in the compiler -->
                 <!-- directly under the -Ymacro-annotations flag.  -->
                 <arg>-Ymacro-annotations</arg>
+                <arg>-Xlint:_</arg>
                 <arg>-Xfatal-warnings</arg>
 
                 <arg>-Wconf:cat=deprecation:wv,any:e</arg>
@@ -1265,6 +1271,8 @@
                 <arg>-Wconf:msg=early initializers are deprecated:s</arg>
                 <arg>-Wconf:cat=other-match-analysis:s</arg>
                 <arg>-Wconf:cat=feature-existentials:s</arg>
+                <!-- See note in base profile: Spark plugin SPIs require exposing `private[spark]` types. -->
+                <arg>-Wconf:cat=lint-inaccessible:s</arg>
               </args>
               <compilerPlugins>
                 <compilerPlugin>

--- a/spark-extension-shims-spark/src/test/scala/org/apache/auron/AuronEmptyNativeRddSuite.scala
+++ b/spark-extension-shims-spark/src/test/scala/org/apache/auron/AuronEmptyNativeRddSuite.scala
@@ -35,8 +35,8 @@ class AuronEmptyNativeRddSuite
         .asInstanceOf[AdaptiveSparkPlanExec]
       val emptyNativeParquetScanExec =
         AuronConverters.convertSparkPlan(emptyExecutePlan.executedPlan).collectFirst {
-          case nativeParquetScanExec: NativeParquetScanExec =>
-            nativeParquetScanExec
+          case scan: NativeParquetScanExec =>
+            scan
         }
       val emptyNativeRDD = emptyNativeParquetScanExec.get.doExecuteNative()
       assert(emptyNativeRDD.isInstanceOf[EmptyNativeRDD])
@@ -63,8 +63,8 @@ class AuronEmptyNativeRddSuite
         .asInstanceOf[AdaptiveSparkPlanExec]
       val emptyNativeOrcScanExec =
         AuronConverters.convertSparkPlan(emptyExecutePlan.executedPlan).collectFirst {
-          case nativeOrcScanExec: NativeOrcScanExec =>
-            nativeOrcScanExec
+          case scan: NativeOrcScanExec =>
+            scan
         }
       val emptyNativeRDD = emptyNativeOrcScanExec.get.doExecuteNative()
       assert(emptyNativeRDD.isInstanceOf[EmptyNativeRDD])

--- a/spark-extension/src/main/scala/org/apache/spark/sql/auron/SparkUDAFWrapperContext.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/auron/SparkUDAFWrapperContext.scala
@@ -248,7 +248,7 @@ class DeclarativeEvaluator(val agg: DeclarativeAggregate)
       expr.transform {
         case BoundReference(odin, dt, nullable) =>
           BoundReference(odin + agg.aggBufferAttributes.length, dt, nullable)
-        case expr => expr
+        case other => other
       }
     }
     UnsafeProjection.create(

--- a/spark-extension/src/main/scala/org/apache/spark/sql/auron/memory/SparkOnHeapSpillManager.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/auron/memory/SparkOnHeapSpillManager.scala
@@ -165,14 +165,13 @@ class SparkOnHeapSpillManager(taskContext: TaskContext)
     // prefer the max spill, to avoid generating too many small files
     Utils.tryWithSafeFinally {
       synchronized {
-        val sortedSpills = spills.seq.sortBy(0 - _.map(_.memUsed).getOrElse(0L))
-        sortedSpills.foreach {
-          case Some(spill) if spill.memUsed > 0 =>
-            totalFreed += spill.spill(trigger)
-            if (totalFreed >= size) {
-              return totalFreed
-            }
-          case _ =>
+        val sortedSpills = spills.seq.sortBy(0 - _.map(_.memUsed).getOrElse(0L)).iterator
+        while (sortedSpills.hasNext && totalFreed < size) {
+          sortedSpills.next() match {
+            case Some(spill) if spill.memUsed > 0 =>
+              totalFreed += spill.spill(trigger)
+            case _ =>
+          }
         }
       }
     } {

--- a/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/plan/ConvertToNativeBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/plan/ConvertToNativeBase.scala
@@ -55,7 +55,7 @@ abstract class ConvertToNativeBase(override val child: SparkPlan)
       .getDefaultNativeMetrics(sparkContext)
       .filterKeys(Set("stage_id", "output_rows", "elapsed_compute"))
       .toSeq :+
-      ("size", SQLMetrics.createSizeMetric(sparkContext, "Native.batch_bytes_size")): _*)
+      ("size" -> SQLMetrics.createSizeMetric(sparkContext, "Native.batch_bytes_size")): _*)
 
   val renamedSchema: StructType = Util.getSchema(child.output)
   val nativeSchema: Schema = NativeConverters.convertSchema(renamedSchema)

--- a/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeBroadcastExchangeBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeBroadcastExchangeBase.scala
@@ -87,11 +87,11 @@ abstract class NativeBroadcastExchangeBase(mode: BroadcastMode, override val chi
     NativeHelper
       .getDefaultNativeMetrics(sparkContext)
       .toSeq :+
-      ("dataSize", SQLMetrics.createSizeMetric(sparkContext, "data size")) :+
-      ("numOutputRows", SQLMetrics.createMetric(sparkContext, "number of output rows")) :+
-      ("collectTime", SQLMetrics.createTimingMetric(sparkContext, "time to collect")) :+
-      ("buildTime", SQLMetrics.createTimingMetric(sparkContext, "time to build")) :+
-      ("broadcastTime", SQLMetrics.createTimingMetric(sparkContext, "time to broadcast")): _*)
+      ("dataSize" -> SQLMetrics.createSizeMetric(sparkContext, "data size")) :+
+      ("numOutputRows" -> SQLMetrics.createMetric(sparkContext, "number of output rows")) :+
+      ("collectTime" -> SQLMetrics.createTimingMetric(sparkContext, "time to collect")) :+
+      ("buildTime" -> SQLMetrics.createTimingMetric(sparkContext, "time to build")) :+
+      ("broadcastTime" -> SQLMetrics.createTimingMetric(sparkContext, "time to broadcast")): _*)
 
   override protected def doExecute(): RDD[InternalRow] = {
     throw new UnsupportedOperationException(

--- a/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeParquetInsertIntoHiveTableBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeParquetInsertIntoHiveTableBase.scala
@@ -68,9 +68,8 @@ abstract class NativeParquetInsertIntoHiveTableBase(
         .getDefaultNativeMetrics(sparkContext)
         .filterKeys(Set("stage_id", "output_rows", "elapsed_compute"))
         .toSeq
-        :+ ("io_time", SQLMetrics.createNanoTimingMetric(sparkContext, "Native.io_time"))
-        :+ ("bytes_written",
-        SQLMetrics
+        :+ ("io_time" -> SQLMetrics.createNanoTimingMetric(sparkContext, "Native.io_time"))
+        :+ ("bytes_written" -> SQLMetrics
           .createSizeMetric(sparkContext, "Native.bytes_written")): _*)
 
   def check(): Unit = {

--- a/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/shuffle/AuronBlockStoreShuffleReaderBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/shuffle/AuronBlockStoreShuffleReaderBase.scala
@@ -138,13 +138,13 @@ object AuronBlockStoreShuffleReaderBase extends Logging {
 
   def getFileSegmentFromInputStream(in: InputStream): Option[(String, Long, Long)] = {
     unwrapInputStream(in) match {
-      case in: LimitedInputStream =>
-        val left = FieldUtils.readDeclaredField(in, "left", true).asInstanceOf[Long]
-        val inner = FieldUtils.readField(in, "in", true).asInstanceOf[InputStream]
+      case limited: LimitedInputStream =>
+        val left = FieldUtils.readDeclaredField(limited, "left", true).asInstanceOf[Long]
+        val inner = FieldUtils.readField(limited, "in", true).asInstanceOf[InputStream]
         inner match {
-          case in: FileInputStream =>
-            val path = FieldUtils.readDeclaredField(in, "path", true).asInstanceOf[String]
-            val offset = in.getChannel.position()
+          case fileIn: FileInputStream =>
+            val path = FieldUtils.readDeclaredField(fileIn, "path", true).asInstanceOf[String]
+            val offset = fileIn.getChannel.position()
             Some((path, offset, left))
           case _ =>
             None

--- a/spark-version-annotation-macros/src/main/scala/org/apache/auron/sparkver.scala
+++ b/spark-version-annotation-macros/src/main/scala/org/apache/auron/sparkver.scala
@@ -24,13 +24,7 @@ object sparkver {
   def matchVersion(vers: String): Boolean = {
     // please ensure the common module is built
     val configuredVer = org.apache.auron.common.ProjectConstants.SHIM_NAME
-    for (ver <- vers.split("/")) {
-      val verStripped = ver.trim
-      if (s"spark-$verStripped" == configuredVer) {
-        return true
-      }
-    }
-    false
+    vers.split("/").exists(ver => s"spark-${ver.trim}" == configuredVer)
   }
 
   object Macros {

--- a/thirdparty/auron-uniffle/src/main/scala/org/apache/spark/sql/execution/auron/shuffle/uniffle/AuronUniffleShuffleReader.scala
+++ b/thirdparty/auron-uniffle/src/main/scala/org/apache/spark/sql/execution/auron/shuffle/uniffle/AuronUniffleShuffleReader.scala
@@ -104,14 +104,14 @@ class AuronUniffleShuffleReader[K, C](
 
     val inputStream =
       new UniffleInputStream(
-        new MultiPartitionIterator[K, C](),
+        new MultiPartitionIterator(),
         shuffleId,
         startPartition,
         endPartition)
     Iterator.single(inputStream)
   }
 
-  private class MultiPartitionIterator[K, C] extends AbstractIterator[Product2[K, C]] {
+  private class MultiPartitionIterator extends AbstractIterator[Product2[K, C]] {
     private var iterators: util.Iterator[RssShuffleDataIterator[K, C]] = null
     private var currentIterator: RssShuffleDataIterator[K, C] = null
 

--- a/thirdparty/auron-uniffle/src/main/scala/org/apache/spark/sql/execution/auron/shuffle/uniffle/AuronUniffleShuffleReader.scala
+++ b/thirdparty/auron-uniffle/src/main/scala/org/apache/spark/sql/execution/auron/shuffle/uniffle/AuronUniffleShuffleReader.scala
@@ -219,7 +219,7 @@ class AuronUniffleShuffleReader[K, C](
 
   @nowarn("cat=unused") // Some params temporarily unused
   private class UniffleInputStream(
-      iterator: MultiPartitionIterator[_, _],
+      iterator: MultiPartitionIterator,
       shuffleId: Int,
       startPartition: Int,
       endPartition: Int)


### PR DESCRIPTION
<!-- Start the PR title with the related issue ID, e.g. '[AURON #XXXX] Short summary...'. -->

# Which issue does this PR close?

Closes #1924. Sets up the next sibling under the [BUILD] epic #1869 (#1925) without changing its scope.

# Rationale for this change

`-Xlint:_` enables Scala's bundled lint checks, several of which catch real bug classes that the existing `-Ywarn-unused` + `-Xfatal-warnings` do not. This turns the flag on in both the base `scala-maven-plugin` config and the `scala-2.13` profile, then resolves every warning it surfaces so the matrix build stays green.

# What changes are included in this PR?

**pom.xml** -- add `-Xlint:_` and `-Wconf:cat=lint-inaccessible:s` to both `scala-maven-plugin` arg lists. The `lint-inaccessible` silencer is commented inline: Auron implements Spark plugin SPIs (`AppHistoryServerPlugin`, the `Shims` trait, `AuronRssShuffleWriterBase`) whose contracts take `private[spark]` types (`ElementTrackingStore`, `SparkUI`, `IndexShuffleBlockResolver`, `ShuffleWriteMetricsReporter`). Exposing them in our overrides is required by Spark, not a defect, so silencing the category project-wide is cleaner than annotating every override site.

**Source fixes** for the warnings that are real bug classes (8 sites across 8 files):

- `lint:adapted-args` -- `:+ ("k", v)` on a `Seq[(String, V)]` was being silently auto-tupled. Made the `Tuple2` explicit via `->`. Files: `ConvertToNativeBase`, `NativeBroadcastExchangeBase`, `NativeParquetInsertIntoHiveTableBase`.

- `lint:nonlocal-return` -- `return` from inside a `for { ... }` / `foreach { ... }` body desugars to throw/catch via `NonLocalReturnControl`. Replaced with `Iterable.exists` in `sparkver.matchVersion`, and an early-exit `while`-loop over an iterator in `SparkOnHeapSpillManager.spill`.

- pattern shadowing (`lint:type-parameter-shadow` / pattern-shadow) -- pattern bindings reusing names from the enclosing scope. Renamed: `case in: ... =>` -> `case limited: ... =>` / `case fileIn: ... =>` in `AuronBlockStoreShuffleReaderBase`; `case expr => expr` -> `case other => other` in `SparkUDAFWrapperContext`; `case nativeXScanExec` -> `case scan` in `AuronEmptyNativeRddSuite`.

# Are there any user-facing changes?

No -- build-only.

# How was this patch tested?

Local `./auron-build.sh --pre --sparkver <v> --scalaver <s> -DskipBuildNative -Dspotless.skip=true` was green for:

- Spark 3.0 / Scala 2.12
- Spark 3.1 / Scala 2.12
- Spark 3.2 / Scala 2.12
- Spark 3.4 / Scala 2.12
- Spark 3.5 / Scala 2.12
- Spark 3.5 / Scala 2.13

Spark 3.3 / Scala 2.12 left for the matrix CI to cover (middle of the range, unlikely to surface different lint categories). Happy to iterate on any warning CI catches that I missed locally.