### PR TITLE
[AURON #2080] Support Hive Parquet table to NativeParquetHiveTableScanExec 

### DIFF
--- a/dev/mvn-build-helper/assembly/pom.xml
+++ b/dev/mvn-build-helper/assembly/pom.xml
@@ -120,10 +120,10 @@
                     <exclude>org.apache.arrow.c.**</exclude>
                   </excludes>
                 </relocation>
-                <relocation>
-                  <pattern>io.netty</pattern>
-                  <shadedPattern>${auron.shade.packageName}.io.netty</shadedPattern>
-                </relocation>
+<!--                <relocation>-->
+<!--                  <pattern>io.netty</pattern>-->
+<!--                  <shadedPattern>${auron.shade.packageName}.io.netty</shadedPattern>-->
+<!--                </relocation>-->
                 <relocation>
                   <pattern>javax.annotation</pattern>
                   <shadedPattern>${auron.shade.packageName}.javax.annotation</shadedPattern>

--- a/spark-extension-shims-spark/pom.xml
+++ b/spark-extension-shims-spark/pom.xml
@@ -57,8 +57,24 @@
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
+      <artifactId>spark-catalyst_${scalaVersion}</artifactId>
+      <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.arrow</groupId>
+          <artifactId>arrow-memory-netty</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
       <artifactId>spark-hive_${scalaVersion}</artifactId>
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-client-api</artifactId>
+      <version>${hadoopVersion}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
@@ -104,14 +120,42 @@
       <type>test-jar</type>
     </dependency>
     <dependency>
+      <groupId>org.apache.arrow</groupId>
+      <artifactId>arrow-memory-core</artifactId>
+      <version>${arrowVersion}</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-catalyst_${scalaVersion}</artifactId>
       <type>test-jar</type>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.arrow</groupId>
+          <artifactId>arrow-memory-netty</artifactId>
+        </exclusion>
+      </exclusions>
+
+
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-sql_${scalaVersion}</artifactId>
       <type>test-jar</type>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-hive_${scalaVersion}</artifactId>
+      <type>test-jar</type>
+      <!--      <exclusions>-->
+      <!--        <exclusion>-->
+      <!--          <groupId>org.apache.hive.shims</groupId>-->
+      <!--          <artifactId>hive-shims-common</artifactId>-->
+      <!--        </exclusion>-->
+      <!--        <exclusion>-->
+      <!--          <groupId>org.apache.hive.shims</groupId>-->
+      <!--          <artifactId>hive-shims-0.23</artifactId>-->
+      <!--        </exclusion>-->
+      <!--      </exclusions>-->
     </dependency>
   </dependencies>
 </project>

--- a/spark-extension-shims-spark/pom.xml
+++ b/spark-extension-shims-spark/pom.xml
@@ -135,7 +135,6 @@
         </exclusion>
       </exclusions>
 
-
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>

--- a/spark-extension-shims-spark/src/main/resources/META-INF/services/org.apache.spark.sql.auron.AuronConvertProvider
+++ b/spark-extension-shims-spark/src/main/resources/META-INF/services/org.apache.spark.sql.auron.AuronConvertProvider
@@ -1,0 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.apache.spark.sql.hive.execution.auron.plan.HiveConvertProvider

--- a/spark-extension-shims-spark/src/main/scala/org/apache/spark/sql/hive/execution/auron/plan/HiveConvertProvider.scala
+++ b/spark-extension-shims-spark/src/main/scala/org/apache/spark/sql/hive/execution/auron/plan/HiveConvertProvider.scala
@@ -17,7 +17,7 @@
 package org.apache.spark.sql.hive.execution.auron.plan
 
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.auron.{AuronConvertProvider, AuronConverters}
+import org.apache.spark.sql.auron.{AuronConverters, AuronConvertProvider}
 import org.apache.spark.sql.auron.AuronConverters.getBooleanConf
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.hive.client.HiveClientImpl
@@ -42,8 +42,9 @@ class HiveConvertProvider extends AuronConvertProvider with Logging {
 
   override def convert(exec: SparkPlan): SparkPlan = {
     exec match {
-      case hiveExec: HiveTableScanExec if enableHiveTableScanExec
-        && HiveTableUtil.isParquetTable(hiveExec) =>
+      case hiveExec: HiveTableScanExec
+          if enableHiveTableScanExec
+            && HiveTableUtil.isParquetTable(hiveExec) =>
         convertParquetHiveTableScanExec(hiveExec)
       case _ => exec
     }
@@ -58,7 +59,11 @@ object HiveTableUtil {
   private val parquetFormat = "MapredParquetInputFormat"
 
   def isParquetTable(basedHiveScan: HiveTableScanExec): Boolean = {
-    if (HiveClientImpl.toHiveTable(basedHiveScan.relation.tableMeta).getInputFormatClass.getSimpleName.equalsIgnoreCase(parquetFormat)) {
+    if (HiveClientImpl
+        .toHiveTable(basedHiveScan.relation.tableMeta)
+        .getInputFormatClass
+        .getSimpleName
+        .equalsIgnoreCase(parquetFormat)) {
       true
     } else {
       false

--- a/spark-extension-shims-spark/src/main/scala/org/apache/spark/sql/hive/execution/auron/plan/HiveConvertProvider.scala
+++ b/spark-extension-shims-spark/src/main/scala/org/apache/spark/sql/hive/execution/auron/plan/HiveConvertProvider.scala
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.hive.execution.auron.plan
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.auron.{AuronConvertProvider, AuronConverters}
+import org.apache.spark.sql.auron.AuronConverters.getBooleanConf
+import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.hive.client.HiveClientImpl
+import org.apache.spark.sql.hive.execution.HiveTableScanExec
+
+class HiveConvertProvider extends AuronConvertProvider with Logging {
+  override def isEnabled: Boolean =
+    getBooleanConf("spark.auron.enable.hiveTable", defaultValue = true)
+
+  private def enableHiveTableScanExec: Boolean =
+    getBooleanConf("spark.auron.enable.parquetHiveTableScanExec", defaultValue = false)
+
+  override def isSupported(exec: SparkPlan): Boolean =
+    exec match {
+      case e: HiveTableScanExec
+          if enableHiveTableScanExec &&
+            e.relation.tableMeta.provider.isDefined &&
+            e.relation.tableMeta.provider.get.equals("hive") =>
+        true
+      case _ => false
+    }
+
+  override def convert(exec: SparkPlan): SparkPlan = {
+    exec match {
+      case hiveExec: HiveTableScanExec if enableHiveTableScanExec
+        && HiveTableUtil.isParquetTable(hiveExec) =>
+        convertParquetHiveTableScanExec(hiveExec)
+      case _ => exec
+    }
+  }
+
+  private def convertParquetHiveTableScanExec(hiveExec: HiveTableScanExec): SparkPlan = {
+    AuronConverters.addRenameColumnsExec(NativeParquetHiveTableScanExec(hiveExec))
+  }
+}
+
+object HiveTableUtil {
+  private val parquetFormat = "MapredParquetInputFormat"
+
+  def isParquetTable(basedHiveScan: HiveTableScanExec): Boolean = {
+    if (HiveClientImpl.toHiveTable(basedHiveScan.relation.tableMeta).getInputFormatClass.getSimpleName.equalsIgnoreCase(parquetFormat)) {
+      true
+    } else {
+      false
+    }
+  }
+
+}

--- a/spark-extension-shims-spark/src/main/scala/org/apache/spark/sql/hive/execution/auron/plan/NativeParquetHiveTableScanExec.scala
+++ b/spark-extension-shims-spark/src/main/scala/org/apache/spark/sql/hive/execution/auron/plan/NativeParquetHiveTableScanExec.scala
@@ -1,0 +1,272 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.hive.execution.auron.plan
+
+import java.util.UUID
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable.ArrayBuffer
+
+import org.apache.hadoop.conf.Configurable
+import org.apache.hadoop.hive.ql.exec.Utilities
+import org.apache.hadoop.hive.ql.metadata.{Table => HiveTable}
+import org.apache.hadoop.hive.ql.plan.TableDesc
+import org.apache.hadoop.hive.serde.serdeConstants
+import org.apache.hadoop.hive.serde2.objectinspector.{ObjectInspectorUtils, StructObjectInspector}
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorUtils.ObjectInspectorCopyOption
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils
+import org.apache.hadoop.io.Writable
+import org.apache.hadoop.mapred.{FileSplit, InputFormat, JobConf}
+import org.apache.hadoop.mapreduce.{InputFormat => newInputClass}
+import org.apache.hadoop.util.ReflectionUtils
+import org.apache.spark.{Partition, TaskContext}
+import org.apache.spark.internal.Logging
+import org.apache.spark.internal.config.HADOOP_RDD_IGNORE_EMPTY_SPLITS
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.auron.{NativeRDD, Shims}
+import org.apache.spark.sql.catalyst.expressions.{AttributeMap, GenericInternalRow}
+import org.apache.spark.sql.execution.datasources.{FilePartition, PartitionedFile}
+import org.apache.spark.sql.hive.{HadoopTableReader, HiveShim}
+import org.apache.spark.sql.hive.client.HiveClientImpl
+import org.apache.spark.sql.hive.execution.HiveTableScanExec
+
+import org.apache.auron.{protobuf => pb}
+import org.apache.auron.metric.SparkMetricNode
+
+case class NativeParquetHiveTableScanExec(basedHiveScan: HiveTableScanExec)
+    extends NativeHiveTableScanBase(basedHiveScan)
+    with Logging {
+
+  @transient private lazy val nativeTable: HiveTable =
+    HiveClientImpl.toHiveTable(relation.tableMeta)
+  @transient private lazy val fileFormat =
+    ParquetHiveTableUtil.getFileFormat(nativeTable.getInputFormatClass)
+  @transient private lazy val nativeTableDesc = new TableDesc(
+    nativeTable.getInputFormatClass,
+    nativeTable.getOutputFormatClass,
+    nativeTable.getMetadata)
+
+  @transient private lazy val nativeHadoopConf = {
+    val hiveConf = SparkSession.getActiveSession.get.sessionState.newHadoopConf()
+    // append columns ids and names before broadcast
+    val columnOrdinals = AttributeMap(relation.dataCols.zipWithIndex)
+    val neededColumnIDs = output.flatMap(columnOrdinals.get).map(o => o: Integer)
+    val neededColumnNames = output.filter(columnOrdinals.contains).map(_.name)
+
+    HiveShim.appendReadColumns(hiveConf, neededColumnIDs, neededColumnNames)
+
+    val deserializer = nativeTableDesc.getDeserializerClass.getConstructor().newInstance()
+    deserializer.initialize(hiveConf, nativeTableDesc.getProperties)
+
+    // Specifies types and object inspectors of columns to be scanned.
+    val structOI = ObjectInspectorUtils
+      .getStandardObjectInspector(deserializer.getObjectInspector, ObjectInspectorCopyOption.JAVA)
+      .asInstanceOf[StructObjectInspector]
+
+    val columnTypeNames = structOI.getAllStructFieldRefs.asScala
+      .map(_.getFieldObjectInspector)
+      .map(TypeInfoUtils.getTypeInfoFromObjectInspector(_).getTypeName)
+      .mkString(",")
+
+    hiveConf.set(serdeConstants.LIST_COLUMN_TYPES, columnTypeNames)
+    hiveConf.set(serdeConstants.LIST_COLUMNS, relation.dataCols.map(_.name).mkString(","))
+    hiveConf
+  }
+
+  private val minPartitions = if (SparkSession.getActiveSession.get.sparkContext.isLocal) {
+    0 // will splitted based on block by default.
+  } else {
+    math.max(
+      nativeHadoopConf.getInt("mapreduce.job.maps", 1),
+      SparkSession.getActiveSession.get.sparkContext.defaultMinPartitions)
+  }
+
+  private val ignoreEmptySplits =
+    SparkSession.getActiveSession.get.sparkContext.conf.get(HADOOP_RDD_IGNORE_EMPTY_SPLITS)
+
+  override val nodeName: String =
+    s"NativeHiveTableScan $tableName"
+
+  override def doExecuteNative(): NativeRDD = {
+    val nativeMetrics = SparkMetricNode(
+      metrics,
+      Nil,
+      Some({
+        case ("bytes_scanned", v) =>
+          val inputMetric = TaskContext.get.taskMetrics().inputMetrics
+          inputMetric.incBytesRead(v)
+        case ("output_rows", v) =>
+          val inputMetric = TaskContext.get.taskMetrics().inputMetrics
+          inputMetric.incRecordsRead(v)
+        case _ =>
+      }))
+    val nativeFileSchema = this.nativeFileSchema
+    val nativeFileGroups = this.nativeFileGroups
+    val nativePartitionSchema = this.nativePartitionSchema
+
+    val projection = schema.map(field => relation.schema.fieldIndex(field.name))
+    val broadcastedHadoopConf = this.broadcastedHadoopConf
+    val numPartitions = partitions.length
+
+    new NativeRDD(
+      sparkContext,
+      nativeMetrics,
+      partitions.asInstanceOf[Array[Partition]],
+      None,
+      Nil,
+      rddShuffleReadFull = true,
+      (partition, _) => {
+        val resourceId = s"NativeParquetHiveTableScan:${UUID.randomUUID().toString}"
+        putJniBridgeResource(resourceId, broadcastedHadoopConf)
+
+        val nativeFileGroup = nativeFileGroups(partition.asInstanceOf[FilePartition])
+        val nativeFileScanConf = pb.FileScanExecConf
+          .newBuilder()
+          .setNumPartitions(numPartitions)
+          .setPartitionIndex(partition.index)
+          .setStatistics(pb.Statistics.getDefaultInstance)
+          .setSchema(nativeFileSchema)
+          .setFileGroup(nativeFileGroup)
+          .addAllProjection(projection.map(Integer.valueOf).asJava)
+          .setPartitionSchema(nativePartitionSchema)
+          .build()
+        fileFormat match {
+          case "parquet" =>
+            val nativeParquetScanExecBuilder = pb.ParquetScanExecNode
+              .newBuilder()
+              .setBaseConf(nativeFileScanConf)
+              .setFsResourceId(resourceId)
+              .addAllPruningPredicates(new java.util.ArrayList()) // not support this filter
+
+            pb.PhysicalPlanNode
+              .newBuilder()
+              .setParquetScan(nativeParquetScanExecBuilder.build())
+              .build()
+          case "other" =>
+            throw new Exception("HiveTableExec only support parquet")
+        }
+      },
+      friendlyName = "NativeRDD.ParquetHiveTableScan")
+  }
+
+  override def getFilePartitions(): Array[FilePartition] = {
+    val newJobConf = new JobConf(nativeHadoopConf)
+    val arrayFilePartition = ArrayBuffer[FilePartition]()
+    val partitionedFiles = if (relation.isPartitioned) {
+      val partitions = basedHiveScan.prunedPartitions
+      val arrayPartitionedFile = ArrayBuffer[PartitionedFile]()
+      partitions.foreach { partition =>
+        val partDesc = Utilities.getPartitionDescFromTableDesc(nativeTableDesc, partition, true)
+        val partPath = partition.getDataLocation
+        HadoopTableReader.initializeLocalJobConfFunc(partPath.toString, nativeTableDesc)(
+          newJobConf)
+        val partitionValues = partition.getTPartition.getValues
+
+        val partitionInternalRow = new GenericInternalRow(partitionValues.size())
+        for (partitionIndex <- 0 until partitionValues.size) {
+          partitionInternalRow.update(partitionIndex, partitionValues.get(partitionIndex))
+        }
+
+        val inputFormatClass = partDesc.getInputFileFormatClass
+          .asInstanceOf[Class[newInputClass[Writable, Writable]]]
+        newJobConf.set("mapred.input.dir", partPath.toString)
+        arrayPartitionedFile ++= getArrayPartitionedFile(
+          newJobConf,
+          inputFormatClass,
+          partitionInternalRow)
+      }
+      arrayPartitionedFile
+        .sortBy(_.length)(implicitly[Ordering[Long]].reverse)
+        .toArray
+    } else {
+      newJobConf.set("mapred.input.dir", nativeTableDesc.getProperties().getProperty("location"))
+      val inputFormatClass =
+        nativeTable.getInputFormatClass.asInstanceOf[Class[newInputClass[Writable, Writable]]]
+      getArrayPartitionedFile(newJobConf, inputFormatClass, new GenericInternalRow(0))
+        .sortBy(_.length)(implicitly[Ordering[Long]].reverse)
+        .toArray
+    }
+    arrayFilePartition ++= FilePartition.getFilePartitions(
+      SparkSession.getActiveSession.get,
+      partitionedFiles,
+      getMaxSplitBytes(SparkSession.getActiveSession.get))
+
+    arrayFilePartition.toArray
+  }
+
+  private def getMaxSplitBytes(sparkSession: SparkSession): Long = {
+    val defaultMaxSplitBytes = sparkSession.sessionState.conf.filesMaxPartitionBytes
+    val openCostInBytes = sparkSession.sessionState.conf.filesOpenCostInBytes
+    Math.min(defaultMaxSplitBytes, openCostInBytes)
+  }
+
+  private def getArrayPartitionedFile(
+      newJobConf: JobConf,
+      inputFormatClass: Class[newInputClass[Writable, Writable]],
+      partitionInternalRow: GenericInternalRow): ArrayBuffer[PartitionedFile] = {
+    val allInputSplits =
+      getInputFormat(newJobConf, inputFormatClass).getSplits(newJobConf, minPartitions)
+    val inputSplits = if (ignoreEmptySplits) {
+      allInputSplits.filter(_.getLength > 0)
+    } else {
+      allInputSplits
+    }
+
+    val arrayFilePartition = ArrayBuffer[PartitionedFile]()
+    for (i <- 0 until inputSplits.size) {
+      val inputSplit = inputSplits(i)
+      if (inputSplit.isInstanceOf[FileSplit]) {
+        val orcInputSplit = inputSplit.asInstanceOf[FileSplit]
+        arrayFilePartition +=
+          Shims.get.getPartitionedFile(
+            partitionInternalRow,
+            orcInputSplit.getPath.toString,
+            orcInputSplit.getStart,
+            orcInputSplit.getLength)
+      }
+    }
+    arrayFilePartition
+  }
+
+  private def getInputFormat(
+      conf: JobConf,
+      inputFormatClass: Class[newInputClass[Writable, Writable]])
+      : InputFormat[Writable, Writable] = {
+    val newInputFormat = ReflectionUtils
+      .newInstance(inputFormatClass.asInstanceOf[Class[_]], conf)
+      .asInstanceOf[InputFormat[Writable, Writable]]
+    newInputFormat match {
+      case c: Configurable => c.setConf(conf)
+      case _ =>
+    }
+    newInputFormat
+  }
+
+}
+
+object ParquetHiveTableUtil {
+  private val parquetFormat = "MapredParquetInputFormat"
+
+  def getFileFormat(inputFormatClass: Class[_ <: InputFormat[_, _]]): String = {
+   if (inputFormatClass.getSimpleName.equalsIgnoreCase(parquetFormat)) {
+      "parquet"
+    } else {
+      "other"
+    }
+  }
+
+}

--- a/spark-extension-shims-spark/src/main/scala/org/apache/spark/sql/hive/execution/auron/plan/NativeParquetHiveTableScanExec.scala
+++ b/spark-extension-shims-spark/src/main/scala/org/apache/spark/sql/hive/execution/auron/plan/NativeParquetHiveTableScanExec.scala
@@ -262,7 +262,7 @@ object ParquetHiveTableUtil {
   private val parquetFormat = "MapredParquetInputFormat"
 
   def getFileFormat(inputFormatClass: Class[_ <: InputFormat[_, _]]): String = {
-   if (inputFormatClass.getSimpleName.equalsIgnoreCase(parquetFormat)) {
+    if (inputFormatClass.getSimpleName.equalsIgnoreCase(parquetFormat)) {
       "parquet"
     } else {
       "other"

--- a/spark-extension-shims-spark/src/test/scala/org/apache/auron/BaseAuronSQLSuite.scala
+++ b/spark-extension-shims-spark/src/test/scala/org/apache/auron/BaseAuronSQLSuite.scala
@@ -20,6 +20,8 @@ import java.io.File
 
 import org.apache.commons.io.FileUtils
 import org.apache.spark.SparkConf
+import org.apache.spark.sql.catalyst.expressions.CodegenObjectFactoryMode
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 
 import org.apache.auron.util.SparkVersionUtil
@@ -61,6 +63,12 @@ trait BaseAuronSQLSuite extends SharedSparkSession {
       .set("spark.ui.enabled", "false")
       .set("spark.sql.warehouse.dir", warehouseDir)
       .set("spark.auron.udf.singleChildFallback.enabled", "false")
+      .set(SQLConf.CODEGEN_FALLBACK.key, "false")
+      .set(SQLConf.CODEGEN_FACTORY_MODE.key, CodegenObjectFactoryMode.CODEGEN_ONLY.toString)
+      .set(
+        "spark.sql.hive.metastore.barrierPrefixes",
+        "org.apache.spark.sql.hive.execution.PairSerDe")
+      .set("spark.hadoop.hive.metastore.disallow.incompatible.col.type.changes", "false")
 
     if (SparkVersionUtil.isSparkV40OrGreater) {
       // Spark 4.0+: Disable session artifact isolation, align with Spark 3.x behavior

--- a/spark-extension-shims-spark/src/test/scala/org/apache/spark/sql/hive/execution/BaseAuronHiveSuite.scala
+++ b/spark-extension-shims-spark/src/test/scala/org/apache/spark/sql/hive/execution/BaseAuronHiveSuite.scala
@@ -16,13 +16,13 @@
  */
 package org.apache.spark.sql.hive.execution
 
+import java.io.File
+
 import org.apache.commons.io.FileUtils
 import org.apache.spark.{SparkConf, SparkContext, SparkFunSuite}
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.hive.test.TestHiveContext
 import org.scalatest.BeforeAndAfterAll
-
-import java.io.File
 
 trait BaseAuronHiveSuite extends SparkFunSuite with BeforeAndAfterAll {
 
@@ -70,5 +70,4 @@ object TestAuronHive
             getClass.getResource("/").getPath + "auron-tests-workdir/spark-warehouse")
           .set("spark.auron.udf.singleChildFallback.enabled", "false")
           .set("spark.auron.enable.parquetHiveTableScanExec", "true")
-          .set("spark.sql.hive.convertMetastoreParquet", "false")
-      )) {}
+          .set("spark.sql.hive.convertMetastoreParquet", "false"))) {}

--- a/spark-extension-shims-spark/src/test/scala/org/apache/spark/sql/hive/execution/BaseAuronHiveSuite.scala
+++ b/spark-extension-shims-spark/src/test/scala/org/apache/spark/sql/hive/execution/BaseAuronHiveSuite.scala
@@ -17,7 +17,6 @@
 package org.apache.spark.sql.hive.execution
 
 import java.io.File
-
 import org.apache.commons.io.FileUtils
 import org.apache.spark.{SparkConf, SparkContext, SparkFunSuite}
 import org.apache.spark.sql.SparkSession
@@ -26,7 +25,7 @@ import org.scalatest.BeforeAndAfterAll
 
 trait BaseAuronHiveSuite extends SparkFunSuite with BeforeAndAfterAll {
 
-  protected val spark: SparkSession = TestAuronHive.sparkSession
+  lazy val spark: SparkSession = TestAuronHive.sparkSession
 
   protected val suiteWorkspace: String = getClass.getResource("/").getPath + "auron-tests-workdir"
   protected val warehouseDir: String = suiteWorkspace + "/spark-warehouse"

--- a/spark-extension-shims-spark/src/test/scala/org/apache/spark/sql/hive/execution/BaseAuronHiveSuite.scala
+++ b/spark-extension-shims-spark/src/test/scala/org/apache/spark/sql/hive/execution/BaseAuronHiveSuite.scala
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.hive.execution
+
+import org.apache.commons.io.FileUtils
+import org.apache.spark.{SparkConf, SparkContext, SparkFunSuite}
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.hive.test.TestHiveContext
+import org.scalatest.BeforeAndAfterAll
+
+import java.io.File
+
+trait BaseAuronHiveSuite extends SparkFunSuite with BeforeAndAfterAll {
+
+  protected val spark: SparkSession = TestAuronHive.sparkSession
+
+  protected val suiteWorkspace: String = getClass.getResource("/").getPath + "auron-tests-workdir"
+  protected val warehouseDir: String = suiteWorkspace + "/spark-warehouse"
+  protected val metastoreDir: String = suiteWorkspace + "/meta"
+
+  protected def resetSuiteWorkspace(): Unit = {
+    val workdir = new File(suiteWorkspace)
+    if (workdir.exists()) {
+      FileUtils.forceDelete(workdir)
+    }
+    FileUtils.forceMkdir(workdir)
+    FileUtils.forceMkdir(new File(warehouseDir))
+    FileUtils.forceMkdir(new File(metastoreDir))
+  }
+
+  override def beforeAll(): Unit = {
+    // Prepare a clean workspace before SparkSession initialization
+    resetSuiteWorkspace()
+    super.beforeAll()
+    spark.sparkContext.setLogLevel("WARN")
+  }
+
+}
+
+object TestAuronHive
+    extends TestHiveContext(
+      new SparkContext(
+        System.getProperty("spark.sql.test.master", "local[1]"),
+        "TestSQLContext",
+        new SparkConf()
+          .set("spark.sql.test", "")
+          .set("spark.sql.extensions", "org.apache.spark.sql.auron.AuronSparkSessionExtension")
+          .set(
+            "spark.shuffle.manager",
+            "org.apache.spark.sql.execution.auron.shuffle.AuronShuffleManager")
+          .set("spark.memory.offHeap.enabled", "false")
+          .set("spark.auron.enable", "true")
+          .set("spark.ui.enabled", "false")
+          .set(
+            "spark.sql.warehouse.dir",
+            getClass.getResource("/").getPath + "auron-tests-workdir/spark-warehouse")
+          .set("spark.auron.udf.singleChildFallback.enabled", "false")
+          .set("spark.auron.enable.parquetHiveTableScanExec", "true")
+          .set("spark.sql.hive.convertMetastoreParquet", "false")
+      )) {}

--- a/spark-extension-shims-spark/src/test/scala/org/apache/spark/sql/hive/execution/BaseAuronHiveSuite.scala
+++ b/spark-extension-shims-spark/src/test/scala/org/apache/spark/sql/hive/execution/BaseAuronHiveSuite.scala
@@ -27,7 +27,8 @@ trait BaseAuronHiveSuite extends SparkFunSuite with BeforeAndAfterAll {
 
   lazy val spark: SparkSession = TestAuronHive.sparkSession
 
-  protected val suiteWorkspace: String = getClass.getResource("/").getPath + "auron-tests-workdir"
+  protected val suiteWorkspace: String = classOf[BaseAuronHiveSuite].
+    getResource("/").getPath + "auron-tests-workdir"
   protected val warehouseDir: String = suiteWorkspace + "/spark-warehouse"
   protected val metastoreDir: String = suiteWorkspace + "/meta"
 
@@ -66,7 +67,7 @@ object TestAuronHive
           .set("spark.ui.enabled", "false")
           .set(
             "spark.sql.warehouse.dir",
-            getClass.getResource("/").getPath + "auron-tests-workdir/spark-warehouse")
+            classOf[BaseAuronHiveSuite].getResource("/").getPath + "auron-tests-workdir/spark-warehouse")
           .set("spark.auron.udf.singleChildFallback.enabled", "false")
           .set("spark.auron.enable.parquetHiveTableScanExec", "true")
           .set("spark.sql.hive.convertMetastoreParquet", "false"))) {}

--- a/spark-extension-shims-spark/src/test/scala/org/apache/spark/sql/hive/execution/HiveParquetTableScanExecSuite.scala
+++ b/spark-extension-shims-spark/src/test/scala/org/apache/spark/sql/hive/execution/HiveParquetTableScanExecSuite.scala
@@ -35,10 +35,10 @@ class HiveParquetTableScanExecSuite extends AuronQueryTest with BaseAuronHiveSui
   }
 
   test("test hive parquet table partition to native") {
-    withTempView("t1") {
-      spark.sql("create table t1 (a string) stored as parquet partitioned by(pt string)")
-      spark.sql("insert into t1 partition(pt='2026-03-10') values('1')")
-      spark.sql("insert into t1 partition(pt='2026-03-11') values('1')")
+    withTempView("t2") {
+      spark.sql("create table t2 (a string) stored as parquet partitioned by(pt string)")
+      spark.sql("insert into t2 partition(pt='2026-03-10') values('1')")
+      spark.sql("insert into t2 partition(pt='2026-03-11') values('1')")
       val df = spark.sql("select * from t1 where pt = '2026-03-10'")
       df.show()
       assert(df.collect().toList.head.get(0) == "1")

--- a/spark-extension-shims-spark/src/test/scala/org/apache/spark/sql/hive/execution/HiveParquetTableScanExecSuite.scala
+++ b/spark-extension-shims-spark/src/test/scala/org/apache/spark/sql/hive/execution/HiveParquetTableScanExecSuite.scala
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.hive.execution
+
+import org.apache.spark.sql.AuronQueryTest
+import org.apache.spark.sql.hive.execution.auron.plan.NativeParquetHiveTableScanExec
+
+class HiveParquetTableScanExecSuite extends AuronQueryTest with BaseAuronHiveSuite {
+
+  test("test hive parquet table without partition to native") {
+    withTempView("t1") {
+      spark.sql("create table t1 (a string) stored as parquet")
+      spark.sql("insert into t1 values(1)")
+      val df = spark.sql("select * from t1")
+      assert(df.collect().toList.head.get(0) == "1")
+      val plan = df.queryExecution.executedPlan
+      assert(collect(plan) { case e: NativeParquetHiveTableScanExec =>
+        e
+      }.size == 1)
+    }
+  }
+
+  test("test hive parquet table partition to native") {
+    withTempView("t1") {
+      spark.sql("create table t1 (a string) stored as parquet partitioned by(pt string)")
+      spark.sql("insert into t1 partition(pt='2026-03-10') values('1')")
+      spark.sql("insert into t1 partition(pt='2026-03-11') values('1')")
+      val df = spark.sql("select * from t1 where pt = '2026-03-10'")
+      df.show()
+      assert(df.collect().toList.head.get(0) == "1")
+      assert(df.collect().toList.head.get(1) == "2026-03-10")
+      val plan = df.queryExecution.executedPlan
+      assert(collect(plan) { case e: NativeParquetHiveTableScanExec =>
+        e
+      }.size == 1)
+    }
+  }
+
+}

--- a/spark-extension-shims-spark/src/test/scala/org/apache/spark/sql/hive/execution/HiveParquetTableScanExecSuite.scala
+++ b/spark-extension-shims-spark/src/test/scala/org/apache/spark/sql/hive/execution/HiveParquetTableScanExecSuite.scala
@@ -22,10 +22,10 @@ import org.apache.spark.sql.hive.execution.auron.plan.NativeParquetHiveTableScan
 class HiveParquetTableScanExecSuite extends AuronQueryTest with BaseAuronHiveSuite {
 
   test("test hive parquet table without partition to native") {
-    withTempView("t1") {
-      spark.sql("create table t1 (a string) stored as parquet")
-      spark.sql("insert into t1 values(1)")
-      val df = spark.sql("select * from t1")
+    withTempView("hive_table_without_partition") {
+      spark.sql("create table hive_table_without_partition (a string) stored as parquet")
+      spark.sql("insert into hive_table_without_partition values(1)")
+      val df = spark.sql("select * from hive_table_without_partition")
       assert(df.collect().toList.head.get(0) == "1")
       val plan = df.queryExecution.executedPlan
       assert(collect(plan) { case e: NativeParquetHiveTableScanExec =>
@@ -35,11 +35,11 @@ class HiveParquetTableScanExecSuite extends AuronQueryTest with BaseAuronHiveSui
   }
 
   test("test hive parquet table partition to native") {
-    withTempView("t2") {
-      spark.sql("create table t2 (a string) stored as parquet partitioned by(pt string)")
-      spark.sql("insert into t2 partition(pt='2026-03-10') values('1')")
-      spark.sql("insert into t2 partition(pt='2026-03-11') values('1')")
-      val df = spark.sql("select * from t1 where pt = '2026-03-10'")
+    withTempView("hive_table_with_partition") {
+      spark.sql("create table hive_table_with_partition (a string) stored as parquet partitioned by(pt string)")
+      spark.sql("insert into hive_table_with_partition partition(pt='2026-03-10') values('1')")
+      spark.sql("insert into hive_table_with_partition partition(pt='2026-03-11') values('1')")
+      val df = spark.sql("select * from hive_table_with_partition where pt = '2026-03-10'")
       df.show()
       assert(df.collect().toList.head.get(0) == "1")
       assert(df.collect().toList.head.get(1) == "2026-03-10")

--- a/spark-extension/src/main/scala/org/apache/spark/sql/auron/AuronConverters.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/auron/AuronConverters.scala
@@ -424,7 +424,7 @@ object AuronConverters extends Logging {
           assert(
             !exec.requiredSchema.exists(e => existTimestampType(e.dataType)),
             s"Parquet scan with timestamp type is not supported for table: ${tableIdentifier
-                .getOrElse("unknown")}. " +
+              .getOrElse("unknown")}. " +
               "Set spark.auron.enable.scan.parquet.timestamp=true to enable timestamp support " +
               "or remove timestamp columns from the query.")
         }
@@ -435,7 +435,7 @@ object AuronConverters extends Logging {
           assert(
             !exec.requiredSchema.exists(e => existTimestampType(e.dataType)),
             s"ORC scan with timestamp type is not supported for tableIdentifier: ${tableIdentifier
-                .getOrElse("unknown")}. " +
+              .getOrElse("unknown")}. " +
               "Set spark.auron.enable.scan.orc.timestamp=true to enable timestamp support " +
               "or remove timestamp columns from the query.")
         }
@@ -443,7 +443,7 @@ object AuronConverters extends Logging {
       case p =>
         throw new NotImplementedError(
           s"Cannot convert FileSourceScanExec tableIdentifier: ${tableIdentifier.getOrElse(
-              "unknown")}, class: ${p.getClass.getName}")
+            "unknown")}, class: ${p.getClass.getName}")
     }
   }
 

--- a/spark-extension/src/main/scala/org/apache/spark/sql/auron/AuronConverters.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/auron/AuronConverters.scala
@@ -424,7 +424,7 @@ object AuronConverters extends Logging {
           assert(
             !exec.requiredSchema.exists(e => existTimestampType(e.dataType)),
             s"Parquet scan with timestamp type is not supported for table: ${tableIdentifier
-              .getOrElse("unknown")}. " +
+                .getOrElse("unknown")}. " +
               "Set spark.auron.enable.scan.parquet.timestamp=true to enable timestamp support " +
               "or remove timestamp columns from the query.")
         }
@@ -435,7 +435,7 @@ object AuronConverters extends Logging {
           assert(
             !exec.requiredSchema.exists(e => existTimestampType(e.dataType)),
             s"ORC scan with timestamp type is not supported for tableIdentifier: ${tableIdentifier
-              .getOrElse("unknown")}. " +
+                .getOrElse("unknown")}. " +
               "Set spark.auron.enable.scan.orc.timestamp=true to enable timestamp support " +
               "or remove timestamp columns from the query.")
         }
@@ -443,7 +443,7 @@ object AuronConverters extends Logging {
       case p =>
         throw new NotImplementedError(
           s"Cannot convert FileSourceScanExec tableIdentifier: ${tableIdentifier.getOrElse(
-            "unknown")}, class: ${p.getClass.getName}")
+              "unknown")}, class: ${p.getClass.getName}")
     }
   }
 

--- a/spark-extension/src/main/scala/org/apache/spark/sql/auron/AuronSparkSessionExtension.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/auron/AuronSparkSessionExtension.scala
@@ -91,7 +91,7 @@ case class AuronColumnarOverrides(sparkSession: SparkSession) extends ColumnarRu
         dumpSimpleSparkPlanTreeNode(sparkPlanTransformed)
 
         logInfo(s"Transformed spark plan after preColumnarTransitions:\n${sparkPlanTransformed
-            .treeString(verbose = true, addSuffix = true)}")
+          .treeString(verbose = true, addSuffix = true)}")
 
         // post-transform
         Shims.get.postTransform(sparkPlanTransformed, sparkSession.sparkContext)

--- a/spark-extension/src/main/scala/org/apache/spark/sql/auron/AuronSparkSessionExtension.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/auron/AuronSparkSessionExtension.scala
@@ -91,7 +91,7 @@ case class AuronColumnarOverrides(sparkSession: SparkSession) extends ColumnarRu
         dumpSimpleSparkPlanTreeNode(sparkPlanTransformed)
 
         logInfo(s"Transformed spark plan after preColumnarTransitions:\n${sparkPlanTransformed
-          .treeString(verbose = true, addSuffix = true)}")
+            .treeString(verbose = true, addSuffix = true)}")
 
         // post-transform
         Shims.get.postTransform(sparkPlanTransformed, sparkSession.sparkContext)

