### PR TITLE
[AURON #2221] Remove hard-coded Iceberg scan class name detection using type-based check

### DIFF
--- a/thirdparty/auron-iceberg/src/main/scala/org/apache/iceberg/spark/source/AuronIcebergSourceUtil.scala
+++ b/thirdparty/auron-iceberg/src/main/scala/org/apache/iceberg/spark/source/AuronIcebergSourceUtil.scala
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.iceberg.spark.source
+
+object AuronIcebergSourceUtil {
+
+  def getClassOfSparkBatchQueryScan(): Class[SparkBatchQueryScan] = {
+    classOf[SparkBatchQueryScan]
+  }
+
+  def getClassOfSparkInputPartition(): Class[SparkInputPartition] = {
+    classOf[SparkInputPartition]
+  }
+}

--- a/thirdparty/auron-iceberg/src/main/scala/org/apache/spark/sql/auron/iceberg/IcebergScanSupport.scala
+++ b/thirdparty/auron-iceberg/src/main/scala/org/apache/spark/sql/auron/iceberg/IcebergScanSupport.scala
@@ -195,7 +195,8 @@ object IcebergScanSupport extends Logging {
   private def icebergPartition(partition: InputPartition): Option[IcebergPartitionView] = {
     val className = partition.getClass.getName
     // Only accept Iceberg SparkInputPartition to access task groups.
-    if (className != AuronIcebergSourceUtil.getClassOfSparkInputPartition()) {
+    if (partition.getClass
+        != AuronIcebergSourceUtil.getClassOfSparkInputPartition()) {
       return None
     }
 

--- a/thirdparty/auron-iceberg/src/main/scala/org/apache/spark/sql/auron/iceberg/IcebergScanSupport.scala
+++ b/thirdparty/auron-iceberg/src/main/scala/org/apache/spark/sql/auron/iceberg/IcebergScanSupport.scala
@@ -18,17 +18,19 @@ package org.apache.spark.sql.auron.iceberg
 
 import scala.collection.JavaConverters._
 import scala.util.control.NonFatal
+
 import org.apache.iceberg.{FileFormat, FileScanTask, MetadataColumns}
-import org.apache.iceberg.expressions.{BoundPredicate, UnboundPredicate, And => IcebergAnd, Expression => IcebergExpression, Not => IcebergNot, Or => IcebergOr}
+import org.apache.iceberg.expressions.{And => IcebergAnd, BoundPredicate, Expression => IcebergExpression, Not => IcebergNot, Or => IcebergOr, UnboundPredicate}
+import org.apache.iceberg.spark.source.AuronIcebergSourceUtil
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.auron.NativeConverters
-import org.apache.spark.sql.catalyst.expressions.{AttributeReference, EqualTo, GreaterThan, GreaterThanOrEqual, In, IsNaN, IsNotNull, IsNull, LessThan, LessThanOrEqual, Literal, And => SparkAnd, Expression => SparkExpression, Not => SparkNot, Or => SparkOr}
+import org.apache.spark.sql.catalyst.expressions.{And => SparkAnd, AttributeReference, EqualTo, Expression => SparkExpression, GreaterThan, GreaterThanOrEqual, In, IsNaN, IsNotNull, IsNull, LessThan, LessThanOrEqual, Literal, Not => SparkNot, Or => SparkOr}
 import org.apache.spark.sql.connector.read.InputPartition
 import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{BinaryType, DataType, DecimalType, StringType, StructField, StructType}
+
 import org.apache.auron.{protobuf => pb}
-import org.apache.iceberg.spark.source.AuronIcebergSourceUtil
 
 // fileSchema is read from the data files. partitionSchema carries supported metadata columns
 // (for example _file) that are materialized as per-file constant values in the native scan.

--- a/thirdparty/auron-iceberg/src/main/scala/org/apache/spark/sql/auron/iceberg/IcebergScanSupport.scala
+++ b/thirdparty/auron-iceberg/src/main/scala/org/apache/spark/sql/auron/iceberg/IcebergScanSupport.scala
@@ -18,18 +18,17 @@ package org.apache.spark.sql.auron.iceberg
 
 import scala.collection.JavaConverters._
 import scala.util.control.NonFatal
-
 import org.apache.iceberg.{FileFormat, FileScanTask, MetadataColumns}
-import org.apache.iceberg.expressions.{And => IcebergAnd, BoundPredicate, Expression => IcebergExpression, Not => IcebergNot, Or => IcebergOr, UnboundPredicate}
+import org.apache.iceberg.expressions.{BoundPredicate, UnboundPredicate, And => IcebergAnd, Expression => IcebergExpression, Not => IcebergNot, Or => IcebergOr}
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.auron.NativeConverters
-import org.apache.spark.sql.catalyst.expressions.{And => SparkAnd, AttributeReference, EqualTo, Expression => SparkExpression, GreaterThan, GreaterThanOrEqual, In, IsNaN, IsNotNull, IsNull, LessThan, LessThanOrEqual, Literal, Not => SparkNot, Or => SparkOr}
+import org.apache.spark.sql.catalyst.expressions.{AttributeReference, EqualTo, GreaterThan, GreaterThanOrEqual, In, IsNaN, IsNotNull, IsNull, LessThan, LessThanOrEqual, Literal, And => SparkAnd, Expression => SparkExpression, Not => SparkNot, Or => SparkOr}
 import org.apache.spark.sql.connector.read.InputPartition
 import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{BinaryType, DataType, DecimalType, StringType, StructField, StructType}
-
 import org.apache.auron.{protobuf => pb}
+import org.apache.iceberg.spark.source.AuronIcebergSourceUtil
 
 // fileSchema is read from the data files. partitionSchema carries supported metadata columns
 // (for example _file) that are materialized as per-file constant values in the native scan.
@@ -47,12 +46,7 @@ object IcebergScanSupport extends Logging {
     val scan = exec.scan
     val scanClassName = scan.getClass.getName
     // Only handle Iceberg scans; other sources must stay on Spark's path.
-    if (!scanClassName.startsWith("org.apache.iceberg.spark.source.")) {
-      return None
-    }
-
-    // Changelog scan carries row-level changes; not supported by native COW-only path.
-    if (scanClassName == "org.apache.iceberg.spark.source.SparkChangelogScan") {
+    if (!(scan.getClass == AuronIcebergSourceUtil.getClassOfSparkBatchQueryScan)) {
       return None
     }
 
@@ -199,7 +193,7 @@ object IcebergScanSupport extends Logging {
   private def icebergPartition(partition: InputPartition): Option[IcebergPartitionView] = {
     val className = partition.getClass.getName
     // Only accept Iceberg SparkInputPartition to access task groups.
-    if (className != "org.apache.iceberg.spark.source.SparkInputPartition") {
+    if (className != AuronIcebergSourceUtil.getClassOfSparkInputPartition()) {
       return None
     }
 

--- a/thirdparty/auron-iceberg/src/main/scala/org/apache/spark/sql/auron/iceberg/IcebergScanSupport.scala
+++ b/thirdparty/auron-iceberg/src/main/scala/org/apache/spark/sql/auron/iceberg/IcebergScanSupport.scala
@@ -48,7 +48,7 @@ object IcebergScanSupport extends Logging {
     val scan = exec.scan
     val scanClassName = scan.getClass.getName
     // Only handle Iceberg scans; other sources must stay on Spark's path.
-    if (!(scan.getClass == AuronIcebergSourceUtil.getClassOfSparkBatchQueryScan)) {
+    if (!AuronIcebergSourceUtil.getClassOfSparkBatchQueryScan.isInstance(scan)) {
       return None
     }
 
@@ -195,8 +195,7 @@ object IcebergScanSupport extends Logging {
   private def icebergPartition(partition: InputPartition): Option[IcebergPartitionView] = {
     val className = partition.getClass.getName
     // Only accept Iceberg SparkInputPartition to access task groups.
-    if (partition.getClass
-        != AuronIcebergSourceUtil.getClassOfSparkInputPartition()) {
+    if (!AuronIcebergSourceUtil.getClassOfSparkInputPartition().isInstance(partition)) {
       return None
     }
 


### PR DESCRIPTION
…erg table types.

# Which issue does this PR close?

Closes #2221 

# Rationale for this change

This PR removes string-based detection and replaces it with type-based checking.

The current implementation relies on hard-coded class name strings to detect Iceberg scan types:

`
if (!scanClassName.startsWith("org.apache.iceberg.spark.source.")) {
return None
}

if (scanClassName == "org.apache.iceberg.spark.source.SparkChangelogScan") {
return None
}

if (className != "org.apache.iceberg.spark.source.SparkInputPartition") {
return None
}
`

This approach introduces tight coupling to Iceberg internal class naming and has several drawbacks:

Fragile to upstream refactoring (class/package rename)
Lacks type safety
Hard to maintain and extend

**Notes on Changelog Scan**

ChangelogScan is not a subclass of SparkBatchQueryScan


# What changes are included in this PR?

Three conditional scenarios were modified to avoid hard-coded logic in the evaluations.

**Benefits**
Removes hard-coded class name dependency
Improves type safety and readability
More robust against Iceberg internal refactoring
Cleaner and more maintainable logic

# Are there any user-facing changes?

No changes.


# How was this patch tested?

Depends on existing unit tests.

