### PR TITLE
[AURON #2227] auron-build.sh fails to parse options after -D arguments

### DIFF
--- a/auron-build.sh
+++ b/auron-build.sh
@@ -572,6 +572,10 @@ if [[ "$USE_DOCKER" == true ]]; then
     exec docker-compose -f dev/docker-build/docker-compose.yml up --abort-on-container-exit
 else
     echo "[INFO] Compiling locally with maven args: $MVN_CMD ${MVN_ARGS[@]} ${MAVEN_OPTS} $@"
-    "$MVN_CMD" "${MVN_ARGS[@]}" "${MAVEN_OPTS}" "$@"
+    if [[ -n "$MAVEN_OPTS" ]]; then
+        "$MVN_CMD" "${MVN_ARGS[@]}" "${MAVEN_OPTS}" "$@"
+    else
+        "$MVN_CMD" "${MVN_ARGS[@]}" "$@"
+    fi
 fi
 

--- a/auron-build.sh
+++ b/auron-build.sh
@@ -351,11 +351,9 @@ while [[ $# -gt 0 ]]; do
             ;;
         -*)
             if [[ "$1" == -D* ]]; then
-                # Maven system property，继续解析
                 MAVEN_OPTS="$MAVEN_OPTS $1"
                 shift
             else
-                # 其他短参数：停止解析
                 break
             fi
             ;;

--- a/auron-build.sh
+++ b/auron-build.sh
@@ -139,6 +139,7 @@ UNIFFLE_VER=""
 PAIMON_VER=""
 ICEBERG_VER=""
 HUDI_VER=""
+MAVEN_OPTS=""
 
 # -----------------------------------------------------------------------------
 # Section: Argument Parsing
@@ -212,6 +213,7 @@ while [[ $# -gt 0 ]]; do
             ;;
         --sparktests)
             if [[ -n "$2" && "$2" =~ ^(true|false)$ ]]; then
+
                 SPARK_TESTS="$2"
                 shift 2
             else
@@ -348,7 +350,14 @@ while [[ $# -gt 0 ]]; do
             exit 1
             ;;
         -*)
-            break
+            if [[ "$1" == -D* ]]; then
+                # Maven system property，继续解析
+                MAVEN_OPTS="$MAVEN_OPTS $1"
+                shift
+            else
+                # 其他短参数：停止解析
+                break
+            fi
             ;;
         *)
             echo "ERROR: $1 is not supported" >&2
@@ -562,6 +571,7 @@ if [[ "$USE_DOCKER" == true ]]; then
     export BUILD_CONTEXT="./${IMAGE_NAME}"
     exec docker-compose -f dev/docker-build/docker-compose.yml up --abort-on-container-exit
 else
-    echo "[INFO] Compiling locally with maven args: $MVN_CMD ${MVN_ARGS[@]} $@"
-    "$MVN_CMD" "${MVN_ARGS[@]}" "$@"
+    echo "[INFO] Compiling locally with maven args: $MVN_CMD ${MVN_ARGS[@]} ${MAVEN_OPTS} $@"
+    "$MVN_CMD" "${MVN_ARGS[@]}" "${MAVEN_OPTS}" "$@"
 fi
+

--- a/auron-build.sh
+++ b/auron-build.sh
@@ -570,6 +570,10 @@ if [[ "$USE_DOCKER" == true ]]; then
     exec docker-compose -f dev/docker-build/docker-compose.yml up --abort-on-container-exit
 else
     echo "[INFO] Compiling locally with maven args: $MVN_CMD ${MVN_ARGS[@]} ${MVN_D_ARGS} $@"
-    "$MVN_CMD" "${MVN_ARGS[@]}" "${MVN_D_ARGS[@]}" "$@"
+    if [[ -n "$MVN_D_ARGS" ]]; then
+        "$MVN_CMD" "${MVN_ARGS[@]}" "${MVN_D_ARGS}" "$@"
+    else
+        "$MVN_CMD" "${MVN_ARGS[@]}" "$@"
+    fi
 fi
 

--- a/auron-build.sh
+++ b/auron-build.sh
@@ -139,7 +139,7 @@ UNIFFLE_VER=""
 PAIMON_VER=""
 ICEBERG_VER=""
 HUDI_VER=""
-MAVEN_OPTS=""
+MVN_D_ARGS=""
 
 # -----------------------------------------------------------------------------
 # Section: Argument Parsing
@@ -351,7 +351,7 @@ while [[ $# -gt 0 ]]; do
             ;;
         -*)
             if [[ "$1" == -D* ]]; then
-                MAVEN_OPTS="$MAVEN_OPTS $1"
+                MVN_D_ARGS="$MVN_D_ARGS $1"
                 shift
             else
                 break
@@ -569,9 +569,9 @@ if [[ "$USE_DOCKER" == true ]]; then
     export BUILD_CONTEXT="./${IMAGE_NAME}"
     exec docker-compose -f dev/docker-build/docker-compose.yml up --abort-on-container-exit
 else
-    echo "[INFO] Compiling locally with maven args: $MVN_CMD ${MVN_ARGS[@]} ${MAVEN_OPTS} $@"
-    if [[ -n "$MAVEN_OPTS" ]]; then
-        "$MVN_CMD" "${MVN_ARGS[@]}" "${MAVEN_OPTS}" "$@"
+    echo "[INFO] Compiling locally with maven args: $MVN_CMD ${MVN_ARGS[@]} ${MVN_D_ARGS} $@"
+    if [[ -n "$MVN_D_ARGS" ]]; then
+        "$MVN_CMD" "${MVN_ARGS[@]}" "${MVN_D_ARGS}" "$@"
     else
         "$MVN_CMD" "${MVN_ARGS[@]}" "$@"
     fi

--- a/auron-build.sh
+++ b/auron-build.sh
@@ -570,10 +570,6 @@ if [[ "$USE_DOCKER" == true ]]; then
     exec docker-compose -f dev/docker-build/docker-compose.yml up --abort-on-container-exit
 else
     echo "[INFO] Compiling locally with maven args: $MVN_CMD ${MVN_ARGS[@]} ${MVN_D_ARGS} $@"
-    if [[ -n "$MVN_D_ARGS" ]]; then
-        "$MVN_CMD" "${MVN_ARGS[@]}" "${MVN_D_ARGS}" "$@"
-    else
-        "$MVN_CMD" "${MVN_ARGS[@]}" "$@"
-    fi
+    "$MVN_CMD" "${MVN_ARGS[@]}" "${MVN_D_ARGS[@]}" "$@"
 fi
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2227 

# Rationale for this change

When a -D Maven system property (e.g. -DskipBuildNative) appears before other command-line options, the script stops parsing further arguments, causing valid options after it to be ignored.

EG

sh auron-build.sh --pre --sparkver 3.5 --scalaver 2.12 -DskipBuildNative --sparktests true

Once a -D* argument is encountered, the argument parsing stops (due to break logic in -* handler).
Any options appearing after -D* (e.g. --sparktests, --sparkver) are not parsed.

ERROR INFO

`
[INFO] Starting Apache Auron build...

Unable to parse command line options: Unrecognized option: --sparktests

usage: mvn [options] [<goal(s)>] [<phase(s)>]

Options:
-am,--also-make If project list is specified,
also build projects required by

`

# What changes are included in this PR?
Handle -D* separately and do not break parsing:

After this PR change, the build command now executes correctly.

sh auron-build.sh --pre --sparkver 3.5 --scalaver 2.12 -DskipBuildNative --sparktests true

sh auron-build.sh --pre --sparkver 3.5 --scalaver 2.12 -DskipBuildNative --sparktests true  -Dscalafix.mode=CHECK


# Are there any user-facing changes?

# How was this patch tested?