--- a/spark-extension/src/main/scala/org/apache/spark/sql/auron/NativeHelper.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/auron/NativeHelper.scala
@@ -74,7 +74,7 @@ object NativeHelper extends Logging {
     val heapMemory = Runtime.getRuntime.maxMemory()
     val offheapMemory = totalMemory - heapMemory
     logWarning(s"memory total: ${Utils.bytesToString(totalMemory)}, onheap: ${Utils.bytesToString(
-      heapMemory)}, offheap: ${Utils.bytesToString(offheapMemory)}")
+        heapMemory)}, offheap: ${Utils.bytesToString(offheapMemory)}")
     offheapMemory
   }
 

--- a/spark-extension/src/main/scala/org/apache/spark/sql/auron/NativeHelper.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/auron/NativeHelper.scala
@@ -74,7 +74,7 @@ object NativeHelper extends Logging {
     val heapMemory = Runtime.getRuntime.maxMemory()
     val offheapMemory = totalMemory - heapMemory
     logWarning(s"memory total: ${Utils.bytesToString(totalMemory)}, onheap: ${Utils.bytesToString(
-        heapMemory)}, offheap: ${Utils.bytesToString(offheapMemory)}")
+      heapMemory)}, offheap: ${Utils.bytesToString(offheapMemory)}")
     offheapMemory
   }
 

