### PR TITLE
[AURON #2217] Support Iceberg _spec_id metadata in native scan

### DIFF
--- a/thirdparty/auron-iceberg/src/main/scala/org/apache/spark/sql/auron/iceberg/IcebergScanSupport.scala
+++ b/thirdparty/auron-iceberg/src/main/scala/org/apache/spark/sql/auron/iceberg/IcebergScanSupport.scala
@@ -33,7 +33,8 @@ import org.apache.spark.sql.types.{BinaryType, DataType, DecimalType, StringType
 import org.apache.auron.{protobuf => pb}
 
 // fileSchema is read from the data files. partitionSchema carries supported metadata columns
-// (for example _file) that are materialized as per-file constant values in the native scan.
+// (for example _file and _spec_id) that are materialized as per-file constant values in
+// the native scan.
 final case class IcebergScanPlan(
     fileTasks: Seq[FileScanTask],
     fileFormat: FileFormat,
@@ -54,7 +55,8 @@ object IcebergScanSupport extends Logging {
 
     val readSchema = scan.readSchema
     val unsupportedMetadataColumns = collectUnsupportedMetadataColumns(readSchema)
-    // Native scan can project file-level metadata columns such as _file via partition values.
+    // Native scan can project file-level metadata columns such as _file and _spec_id
+    // via partition values.
     // Metadata columns that require per-row materialization (for example _pos) still fallback.
     if (unsupportedMetadataColumns.nonEmpty) {
       return None
@@ -132,7 +134,8 @@ object IcebergScanSupport extends Logging {
     }
 
   private def isSupportedMetadataColumn(field: org.apache.spark.sql.types.StructField): Boolean =
-    field.name == MetadataColumns.FILE_PATH.name()
+    field.name == MetadataColumns.FILE_PATH.name() ||
+      field.name == MetadataColumns.SPEC_ID.name()
 
   private def inputPartitions(exec: BatchScanExec): Seq[InputPartition] = {
     // Prefer DataSource V2 batch API; if not available, fallback to exec methods via reflection.

--- a/thirdparty/auron-iceberg/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeIcebergTableScanExec.scala
+++ b/thirdparty/auron-iceberg/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeIcebergTableScanExec.scala
@@ -72,6 +72,7 @@ case class NativeIcebergTableScanExec(basedScan: BatchScanExec, plan: IcebergSca
     filePartitions
   }
   private lazy val fileSizes: Map[String, Long] = buildFileSizes()
+  private lazy val fileSpecIds: Map[String, Int] = buildFileSpecIds()
 
   private lazy val nativeFileSchema: pb.Schema = NativeConverters.convertSchema(fileSchema)
   private lazy val nativePartitionSchema: pb.Schema =
@@ -130,6 +131,10 @@ case class NativeIcebergTableScanExec(basedScan: BatchScanExec, plan: IcebergSca
       field.name match {
         case name if name == MetadataColumns.FILE_PATH.name() =>
           NativeConverters.convertExpr(Literal.create(filePath, StringType)).getLiteral
+        case name if name == MetadataColumns.SPEC_ID.name() =>
+          NativeConverters
+            .convertExpr(Literal.create(fileSpecIds(filePath), field.dataType))
+            .getLiteral
         case name =>
           throw new IllegalStateException(
             s"unsupported Iceberg metadata column in native scan: $name")
@@ -236,6 +241,25 @@ case class NativeIcebergTableScanExec(basedScan: BatchScanExec, plan: IcebergSca
       sparkContext,
       executionId,
       Seq(metrics("numPartitions"), metrics("numFiles")))
+  }
+
+  private def buildFileSpecIds(): Map[String, Int] = {
+    // Map file path to Iceberg partition spec id; tasks may split a file into multiple ranges.
+    val specIds = scala.collection.mutable.HashMap.empty[String, Int]
+    fileTasks.foreach { task =>
+      val filePath = task.file().location()
+      val specId = task.file().specId()
+      specIds.get(filePath) match {
+        case Some(existingSpecId) if existingSpecId != specId =>
+          throw new IllegalStateException(
+            s"Inconsistent Iceberg partition spec id for file $filePath: " +
+              s"$existingSpecId != $specId")
+        case Some(_) =>
+        case None =>
+          specIds.put(filePath, specId)
+      }
+    }
+    specIds.toMap
   }
 
   private def buildFilePartitions(): Array[FilePartition] = {

--- a/thirdparty/auron-iceberg/src/test/scala/org/apache/auron/iceberg/AuronIcebergIntegrationSuite.scala
+++ b/thirdparty/auron-iceberg/src/test/scala/org/apache/auron/iceberg/AuronIcebergIntegrationSuite.scala
@@ -266,6 +266,20 @@ class AuronIcebergIntegrationSuite
     }
   }
 
+  test("iceberg native scan supports _spec_id metadata column") {
+    withTable("local.db.t4_spec_id") {
+      sql("create table local.db.t4_spec_id using iceberg as select 1 as id, 'a' as v")
+      checkSparkAnswerAndOperator("select _spec_id from local.db.t4_spec_id")
+    }
+  }
+
+  test("iceberg native scan supports data columns with _file and _spec_id metadata columns") {
+    withTable("local.db.t4_metadata_mixed") {
+      sql("create table local.db.t4_metadata_mixed using iceberg as select 1 as id, 'a' as v")
+      checkSparkAnswerAndOperator("select id, _file, _spec_id from local.db.t4_metadata_mixed")
+    }
+  }
+
   test("iceberg native scan supports data columns with _file metadata column") {
     withTable("local.db.t4_mixed") {
       sql("create table local.db.t4_mixed using iceberg as select 1 as id, 'a' as v")


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2217 

# Rationale for this change

Native Iceberg scan currently supports projecting the `_file` metadata column, but falls back when `_spec_id` is requested. `_spec_id` is a file-level Iceberg metadata column and can be materialized as a per-file constant value in the native scan, similar to `_file`.

# What changes are included in this PR?

This PR adds native scan support for the Iceberg `_spec_id` metadata column.

- Allows `_spec_id` in Iceberg native scan metadata column validation.
- Materializes `_spec_id` from `FileScanTask.file().specId()` as a per-file partition value.
- Adds integration tests for `_spec_id` projection and mixed data/metadata projection with `_file` and `_spec_id`.

# Are there any user-facing changes?
Yes. Queries that project Iceberg `_spec_id` can now use the native Iceberg scan path instead of falling back to Spark.

# How was this patch tested?
CI.
