### PR TITLE
[AURON #2236] Support compile with Celeborn 0.6 and spark 4.0

### DIFF
--- a/spark-extension/src/main/scala/org/apache/spark/sql/auron/NativeRDD.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/auron/NativeRDD.scala
@@ -67,8 +67,10 @@ class NativeRDD(
   override def compute(split: Partition, context: TaskContext): Iterator[InternalRow] = {
     val computingNativePlan = nativePlanWrapper.plan(split, context)
 
-    // SPARK-44605: Spark 4+ refines ShuffleWriteProcessor API (early execution of NativeRDD.ShuffleWrite iterator)
-    // Adaptation for Spark 4.x: Defer NativeRDD.ShuffleWrite execution to ShuffleWriteProcessor.write() to align with Spark 3.x logic
+    // SPARK-44605: Spark 4+ refines ShuffleWriteProcessor API (early execution of native
+    // shuffle-writer iterators). Adaptation for Spark 4.x: defer both native shuffle-writer
+    // plan types (SHUFFLE_WRITER and RSS_SHUFFLE_WRITER) to ShuffleWriteProcessor.write() to
+    // align with Spark 3.x logic.
     if (SparkVersionUtil.isSparkV40OrGreater && (computingNativePlan.getPhysicalPlanTypeCase == PhysicalPlanNode.PhysicalPlanTypeCase.SHUFFLE_WRITER
         || computingNativePlan.getPhysicalPlanTypeCase == PhysicalPlanNode.PhysicalPlanTypeCase.RSS_SHUFFLE_WRITER)) {
       Iterator.empty

--- a/spark-extension/src/main/scala/org/apache/spark/sql/auron/NativeRDD.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/auron/NativeRDD.scala
@@ -69,9 +69,8 @@ class NativeRDD(
 
     // SPARK-44605: Spark 4+ refines ShuffleWriteProcessor API (early execution of NativeRDD.ShuffleWrite iterator)
     // Adaptation for Spark 4.x: Defer NativeRDD.ShuffleWrite execution to ShuffleWriteProcessor.write() to align with Spark 3.x logic
-    if (SparkVersionUtil.isSparkV40OrGreater &&
-      computingNativePlan.getPhysicalPlanTypeCase == PhysicalPlanNode.PhysicalPlanTypeCase.SHUFFLE_WRITER
-      ||  computingNativePlan.getPhysicalPlanTypeCase == PhysicalPlanNode.PhysicalPlanTypeCase.RSS_SHUFFLE_WRITER) {
+    if (SparkVersionUtil.isSparkV40OrGreater && (computingNativePlan.getPhysicalPlanTypeCase == PhysicalPlanNode.PhysicalPlanTypeCase.SHUFFLE_WRITER
+        || computingNativePlan.getPhysicalPlanTypeCase == PhysicalPlanNode.PhysicalPlanTypeCase.RSS_SHUFFLE_WRITER)) {
       Iterator.empty
     } else {
       NativeHelper.executeNativePlan(computingNativePlan, metrics, split, Some(context))

--- a/spark-extension/src/main/scala/org/apache/spark/sql/auron/NativeRDD.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/auron/NativeRDD.scala
@@ -70,7 +70,8 @@ class NativeRDD(
     // SPARK-44605: Spark 4+ refines ShuffleWriteProcessor API (early execution of NativeRDD.ShuffleWrite iterator)
     // Adaptation for Spark 4.x: Defer NativeRDD.ShuffleWrite execution to ShuffleWriteProcessor.write() to align with Spark 3.x logic
     if (SparkVersionUtil.isSparkV40OrGreater &&
-      computingNativePlan.getPhysicalPlanTypeCase == PhysicalPlanNode.PhysicalPlanTypeCase.SHUFFLE_WRITER) {
+      computingNativePlan.getPhysicalPlanTypeCase == PhysicalPlanNode.PhysicalPlanTypeCase.SHUFFLE_WRITER
+      ||  computingNativePlan.getPhysicalPlanTypeCase == PhysicalPlanNode.PhysicalPlanTypeCase.RSS_SHUFFLE_WRITER) {
       Iterator.empty
     } else {
       NativeHelper.executeNativePlan(computingNativePlan, metrics, split, Some(context))

--- a/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/shuffle/AuronRssShuffleWriterBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/shuffle/AuronRssShuffleWriterBase.scala
@@ -78,7 +78,7 @@ abstract class AuronRssShuffleWriterBase[K, V](metrics: ShuffleWriteMetricsRepor
 
   def rssStop(success: Boolean): Option[MapStatus]
 
-  @sparkver("3.2 / 3.3 / 3.4 / 3.5")
+  @sparkver("3.2 / 3.3 / 3.4 / 3.5 / 4.0")
   override def getPartitionLengths(): Array[Long] = rpw.getPartitionLengthMap
 
   override def write(records: Iterator[Product2[K, V]]): Unit = {

--- a/thirdparty/auron-celeborn-0.6/src/main/scala/org/apache/spark/sql/execution/auron/shuffle/celeborn/AuronCelebornShuffleWriter.scala
+++ b/thirdparty/auron-celeborn-0.6/src/main/scala/org/apache/spark/sql/execution/auron/shuffle/celeborn/AuronCelebornShuffleWriter.scala
@@ -63,7 +63,7 @@ class AuronCelebornShuffleWriter[K, V](
     celebornPartitionWriter
   }
 
-  @sparkver("3.2 / 3.3 / 3.4 / 3.5")
+  @sparkver("3.2 / 3.3 / 3.4 / 3.5 / 4.0")
   override def getPartitionLengths(): Array[Long] = {
     celebornPartitionWriter.getPartitionLengthMap
   }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2236 

# Rationale for this change
Spark 4.0 has been release for over 1 year, and celeborn 0.6 provides official spark 4.0 support.

This change will add spark 4.0 support when auron is compiled with spark 4.0 and celeborn 0.6.

Spark 4.1 supported is not included in this PR since latest celeborn version does not support this configuration. Spark 4.1 also changed signature of Mapstatus.apply(), which demands heavy changes to codebase.

# What changes are included in this PR?

# Are there any user-facing changes?
no

# How was this patch tested?
Tested in our staging env