--- a/spark-extension/src/main/scala/org/apache/spark/sql/auron/util/TaskContextHelper.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/auron/util/TaskContextHelper.scala
@@ -47,7 +47,7 @@ object TaskContextHelper extends Logging {
     val thread = Thread.currentThread()
     val threadName = if (context != null) {
       s"auron native task ${context.partitionId()}.${context.attemptNumber()} in stage ${context
-        .stageId()}.${context.stageAttemptNumber()} (TID ${context.taskAttemptId()})"
+          .stageId()}.${context.stageAttemptNumber()} (TID ${context.taskAttemptId()})"
     } else {
       "auron native task " + thread.getName
     }

--- a/spark-extension/src/main/scala/org/apache/spark/sql/auron/util/TaskContextHelper.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/auron/util/TaskContextHelper.scala
@@ -47,7 +47,7 @@ object TaskContextHelper extends Logging {
     val thread = Thread.currentThread()
     val threadName = if (context != null) {
       s"auron native task ${context.partitionId()}.${context.attemptNumber()} in stage ${context
-          .stageId()}.${context.stageAttemptNumber()} (TID ${context.taskAttemptId()})"
+        .stageId()}.${context.stageAttemptNumber()} (TID ${context.taskAttemptId()})"
     } else {
       "auron native task " + thread.getName
     }

