### PR TITLE
[AURON #2231] Empty partitions case incorrectly defaults file format to PARQUET in Iceberg scan planning 

### DIFF
--- a/thirdparty/auron-iceberg/src/main/scala/org/apache/iceberg/spark/source/IcebergResolveFileFormatUtil.scala
+++ b/thirdparty/auron-iceberg/src/main/scala/org/apache/iceberg/spark/source/IcebergResolveFileFormatUtil.scala
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.iceberg.spark.source
+
+import java.util.Locale
+
+import scala.jdk.CollectionConverters.{asScalaBufferConverter, collectionAsScalaIterableConverter}
+
+import org.apache.iceberg.{CombinedScanTask, FileFormat, FileScanTask, ScanTask}
+import org.apache.spark.sql.connector.read.Scan
+
+object IcebergResolveFileFormatUtil {
+  private val PARQUET_STRING = "parquet"
+  private val ORC_STRING = "orc"
+  private val FORMAT_STRING = "format"
+  private val WRITE_FORMAT_DEFAULT = "write.format.default"
+
+  def resolveFileFormat(scan: Scan): FileFormat = scan match {
+    case scan: SparkBatchQueryScan =>
+      val tasks = scan.tasks().asScala.toList
+      // get format info from tasks
+      if (tasks.nonEmpty) {
+        val formats = asFileScanTask(tasks).map(_.file().format()).distinct
+        formats match {
+          case Seq(FileFormat.PARQUET) =>
+            FileFormat.PARQUET
+          case Seq(FileFormat.ORC) =>
+            FileFormat.ORC
+          case Seq(other) =>
+            throw new UnsupportedOperationException(s"Unsupported Iceberg file format: $other")
+          case multi =>
+            throw new IllegalStateException(s"Mixed file formats are not supported: $multi")
+        }
+      } else {
+        // if tasks is empty, get format info from table properties
+        val props = scan.table().properties()
+        val formatStr =
+          Option(props.get(WRITE_FORMAT_DEFAULT))
+            .orElse(Option(props.get(FORMAT_STRING)))
+            .getOrElse(PARQUET_STRING)
+
+        formatStr.toLowerCase(Locale.ROOT) match {
+          case PARQUET_STRING => FileFormat.PARQUET
+          case ORC_STRING => FileFormat.ORC
+          case other =>
+            throw new UnsupportedOperationException(s"Unsupported Iceberg file format: $other")
+        }
+      }
+    case _ =>
+      throw new UnsupportedOperationException("Only support iceberg SparkBatchQueryScan.")
+  }
+
+  private def asFileScanTask(tasks: List[ScanTask]): List[FileScanTask] = {
+    if (tasks.forall(_.isFileScanTask)) {
+      tasks.map(_.asFileScanTask())
+    } else if (tasks.forall(_.isInstanceOf[CombinedScanTask])) {
+      tasks.flatMap(_.asCombinedScanTask().tasks().asScala)
+    } else {
+      throw new UnsupportedOperationException(
+        "Only support iceberg CombinedScanTask and FileScanTask.")
+    }
+  }
+}

--- a/thirdparty/auron-iceberg/src/main/scala/org/apache/spark/sql/auron/iceberg/IcebergScanSupport.scala
+++ b/thirdparty/auron-iceberg/src/main/scala/org/apache/spark/sql/auron/iceberg/IcebergScanSupport.scala
@@ -21,6 +21,7 @@ import scala.util.control.NonFatal
 
 import org.apache.iceberg.{FileFormat, FileScanTask, MetadataColumns}
 import org.apache.iceberg.expressions.{And => IcebergAnd, BoundPredicate, Expression => IcebergExpression, Not => IcebergNot, Or => IcebergOr, UnboundPredicate}
+import org.apache.iceberg.spark.source.IcebergResolveFileFormatUtil
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.auron.NativeConverters
 import org.apache.spark.sql.catalyst.expressions.{And => SparkAnd, AttributeReference, EqualTo, Expression => SparkExpression, GreaterThan, GreaterThanOrEqual, In, IsNaN, IsNotNull, IsNull, LessThan, LessThanOrEqual, Literal, Not => SparkNot, Or => SparkOr}
@@ -79,13 +80,15 @@ object IcebergScanSupport extends Logging {
     }
 
     val partitions = inputPartitions(exec)
+
+    val fileFormat = IcebergResolveFileFormatUtil.resolveFileFormat(exec.scan)
     // Empty scan (e.g. empty table) should still build a plan to return no rows.
     if (partitions.isEmpty) {
       logWarning(s"Native Iceberg scan planned with empty partitions for $scanClassName.")
       return Some(
         IcebergScanPlan(
           Seq.empty,
-          FileFormat.PARQUET,
+          fileFormat,
           readSchema,
           fileSchema,
           partitionSchema,

--- a/thirdparty/auron-iceberg/src/test/scala/org/apache/auron/iceberg/AuronIcebergIntegrationSuite.scala
+++ b/thirdparty/auron-iceberg/src/test/scala/org/apache/auron/iceberg/AuronIcebergIntegrationSuite.scala
@@ -24,6 +24,7 @@ import org.apache.iceberg.{FileFormat, FileScanTask}
 import org.apache.iceberg.data.{GenericAppenderFactory, Record}
 import org.apache.iceberg.deletes.PositionDelete
 import org.apache.iceberg.spark.Spark3Util
+import org.apache.iceberg.spark.source.IcebergResolveFileFormatUtil.resolveFileFormat
 import org.apache.spark.sql.{DataFrame, Row}
 import org.apache.spark.sql.auron.iceberg.IcebergScanSupport
 import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
@@ -31,6 +32,36 @@ import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
 class AuronIcebergIntegrationSuite
     extends org.apache.spark.sql.QueryTest
     with BaseAuronIcebergSuite {
+
+  test("empty iceberg table should still resolve correct format") {
+    withTable("local.db.t1") {
+      sql(
+        "create table local.db.t1(id int) using iceberg TBLPROPERTIES ('write.format.default'='orc')")
+      val df = spark.sql("SELECT * FROM local.db.t1")
+
+      val scanExec = df.queryExecution.executedPlan.collectFirst { case e: BatchScanExec =>
+        e
+      }.get
+
+      val format = resolveFileFormat(scanExec.scan)
+      assert(format == FileFormat.ORC)
+    }
+  }
+
+  test("empty iceberg scan should preserve ORC file format") {
+    withTable("local.db.t1") {
+      sql(
+        "CREATE TABLE local.db.t1 (id INT) USING iceberg TBLPROPERTIES ('write.format.default'='orc')")
+      sql("INSERT INTO local.db.t1 VALUES (1), (2)")
+      val df = spark.sql("SELECT * FROM iceberg_orc_table WHERE id > 100")
+      val executedPlan = df.queryExecution.executedPlan
+      val scanExec = executedPlan.collectFirst { case e: BatchScanExec =>
+        e
+      }.get
+      val format = resolveFileFormat(scanExec.scan)
+      assert(format == FileFormat.ORC)
+    }
+  }
 
   test("test iceberg integrate ") {
     withTable("local.db.t1") {


### PR DESCRIPTION
…to PARQUET in Iceberg scan planning

# Which issue does this PR close?

Closes #2231 

# Rationale for this change

In Iceberg scan planning, when inputPartitions(exec) returns empty, the code incorrectly defaults FileFormat.PARQUET, which can lead to incorrect file format inference and potential runtime errors.


**When partitions.isEmpty, the code assumes the file format is always PARQUET.**

However, in Iceberg:

File format is determined by table metadata, not scan results
Tables may use ORC / Avro / Parquet / mixed formats
Empty partitions do NOT imply Parquet



# What changes are included in this PR?
Fix incorrect file format inference when Iceberg scan has empty input partitions.

Previously, the planner defaulted to PARQUET when no partitions were returned, which is incorrect for non-Parquet Iceberg tables (e.g. ORC).


- Introduce resolveFileFormat() to derive file format from:
  1. Scan tasks (if available)
  2. Iceberg table metadata (write.format.default) as fallback

- Replace hardcoded PARQUET with resolved format in empty scan case
- Fix incorrect planning for non-Parquet Iceberg tables
- Prevent potential runtime format mismatch


# Are there any user-facing changes?
Nothing.

# How was this patch tested?
- Add test for ORC table with empty scan (filter pushdown)
- Add test for empty Iceberg table

