### PR TITLE
[AURON #2240] Implement native function of make_date #2240

### DIFF
--- a/native-engine/auron-planner/proto/auron.proto
+++ b/native-engine/auron-planner/proto/auron.proto
@@ -287,6 +287,7 @@ enum ScalarFunction {
   Nvl2=83;
   Least=84;
   Greatest=85;
+  MakeDate=86;
   AuronExtFunctions=10000;
 }
 

--- a/native-engine/auron-planner/src/planner.rs
+++ b/native-engine/auron-planner/src/planner.rs
@@ -1301,6 +1301,7 @@ impl From<protobuf::ScalarFunction> for Arc<ScalarUDF> {
             ScalarFunction::ToTimestampMicros => f::datetime::to_timestamp_micros(),
             ScalarFunction::ToTimestampSeconds => f::datetime::to_timestamp_seconds(),
             ScalarFunction::Now => f::datetime::now(),
+            ScalarFunction::MakeDate => f::datetime::make_date(),
             ScalarFunction::Translate => f::unicode::translate(),
             ScalarFunction::RegexpMatch => f::regex::regexp_match(),
             ScalarFunction::Greatest => f::core::greatest(),

--- a/spark-extension-shims-spark/src/test/scala/org/apache/auron/AuronFunctionSuite.scala
+++ b/spark-extension-shims-spark/src/test/scala/org/apache/auron/AuronFunctionSuite.scala
@@ -16,12 +16,13 @@
  */
 package org.apache.auron
 
+import java.sql.Date
 import java.text.SimpleDateFormat
+
 import org.apache.spark.sql.{AuronQueryTest, Row}
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.auron.util.AuronTestUtils
 
-import java.sql.Date
+import org.apache.auron.util.AuronTestUtils
 
 class AuronFunctionSuite extends AuronQueryTest with BaseAuronSQLSuite {
 

--- a/spark-extension-shims-spark/src/test/scala/org/apache/auron/AuronFunctionSuite.scala
+++ b/spark-extension-shims-spark/src/test/scala/org/apache/auron/AuronFunctionSuite.scala
@@ -997,6 +997,23 @@ class AuronFunctionSuite extends AuronQueryTest with BaseAuronSQLSuite {
     }
   }
 
+  test("test function make_date") {
+    withTable("t1") {
+      sql(
+        "create table t1 using parquet as select '2025'" +
+          " as year, '03' as month, '01' as day")
+      val functions =
+        """
+          |select
+          |  make_date(year, month, day)
+          |from t1
+         """.stripMargin
+
+      val df = sql(functions)
+      checkAnswer(df, Seq(Row("2025-03-01")))
+    }
+  }
+
   test("months_between function") {
     withSQLConf("spark.sql.session.timeZone" -> "UTC") {
       withTable("t1") {

--- a/spark-extension-shims-spark/src/test/scala/org/apache/auron/AuronFunctionSuite.scala
+++ b/spark-extension-shims-spark/src/test/scala/org/apache/auron/AuronFunctionSuite.scala
@@ -17,11 +17,11 @@
 package org.apache.auron
 
 import java.text.SimpleDateFormat
-
 import org.apache.spark.sql.{AuronQueryTest, Row}
 import org.apache.spark.sql.internal.SQLConf
-
 import org.apache.auron.util.AuronTestUtils
+
+import java.sql.Date
 
 class AuronFunctionSuite extends AuronQueryTest with BaseAuronSQLSuite {
 
@@ -1010,7 +1010,7 @@ class AuronFunctionSuite extends AuronQueryTest with BaseAuronSQLSuite {
          """.stripMargin
 
       val df = sql(functions)
-      checkAnswer(df, Seq(Row("2025-03-01")))
+      checkAnswer(df, Seq(Row(Date.valueOf("2025-03-01"))))
     }
   }
 

--- a/spark-extension/src/main/scala/org/apache/spark/sql/auron/NativeConverters.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/auron/NativeConverters.scala
@@ -832,6 +832,7 @@ object NativeConverters extends Logging {
       case e: Acosh => buildScalarFunction(pb.ScalarFunction.Acosh, e.children, e.dataType)
       case e: Atan => buildScalarFunction(pb.ScalarFunction.Atan, e.children, e.dataType)
       case e: Exp => buildScalarFunction(pb.ScalarFunction.Exp, e.children, e.dataType)
+      case e: MakeDate => buildScalarFunction(pb.ScalarFunction.MakeDate, e.children, e.dataType)
       case e: Log =>
         buildScalarFunction(pb.ScalarFunction.Ln, e.children.map(nullIfNegative), e.dataType)
       case e: Log2 =>


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2240

# Rationale for this change

Spark SQL provides the `make_date` function to construct a date from year, month, and day components. To improve query performance, this PR implements native support for `make_date` in Auron's execution engine, allowing this function to be executed natively instead of falling back to Spark's JVM-based implementation.

# What changes are included in this PR?

- Protocol Buffer definition
- Planner mapping
- Spark-to-Native converter 
- Test coverage

# Are there any user-facing changes?

No.

# How was this patch tested?

- Added unit test