### PR TITLE
[AURON #2219] Expose numFiles and numPartitions metrics for native Iceberg scan

### DIFF
--- a/spark-extension-shims-spark/src/test/scala/org/apache/spark/sql/execution/BuildInfoInSparkUISuite.scala
+++ b/spark-extension-shims-spark/src/test/scala/org/apache/spark/sql/execution/BuildInfoInSparkUISuite.scala
@@ -46,6 +46,7 @@ class BuildInfoInSparkUISuite extends AuronQueryTest with BaseAuronSQLSuite {
     val listeners = spark.sparkContext.listenerBus.findListenersByClass[AuronSQLAppStatusListener]
     assert(listeners.size === 1)
     val listener = listeners(0)
+    spark.sparkContext.listenerBus.waitUntilEmpty()
     assert(listener.getAuronBuildInfo() == 1)
   }
 

--- a/thirdparty/auron-iceberg/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeIcebergTableScanExec.scala
+++ b/thirdparty/auron-iceberg/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeIcebergTableScanExec.scala
@@ -34,11 +34,10 @@ import org.apache.spark.sql.auron.{EmptyNativeRDD, NativeConverters, NativeHelpe
 import org.apache.spark.sql.auron.iceberg.IcebergScanPlan
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Literal
-import org.apache.spark.sql.execution.LeafExecNode
-import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.execution.{LeafExecNode, SparkPlan, SQLExecution}
 import org.apache.spark.sql.execution.datasources.{FilePartition, PartitionedFile}
 import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
-import org.apache.spark.sql.execution.metric.SQLMetric
+import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{StringType, StructType}
 import org.apache.spark.util.SerializableConfiguration
@@ -53,7 +52,9 @@ case class NativeIcebergTableScanExec(basedScan: BatchScanExec, plan: IcebergSca
     with Logging {
 
   override lazy val metrics: Map[String, SQLMetric] =
-    NativeHelper.getNativeFileScanMetrics(sparkContext)
+    NativeHelper.getNativeFileScanMetrics(sparkContext) ++ Seq(
+      "numPartitions" -> SQLMetrics.createMetric(sparkContext, "Native.partitions_read"),
+      "numFiles" -> SQLMetrics.createMetric(sparkContext, "Native.files_read"))
 
   override val output = basedScan.output
   override val outputPartitioning = basedScan.outputPartitioning
@@ -65,7 +66,11 @@ case class NativeIcebergTableScanExec(basedScan: BatchScanExec, plan: IcebergSca
   private lazy val fileTasks: Seq[FileScanTask] = plan.fileTasks
   private lazy val pruningPredicates: Seq[pb.PhysicalExprNode] = plan.pruningPredicates
 
-  private lazy val partitions: Array[FilePartition] = buildFilePartitions()
+  private lazy val partitions: Array[FilePartition] = {
+    val filePartitions = buildFilePartitions()
+    postDriverMetrics(filePartitions)
+    filePartitions
+  }
   private lazy val fileSizes: Map[String, Long] = buildFileSizes()
 
   private lazy val nativeFileSchema: pb.Schema = NativeConverters.convertSchema(fileSchema)
@@ -219,6 +224,18 @@ case class NativeIcebergTableScanExec(basedScan: BatchScanExec, plan: IcebergSca
       .groupBy(_._1)
       .mapValues(_.head._2)
       .toMap
+  }
+
+  private def postDriverMetrics(filePartitions: Array[FilePartition]): Unit = {
+    val numPartitions = filePartitions.length
+    metrics("numPartitions").add(numPartitions)
+    val numFiles = filePartitions.foldLeft(0L)(_ + _.files.length)
+    metrics("numFiles").add(numFiles)
+    val executionId = sparkContext.getLocalProperty(SQLExecution.EXECUTION_ID_KEY)
+    SQLMetrics.postDriverMetricUpdates(
+      sparkContext,
+      executionId,
+      Seq(metrics("numPartitions"), metrics("numFiles")))
   }
 
   private def buildFilePartitions(): Array[FilePartition] = {

--- a/thirdparty/auron-iceberg/src/test/scala/org/apache/auron/iceberg/AuronIcebergIntegrationSuite.scala
+++ b/thirdparty/auron-iceberg/src/test/scala/org/apache/auron/iceberg/AuronIcebergIntegrationSuite.scala
@@ -26,6 +26,7 @@ import org.apache.iceberg.deletes.PositionDelete
 import org.apache.iceberg.spark.Spark3Util
 import org.apache.spark.sql.{DataFrame, Row}
 import org.apache.spark.sql.auron.iceberg.IcebergScanSupport
+import org.apache.spark.sql.execution.auron.plan.NativeIcebergTableScanExec
 import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
 
 class AuronIcebergIntegrationSuite
@@ -48,6 +49,21 @@ class AuronIcebergIntegrationSuite
       df.collect()
       val plan = df.queryExecution.executedPlan.toString()
       assert(plan.contains("NativeIcebergTableScan"))
+    }
+  }
+
+  test("iceberg native scan exposes file scan driver metrics") {
+    withTable("local.db.t_metrics") {
+      sql("create table local.db.t_metrics using iceberg as select 1 as id, 'a' as v")
+      val df = sql("select * from local.db.t_metrics")
+      checkAnswer(df, Seq(Row(1, "a")))
+      val nativeScan = nativeIcebergTableScanExec(df)
+      nativeScan.doExecuteNative()
+      val metrics = nativeScan.metrics.map { case (name, metric) => name -> metric.value }
+      assert(metrics.contains("numPartitions"))
+      assert(metrics.contains("numFiles"))
+      assert(metrics("numPartitions") > 0)
+      assert(metrics("numFiles") > 0)
     }
   }
 
@@ -345,4 +361,14 @@ class AuronIcebergIntegrationSuite
     df.queryExecution.sparkPlan.collectFirst { case scan: BatchScanExec =>
       IcebergScanSupport.plan(scan)
     }.flatten
+
+  private def nativeIcebergTableScanExec(df: DataFrame): NativeIcebergTableScanExec = {
+    val batchScan = df.queryExecution.sparkPlan.collectFirst { case scan: BatchScanExec =>
+      scan
+    }
+    assert(batchScan.nonEmpty)
+    val scanPlan = IcebergScanSupport.plan(batchScan.get)
+    assert(scanPlan.nonEmpty)
+    NativeIcebergTableScanExec(batchScan.get, scanPlan.get)
+  }
 }

--- a/thirdparty/auron-iceberg/src/test/scala/org/apache/auron/iceberg/AuronIcebergIntegrationSuite.scala
+++ b/thirdparty/auron-iceberg/src/test/scala/org/apache/auron/iceberg/AuronIcebergIntegrationSuite.scala
@@ -17,6 +17,9 @@
 package org.apache.auron.iceberg
 
 import java.util.UUID
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 
 import scala.collection.JavaConverters._
 
@@ -24,10 +27,12 @@ import org.apache.iceberg.{FileFormat, FileScanTask}
 import org.apache.iceberg.data.{GenericAppenderFactory, Record}
 import org.apache.iceberg.deletes.PositionDelete
 import org.apache.iceberg.spark.Spark3Util
+import org.apache.spark.scheduler.{SparkListener, SparkListenerEvent}
 import org.apache.spark.sql.{DataFrame, Row}
 import org.apache.spark.sql.auron.iceberg.IcebergScanSupport
 import org.apache.spark.sql.execution.auron.plan.NativeIcebergTableScanExec
 import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
+import org.apache.spark.sql.execution.ui.SparkListenerDriverAccumUpdates
 
 class AuronIcebergIntegrationSuite
     extends org.apache.spark.sql.QueryTest
@@ -55,15 +60,46 @@ class AuronIcebergIntegrationSuite
   test("iceberg native scan exposes file scan driver metrics") {
     withTable("local.db.t_metrics") {
       sql("create table local.db.t_metrics using iceberg as select 1 as id, 'a' as v")
-      val df = sql("select * from local.db.t_metrics")
-      checkAnswer(df, Seq(Row(1, "a")))
-      val nativeScan = nativeIcebergTableScanExec(df)
-      nativeScan.doExecuteNative()
-      val metrics = nativeScan.metrics.map { case (name, metric) => name -> metric.value }
-      assert(metrics.contains("numPartitions"))
-      assert(metrics.contains("numFiles"))
-      assert(metrics("numPartitions") > 0)
-      assert(metrics("numFiles") > 0)
+      withSQLConf("spark.sql.adaptive.enabled" -> "false") {
+        val df = sql("select * from local.db.t_metrics")
+        val nativeScan = executedNativeIcebergTableScanExec(df)
+        val metricIds = Map(
+          "numPartitions" -> nativeScan.metrics("numPartitions").id,
+          "numFiles" -> nativeScan.metrics("numFiles").id)
+        val driverMetricUpdates = new ConcurrentLinkedQueue[(Long, Long)]()
+        val driverMetricUpdatesPosted = new CountDownLatch(1)
+        val listener = new SparkListener {
+          override def onOtherEvent(event: SparkListenerEvent): Unit = event match {
+            case SparkListenerDriverAccumUpdates(_, updates) =>
+              updates.foreach { case (metricId, value) =>
+                driverMetricUpdates.add(metricId -> value)
+              }
+              val updatedMetricIds = driverMetricUpdates.iterator().asScala.map(_._1).toSet
+              if (metricIds.values.forall(updatedMetricIds.contains)) {
+                driverMetricUpdatesPosted.countDown()
+              }
+            case _ =>
+          }
+        }
+
+        spark.sparkContext.addSparkListener(listener)
+        try {
+          checkAnswer(df, Seq(Row(1, "a")))
+          assert(driverMetricUpdatesPosted.await(30, TimeUnit.SECONDS))
+        } finally {
+          spark.sparkContext.removeSparkListener(listener)
+        }
+
+        val driverMetricValues = driverMetricUpdates
+          .iterator()
+          .asScala
+          .toSeq
+          .groupBy(_._1)
+          .mapValues(_.map(_._2).sum)
+          .toMap
+        assert(driverMetricValues.getOrElse(metricIds("numPartitions"), 0L) > 0)
+        assert(driverMetricValues.getOrElse(metricIds("numFiles"), 0L) > 0)
+      }
     }
   }
 
@@ -362,13 +398,11 @@ class AuronIcebergIntegrationSuite
       IcebergScanSupport.plan(scan)
     }.flatten
 
-  private def nativeIcebergTableScanExec(df: DataFrame): NativeIcebergTableScanExec = {
-    val batchScan = df.queryExecution.sparkPlan.collectFirst { case scan: BatchScanExec =>
-      scan
+  private def executedNativeIcebergTableScanExec(df: DataFrame): NativeIcebergTableScanExec = {
+    val nativeScan = df.queryExecution.executedPlan.collectFirst {
+      case scan: NativeIcebergTableScanExec => scan
     }
-    assert(batchScan.nonEmpty)
-    val scanPlan = IcebergScanSupport.plan(batchScan.get)
-    assert(scanPlan.nonEmpty)
-    NativeIcebergTableScanExec(batchScan.get, scanPlan.get)
+    assert(nativeScan.nonEmpty)
+    nativeScan.get
   }
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2219 

# Rationale for this change

Native Iceberg scan currently exposes native file scan metrics, but it does not report the driver-side `numFiles` and `numPartitions` metrics that regular native file scans expose. These metrics are useful for understanding the scan planning result in Spark SQL UI.

# What changes are included in this PR?

This PR adds `numFiles` and `numPartitions` metrics to `NativeIcebergTableScanExec`.

- Adds `Native.files_read` and `Native.partitions_read` metrics.
- Populates these metrics after Iceberg file tasks are converted into Spark file partitions.
- Posts the driver metric updates via `SQLMetrics.postDriverMetricUpdates`.
- Adds integration test coverage for the new native Iceberg scan metrics.

# Are there any user-facing changes?
Yes. Spark SQL metrics for native Iceberg scans now include file count and partition count.

# How was this patch tested?
CI.