### PR TITLE
[AURON #2250] Add native Hudi scan coverage for partitioned COW tables

### DIFF
--- a/thirdparty/auron-hudi/src/test/scala/org/apache/spark/sql/auron/hudi/HudiScanSupportSuite.scala
+++ b/thirdparty/auron-hudi/src/test/scala/org/apache/spark/sql/auron/hudi/HudiScanSupportSuite.scala
@@ -23,9 +23,12 @@ import java.util.Properties
 
 import org.apache.spark.SparkConf
 import org.apache.spark.SparkFunSuite
-import org.apache.spark.sql.Row
+import org.apache.spark.sql.{DataFrame, Row}
+import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.execution.FileSourceScanExec
 import org.apache.spark.sql.execution.auron.plan.NativeOrcScanBase
 import org.apache.spark.sql.execution.auron.plan.NativeParquetScanBase
+import org.apache.spark.sql.execution.auron.plan.NativeParquetScanExec
 import org.apache.spark.sql.test.SharedSparkSession
 
 import org.apache.auron.util.SparkVersionUtil
@@ -125,6 +128,41 @@ class HudiScanSupportSuite extends SparkFunSuite with SharedSparkSession {
     assert(df.queryExecution.executedPlan.collect { case _: NativeParquetScanBase =>
       true
     }.isEmpty)
+  }
+
+  private def fileSourceScanFromPlan(
+      plan: org.apache.spark.sql.execution.SparkPlan): Option[FileSourceScanExec] =
+    plan.collectFirst {
+      case scan: FileSourceScanExec =>
+        scan
+      case nativeScan: NativeParquetScanExec =>
+        nativeScan.basedFileScan
+    }
+
+  private def assertProviderConvertsToNativeParquetScan(df: DataFrame): FileSourceScanExec = {
+    val plan = materializedPlan(df)
+    val preAqePlan = df.queryExecution.sparkPlan
+    val scan = fileSourceScanFromPlan(plan)
+      .orElse(fileSourceScanFromPlan(preAqePlan))
+      .getOrElse {
+        fail(
+          "Expected FileSourceScanExec or NativeParquetScanExec in Hudi scan plan.\n" +
+            s"Materialized plan:\n$plan\nPre-AQE plan:\n$preAqePlan")
+      }
+    val provider = new HudiConvertProvider
+    assert(provider.isSupported(scan))
+    val converted = provider.convert(scan)
+    assertHasNativeParquetScan(converted)
+    scan
+  }
+
+  private def assertFilterReferences(
+      filters: Seq[Expression],
+      attributeName: String,
+      filterType: String): Unit = {
+    assert(
+      filters.exists(_.references.exists(_.name == attributeName)),
+      s"Expected $filterType filters to reference $attributeName, but got: $filters")
   }
 
   private def logFileFormats(df: org.apache.spark.sql.DataFrame): Unit = {
@@ -413,6 +451,56 @@ class HudiScanSupportSuite extends SparkFunSuite with SharedSparkSession {
       assert(provider.isSupported(scan.get))
       val converted = provider.convert(scan.get)
       assertHasNativeParquetScan(converted)
+    }
+  }
+
+  test("hudi: partitioned COW parquet scan converts to native with filters") {
+    withTable("hudi_partitioned_cow") {
+      spark.sql("""create table hudi_partitioned_cow (id int, name string, dt string)
+          |using hudi
+          |partitioned by (dt)
+          |tblproperties (
+          |  'hoodie.datasource.write.table.type' = 'cow'
+          |)""".stripMargin)
+      spark.sql("""insert into hudi_partitioned_cow values
+          |  (1, 'v1', '2026-05-01'),
+          |  (2, 'v2', '2026-05-01'),
+          |  (3, 'v3', '2026-05-02')
+          |""".stripMargin)
+
+      val fullScan = spark.sql("select id, name, dt from hudi_partitioned_cow order by id")
+      logFileFormats(fullScan)
+      assert(
+        fullScan.collect().toSeq == Seq(
+          Row(1, "v1", "2026-05-01"),
+          Row(2, "v2", "2026-05-01"),
+          Row(3, "v3", "2026-05-02")))
+      assertProviderConvertsToNativeParquetScan(fullScan)
+
+      val partitionPruned = spark.sql("""
+          |select id, name, dt
+          |from hudi_partitioned_cow
+          |where dt = '2026-05-01'
+          |order by id
+          |""".stripMargin)
+      logFileFormats(partitionPruned)
+      assert(
+        partitionPruned.collect().toSeq == Seq(
+          Row(1, "v1", "2026-05-01"),
+          Row(2, "v2", "2026-05-01")))
+      val partitionScan = assertProviderConvertsToNativeParquetScan(partitionPruned)
+      assertFilterReferences(partitionScan.partitionFilters, "dt", "partition")
+
+      val partitionAndDataFiltered = spark.sql("""
+          |select id, name, dt
+          |from hudi_partitioned_cow
+          |where dt = '2026-05-01' and id = 2
+          |""".stripMargin)
+      logFileFormats(partitionAndDataFiltered)
+      assert(partitionAndDataFiltered.collect().toSeq == Seq(Row(2, "v2", "2026-05-01")))
+      val filteredScan = assertProviderConvertsToNativeParquetScan(partitionAndDataFiltered)
+      assertFilterReferences(filteredScan.partitionFilters, "dt", "partition")
+      assertFilterReferences(filteredScan.dataFilters, "id", "data")
     }
   }
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2250 

# Rationale for this change

Partitioned COW Hudi tables are a common use case, but native Hudi scan coverage currently focuses on simple non-partitioned COW tables and fallback cases. Adding partitioned table coverage helps catch regressions around partition pruning and mixed partition/data filters.

# What changes are included in this PR?

Add a partitioned COW Parquet Hudi table test.
- Verify full scan query result correctness.
- Verify partition pruning with a partition filter.
- Verify combined partition filter and data filter.
- Verify the Hudi convert provider can convert the scan to native Parquet scan.

# Are there any user-facing changes?

No. This PR only adds test coverage.

# How was this patch tested?
- Added Hudi scan support suite coverage.

