### PR TITLE
[AURON #2223] Fix batch_size() OnceCell cache by using static instead of const

### DIFF
--- a/native-engine/datafusion-ext-commons/src/lib.rs
+++ b/native-engine/datafusion-ext-commons/src/lib.rs
@@ -72,7 +72,7 @@ macro_rules! downcast_any {
 }
 
 pub fn batch_size() -> usize {
-    const CACHED_BATCH_SIZE: OnceCell<usize> = OnceCell::new();
+    static CACHED_BATCH_SIZE: OnceCell<usize> = OnceCell::new();
     *CACHED_BATCH_SIZE.get_or_init(|| BATCH_SIZE.value().unwrap_or(10000) as usize)
 }
 


### PR DESCRIPTION

# Which issue does this PR close?

Closes #2223 

# Rationale for this change
The batch_size() function used const for its OnceCell, which created a new cell on every call and prevented caching. Change to static so the cached value is computed once and reused.


# What changes are included in this PR?

# Are there any user-facing changes?

# How was this patch tested?