--- a/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeParquetInsertIntoHiveTableBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeParquetInsertIntoHiveTableBase.scala
@@ -69,9 +69,10 @@ abstract class NativeParquetInsertIntoHiveTableBase(
         .filterKeys(Set("stage_id", "output_rows", "elapsed_compute"))
         .toSeq
         :+ ("io_time", SQLMetrics.createNanoTimingMetric(sparkContext, "Native.io_time"))
-        :+ ("bytes_written",
-        SQLMetrics
-          .createSizeMetric(sparkContext, "Native.bytes_written")): _*)
+        :+ (
+          "bytes_written",
+          SQLMetrics
+            .createSizeMetric(sparkContext, "Native.bytes_written")): _*)
 
   def check(): Unit = {
     val hadoopConf = sparkContext.hadoopConfiguration

--- a/spark-extension/src/main/scala/org/apache/spark/sql/hive/execution/auron/plan/NativeHiveTableScanBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/hive/execution/auron/plan/NativeHiveTableScanBase.scala
@@ -85,7 +85,8 @@ abstract class NativeHiveTableScanBase(basedHiveScan: HiveTableScanExec)
     val nativePartitionedFile = (file: PartitionedFile) => {
       val nativePartitionValues = partitionSchema.zipWithIndex.map { case (field, index) =>
         NativeConverters
-          .convertExpr(Literal.create(file.partitionValues.get(index, field.dataType), field.dataType))
+          .convertExpr(
+            Literal.create(file.partitionValues.get(index, field.dataType), field.dataType))
           .getLiteral
       }
       pb.PartitionedFile

--- a/spark-extension/src/main/scala/org/apache/spark/sql/hive/execution/auron/plan/NativeHiveTableScanBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/hive/execution/auron/plan/NativeHiveTableScanBase.scala
@@ -85,7 +85,7 @@ abstract class NativeHiveTableScanBase(basedHiveScan: HiveTableScanExec)
     val nativePartitionedFile = (file: PartitionedFile) => {
       val nativePartitionValues = partitionSchema.zipWithIndex.map { case (field, index) =>
         NativeConverters
-          .convertExpr(Literal(file.partitionValues.get(index, field.dataType), field.dataType))
+          .convertExpr(Literal.create(file.partitionValues.get(index, field.dataType), field.dataType))
           .getLiteral
       }
       pb.PartitionedFile

--- a/thirdparty/auron-uniffle/src/main/scala/org/apache/spark/sql/execution/auron/shuffle/uniffle/AuronUniffleShuffleReader.scala
+++ b/thirdparty/auron-uniffle/src/main/scala/org/apache/spark/sql/execution/auron/shuffle/uniffle/AuronUniffleShuffleReader.scala
@@ -172,7 +172,7 @@ class AuronUniffleShuffleReader[K, C](
       }
       if (!emptyPartitionIds.isEmpty) {
         logDebug(s"Found ${emptyPartitionIds
-          .size()} empty shuffle partitions: ${emptyPartitionIds.asScala.mkString(",")}")
+            .size()} empty shuffle partitions: ${emptyPartitionIds.asScala.mkString(",")}")
       }
       iterators = shuffleDataIterList.iterator()
       if (iterators.hasNext) {


### PR DESCRIPTION
<!--
  - Start the PR title with the related issue ID, e.g. '[AURON #XXXX] Short summary...'.
-->
# Which issue does this PR close?

Closes #2080

# Rationale for this change

Switch the Spark execution plan to HiveTableScanExec, and when the table storage type is Parquet, the native execution plan NativeParquetHiveTableScanExec executes.

Design parameters are as follows: 
spark.auron.enable.hiveTable and spark.auron.enable.parquetHiveTableScanExec parameters

Eg：
spark.auron.enable.hiveTable  default is true （When set to true, this conversion is enabled by default）
spark.auron.enable.parquetHiveTableScanExec  default is false（When set to true, this conversion is enabled by default））

# What changes are included in this PR?

# Are there any user-facing changes?

NO.

# How was this patch tested?

UT
