### PR TITLE
[AURON #2229] bugfix Silent fallback to empty partitions may cause data loss

### DIFF
--- a/thirdparty/auron-iceberg/src/main/scala/org/apache/spark/sql/auron/iceberg/IcebergScanSupport.scala
+++ b/thirdparty/auron-iceberg/src/main/scala/org/apache/spark/sql/auron/iceberg/IcebergScanSupport.scala
@@ -190,7 +190,10 @@ object IcebergScanSupport extends Logging {
         logWarning(
           s"Failed to obtain input partitions via reflection for ${exec.getClass.getName}.",
           t)
-        Seq.empty
+        throw new IllegalStateException(
+          s"Cannot resolve input partitions for ${exec.getClass.getName}",
+          t
+        )
     }
   }
 

--- a/thirdparty/auron-iceberg/src/main/scala/org/apache/spark/sql/auron/iceberg/IcebergScanSupport.scala
+++ b/thirdparty/auron-iceberg/src/main/scala/org/apache/spark/sql/auron/iceberg/IcebergScanSupport.scala
@@ -192,8 +192,7 @@ object IcebergScanSupport extends Logging {
           t)
         throw new IllegalStateException(
           s"Cannot resolve input partitions for ${exec.getClass.getName}",
-          t
-        )
+          t)
     }
   }
 

--- a/thirdparty/auron-iceberg/src/main/scala/org/apache/spark/sql/auron/iceberg/IcebergScanSupport.scala
+++ b/thirdparty/auron-iceberg/src/main/scala/org/apache/spark/sql/auron/iceberg/IcebergScanSupport.scala
@@ -78,7 +78,14 @@ object IcebergScanSupport extends Logging {
       return None
     }
 
-    val partitions = inputPartitions(exec)
+    val partitions =
+      try {
+        inputPartitions(exec)
+      } catch {
+        case e: IllegalStateException =>
+          logWarning(s"get Partition error: ${e.getMessage}")
+          return None
+      }
     // Empty scan (e.g. empty table) should still build a plan to return no rows.
     if (partitions.isEmpty) {
       logWarning(s"Native Iceberg scan planned with empty partitions for $scanClassName.")

--- a/thirdparty/auron-iceberg/src/main/scala/org/apache/spark/sql/auron/iceberg/IcebergScanSupport.scala
+++ b/thirdparty/auron-iceberg/src/main/scala/org/apache/spark/sql/auron/iceberg/IcebergScanSupport.scala
@@ -83,7 +83,7 @@ object IcebergScanSupport extends Logging {
         inputPartitions(exec)
       } catch {
         case e: IllegalStateException =>
-          logWarning(s"get Partition error: ${e.getMessage}")
+          logWarning(s"Get Partition error: ${e.getMessage}")
           return None
       }
     // Empty scan (e.g. empty table) should still build a plan to return no rows.

--- a/thirdparty/auron-iceberg/src/main/scala/org/apache/spark/sql/auron/iceberg/IcebergScanSupport.scala
+++ b/thirdparty/auron-iceberg/src/main/scala/org/apache/spark/sql/auron/iceberg/IcebergScanSupport.scala
@@ -82,7 +82,7 @@ object IcebergScanSupport extends Logging {
       try {
         inputPartitions(exec)
       } catch {
-        case e: IllegalStateException =>
+        case e: Throwable =>
           logWarning(s"Get Partition error: ${e.getMessage}")
           return None
       }


### PR DESCRIPTION
… #2229

# Which issue does this PR close?

Closes #2229

# Rationale for this change
The current implementation silently falls back to Seq.empty when both DataSource V2 and reflective partition retrieval fail. This may lead to empty input partitions without any failure signal, potentially causing silent data loss or empty query results.

**Problem Description**

In inputPartitions(exec: BatchScanExec), when partition planning fails:

V2 API failure → caught and ignored
Reflection failure → caught and ignored
Final fallback → Seq.empty

`
catch { 
       case t: Throwable => logWarning(...) 
      Seq.empty 
}
`


and

`
catch { 
       case t: Throwable => logWarning(...) 
      Seq.empty 
}
`

**Risk**

Returning an empty partition list is dangerous because:

1. Silent data loss
Downstream execution may interpret empty partitions as:

2. no data available
valid empty scan result

→ leads to incorrect empty query results without failure

Hard to detect in production
Only warning logs are emitted
No exception or job failure
Easy to miss in large pipelines

3. Misleading semantics
A scan failure (cannot plan partitions) is semantically different from:

dataset is actually empty

But both are currently indistinguishable.



# What changes are included in this PR?
**Expected Behavior**

When both:

V2 planInputPartitions
reflection-based partition retrieval

fail, the system should:

Fail fast with a clear exception:

throw new IllegalStateException( s"Failed to plan input partitions for ${exec.getClass.getName}")




# Are there any user-facing changes?

Nothing.

# How was this patch tested?

Depends on existing unit tests.

