### PR TITLE
[AURON #2260] Add support for Spark 4.0 and 4.1 in build workflows

### DIFF
--- a/.github/workflows/build-amd64-releases.yml
+++ b/.github/workflows/build-amd64-releases.yml
@@ -128,7 +128,7 @@ jobs:
 
       - name: Build auron-${{ matrix.sparkver }}_${{ matrix.scalaver }}
         env:
-          JAVA_VERSION: ${{ matrix.javaver }}
+          AURON_JAVA_VERSION: ${{ matrix.javaver }}
         run: |
           sed -i 's/docker-compose -f/docker compose -f/g' ./auron-build.sh
           ./auron-build.sh \

--- a/.github/workflows/build-amd64-releases.yml
+++ b/.github/workflows/build-amd64-releases.yml
@@ -73,6 +73,13 @@ jobs:
             javaver: '8'
           - sparkver: spark-4.1
             javaver: '8'
+          # Spark 4.x JDK 21 builds are handled by explicit rockylinux8 include entries below.
+          - sparkver: spark-4.0
+            scalaver: '2.13'
+            javaver: '21'
+          - sparkver: spark-4.1
+            scalaver: '2.13'
+            javaver: '21'
         include:
           # Spark 4.x uses rockylinux8 image (with JDK 21)
           - sparkver: spark-4.0

--- a/.github/workflows/build-amd64-releases.yml
+++ b/.github/workflows/build-amd64-releases.yml
@@ -85,14 +85,10 @@ jobs:
           - sparkver: spark-4.0
             scalaver: '2.13'
             javaver: '21'
-            auronver: 8.0.0-SNAPSHOT
-            runner: ubuntu-24.04
             image: rockylinux8
           - sparkver: spark-4.1
             scalaver: '2.13'
             javaver: '21'
-            auronver: 8.0.0-SNAPSHOT
-            runner: ubuntu-24.04
             image: rockylinux8
 
     steps:

--- a/.github/workflows/build-amd64-releases.yml
+++ b/.github/workflows/build-amd64-releases.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
-        sparkver: [spark-3.0, spark-3.1, spark-3.2, spark-3.3, spark-3.4, spark-3.5]
+        sparkver: [spark-3.0, spark-3.1, spark-3.2, spark-3.3, spark-3.4, spark-3.5, spark-4.0, spark-4.1]
         scalaver: [ 2.12, 2.13 ]
         javaver: [ 8, 21 ]
         auronver: [8.0.0-SNAPSHOT]
@@ -64,6 +64,15 @@ jobs:
             javaver: '21'
           - sparkver: spark-3.4
             javaver: '21'
+          # Spark 4.x only supports scala-2.13 and java 17+
+          - sparkver: spark-4.0
+            scalaver: '2.12'
+          - sparkver: spark-4.1
+            scalaver: '2.12'
+          - sparkver: spark-4.0
+            javaver: '8'
+          - sparkver: spark-4.1
+            javaver: '8'
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/build-amd64-releases.yml
+++ b/.github/workflows/build-amd64-releases.yml
@@ -43,7 +43,7 @@ jobs:
         auronver: [8.0.0-SNAPSHOT]
         runner: [ ubuntu-24.04 ]
         exclude:
-          # Only build on scala-2.13 for spark-3.5
+          # Only build on scala-2.13 for spark-3.5+
           - sparkver: spark-3.0
             scalaver: '2.13'
           - sparkver: spark-3.1
@@ -73,6 +73,20 @@ jobs:
             javaver: '8'
           - sparkver: spark-4.1
             javaver: '8'
+        include:
+          # Spark 4.x uses rockylinux8 image (with JDK 21)
+          - sparkver: spark-4.0
+            scalaver: '2.13'
+            javaver: '21'
+            auronver: 8.0.0-SNAPSHOT
+            runner: ubuntu-24.04
+            image: rockylinux8
+          - sparkver: spark-4.1
+            scalaver: '2.13'
+            javaver: '21'
+            auronver: 8.0.0-SNAPSHOT
+            runner: ubuntu-24.04
+            image: rockylinux8
 
     steps:
       - uses: actions/checkout@v6
@@ -106,11 +120,13 @@ jobs:
           key: auron-${{matrix.sparkver}}_${{matrix.scalaver}}-release-${{ env.osclassfier }}-${{ matrix.auronver }}.jar
 
       - name: Build auron-${{ matrix.sparkver }}_${{ matrix.scalaver }}
+        env:
+          JAVA_VERSION: ${{ matrix.javaver }}
         run: |
           sed -i 's/docker-compose -f/docker compose -f/g' ./auron-build.sh
           ./auron-build.sh \
           --docker true \
-          --image centos7 \
+          --image ${{ matrix.image || 'centos7' }} \
           --release \
           --sparkver ${{ env.sparkver_short }} \
           --scalaver ${{ matrix.scalaver }}

--- a/.github/workflows/build-amd64-releases.yml
+++ b/.github/workflows/build-amd64-releases.yml
@@ -85,10 +85,14 @@ jobs:
           - sparkver: spark-4.0
             scalaver: '2.13'
             javaver: '21'
+            auronver: 8.0.0-SNAPSHOT
+            runner: ubuntu-24.04
             image: rockylinux8
           - sparkver: spark-4.1
             scalaver: '2.13'
             javaver: '21'
+            auronver: 8.0.0-SNAPSHOT
+            runner: ubuntu-24.04
             image: rockylinux8
 
     steps:

--- a/.github/workflows/build-arm-releases.yml
+++ b/.github/workflows/build-arm-releases.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
-        sparkver: [spark-3.0, spark-3.1, spark-3.2, spark-3.3, spark-3.4, spark-3.5]
+        sparkver: [spark-3.0, spark-3.1, spark-3.2, spark-3.3, spark-3.4, spark-3.5, spark-4.0, spark-4.1]
         auronver: [8.0.0-SNAPSHOT]
         scalaver: [2.12, 2.13]
         javaver: [ 8, 21 ]
@@ -64,6 +64,15 @@ jobs:
             javaver: '21'
           - sparkver: spark-3.4
             javaver: '21'
+          # Spark 4.x only supports scala-2.13 and java 17+
+          - sparkver: spark-4.0
+            scalaver: '2.12'
+          - sparkver: spark-4.1
+            scalaver: '2.12'
+          - sparkver: spark-4.0
+            javaver: '8'
+          - sparkver: spark-4.1
+            javaver: '8'
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/build-macos-releases.yml
+++ b/.github/workflows/build-macos-releases.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
-        sparkver: [spark-3.0, spark-3.1, spark-3.2, spark-3.3, spark-3.4, spark-3.5]
+        sparkver: [spark-3.0, spark-3.1, spark-3.2, spark-3.3, spark-3.4, spark-3.5, spark-4.0, spark-4.1]
         auronver: [8.0.0-SNAPSHOT]
         scalaver: [2.12, 2.13]
         javaver: [8, 21]
@@ -64,6 +64,15 @@ jobs:
             javaver: '21'
           - sparkver: spark-3.4
             javaver: '21'
+          # Spark 4.x only supports scala-2.13 and java 17+
+          - sparkver: spark-4.0
+            scalaver: '2.12'
+          - sparkver: spark-4.1
+            scalaver: '2.12'
+          - sparkver: spark-4.0
+            javaver: '8'
+          - sparkver: spark-4.1
+            javaver: '8'
 
     steps:
       - uses: actions/checkout@v6

--- a/auron-build.sh
+++ b/auron-build.sh
@@ -567,6 +567,10 @@ if [[ "$USE_DOCKER" == true ]]; then
     echo "[INFO] Compiling inside Docker container..."
     export AURON_BUILD_ARGS="${BUILD_ARGS[*]}"
     export BUILD_CONTEXT="./${IMAGE_NAME}"
+    # Spark 4.x requires JDK 17+, auto-set if not specified
+    if [[ -z "$AURON_JAVA_VERSION" && "$SPARK_VER" == 4.* ]]; then
+        export AURON_JAVA_VERSION="17"
+    fi
     exec docker-compose -f dev/docker-build/docker-compose.yml up --abort-on-container-exit
 else
     echo "[INFO] Compiling locally with maven args: $MVN_CMD ${MVN_ARGS[@]} ${MVN_D_ARGS} $@"

--- a/dev/docker-build/centos7/Dockerfile
+++ b/dev/docker-build/centos7/Dockerfile
@@ -44,3 +44,11 @@ RUN /rustup-init -y --default-toolchain nightly-2025-05-09-x86_64-unknown-linux-
 # install java
 RUN yum install -y java-1.8.0-openjdk java-1.8.0-openjdk-devel
 RUN echo 'export JAVA_HOME="/usr/lib/jvm/java-1.8.0-openjdk"' >> ~/.bashrc
+
+# Entrypoint script: source bashrc (for devtoolset-11, rust, java) then exec command
+RUN echo '#!/bin/bash'                                          > /usr/local/bin/entrypoint.sh && \
+    echo 'source ~/.bashrc 2>/dev/null || true'                >> /usr/local/bin/entrypoint.sh && \
+    echo 'exec "$@"'                                           >> /usr/local/bin/entrypoint.sh && \
+    chmod +x /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/dev/docker-build/centos7/Dockerfile
+++ b/dev/docker-build/centos7/Dockerfile
@@ -44,11 +44,3 @@ RUN /rustup-init -y --default-toolchain nightly-2025-05-09-x86_64-unknown-linux-
 # install java
 RUN yum install -y java-1.8.0-openjdk java-1.8.0-openjdk-devel
 RUN echo 'export JAVA_HOME="/usr/lib/jvm/java-1.8.0-openjdk"' >> ~/.bashrc
-
-# Entrypoint script: source bashrc (for devtoolset-11, rust, java) then exec command
-RUN echo '#!/bin/bash'                                          > /usr/local/bin/entrypoint.sh && \
-    echo 'source ~/.bashrc 2>/dev/null || true'                >> /usr/local/bin/entrypoint.sh && \
-    echo 'exec "$@"'                                           >> /usr/local/bin/entrypoint.sh && \
-    chmod +x /usr/local/bin/entrypoint.sh
-
-ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/dev/docker-build/docker-compose.yml
+++ b/dev/docker-build/docker-compose.yml
@@ -32,7 +32,7 @@ services:
     environment:
       RUSTFLAGS: "-C target-cpu=skylake"
       AURON_BUILD_ARGS: "${AURON_BUILD_ARGS}"
-      JAVA_VERSION: "${JAVA_VERSION:-8}"
+      AURON_JAVA_VERSION: "${AURON_JAVA_VERSION:-8}"
     command: >
       bash -c '
         cd /auron &&

--- a/dev/docker-build/docker-compose.yml
+++ b/dev/docker-build/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       AURON_JAVA_VERSION: "${AURON_JAVA_VERSION:-8}"
     command: >
       bash -c '
-        source ~/.bashrc 2>/dev/null || true &&
+        source ~/.bashrc &&
         cd /auron &&
         echo "[DOCKER] Running: ./build/mvn $AURON_BUILD_ARGS" &&
         ./build/mvn $AURON_BUILD_ARGS

--- a/dev/docker-build/docker-compose.yml
+++ b/dev/docker-build/docker-compose.yml
@@ -35,6 +35,7 @@ services:
       AURON_JAVA_VERSION: "${AURON_JAVA_VERSION:-8}"
     command: >
       bash -c '
+        source ~/.bashrc 2>/dev/null || true &&
         cd /auron &&
         echo "[DOCKER] Running: ./build/mvn $AURON_BUILD_ARGS" &&
         ./build/mvn $AURON_BUILD_ARGS

--- a/dev/docker-build/docker-compose.yml
+++ b/dev/docker-build/docker-compose.yml
@@ -32,6 +32,7 @@ services:
     environment:
       RUSTFLAGS: "-C target-cpu=skylake"
       AURON_BUILD_ARGS: "${AURON_BUILD_ARGS}"
+      JAVA_VERSION: "${JAVA_VERSION:-8}"
     command: >
       bash -c '
         source ~/.bashrc &&

--- a/dev/docker-build/docker-compose.yml
+++ b/dev/docker-build/docker-compose.yml
@@ -35,9 +35,7 @@ services:
       JAVA_VERSION: "${JAVA_VERSION:-8}"
     command: >
       bash -c '
-        source ~/.bashrc &&
         cd /auron &&
-        echo "[DOCKER] Using JAVA_HOME=$JAVA_HOME ($(java -version 2>&1 | head -1))" &&
         echo "[DOCKER] Running: ./build/mvn $AURON_BUILD_ARGS" &&
         ./build/mvn $AURON_BUILD_ARGS
       '

--- a/dev/docker-build/docker-compose.yml
+++ b/dev/docker-build/docker-compose.yml
@@ -37,6 +37,7 @@ services:
       bash -c '
         source ~/.bashrc &&
         cd /auron &&
+        echo "[DOCKER] Using JAVA_HOME=$JAVA_HOME ($(java -version 2>&1 | head -1))" &&
         echo "[DOCKER] Running: ./build/mvn $AURON_BUILD_ARGS" &&
         ./build/mvn $AURON_BUILD_ARGS
       '

--- a/dev/docker-build/rockylinux8/Dockerfile
+++ b/dev/docker-build/rockylinux8/Dockerfile
@@ -70,19 +70,23 @@ RUN dnf -y install java-1.8.0-openjdk java-1.8.0-openjdk-devel \
     dnf clean all && \
     rm -rf /var/cache/dnf
 
-# Default to JDK 8; runtime switching handled via JAVA_VERSION env var in docker-compose
-ENV JAVA_HOME="/usr/lib/jvm/java-1.8.0-openjdk"
+# Create stable symlinks (Rocky 8 installs to versioned directories)
+RUN ln -sfn /usr/lib/jvm/java-1.8.0-openjdk /usr/lib/jvm/java-8 && \
+    ln -sfn $(rpm -ql java-21-openjdk-devel | grep '/bin/javac$' | sed 's|/bin/javac||') /usr/lib/jvm/java-21
+
+ENV JAVA_HOME="/usr/lib/jvm/java-8"
 ENV PATH="${JAVA_HOME}/bin:${PATH}"
 
-# Entrypoint script to switch JDK at runtime
-RUN printf '#!/bin/bash\n\
-if [ "$JAVA_VERSION" = "21" ]; then\n\
-  export JAVA_HOME="/usr/lib/jvm/java-21-openjdk"\n\
-else\n\
-  export JAVA_HOME="/usr/lib/jvm/java-1.8.0-openjdk"\n\
-fi\n\
-export PATH="$JAVA_HOME/bin:$PATH"\n\
-exec "$@"\n' > /usr/local/bin/entrypoint.sh && \
+# Entrypoint script to switch JDK at runtime based on JAVA_VERSION env var
+RUN echo '#!/bin/bash'                                          > /usr/local/bin/entrypoint.sh && \
+    echo 'source ~/.bashrc 2>/dev/null || true'                >> /usr/local/bin/entrypoint.sh && \
+    echo 'if [ "$JAVA_VERSION" = "21" ]; then'                 >> /usr/local/bin/entrypoint.sh && \
+    echo '  export JAVA_HOME="/usr/lib/jvm/java-21"'           >> /usr/local/bin/entrypoint.sh && \
+    echo 'else'                                                >> /usr/local/bin/entrypoint.sh && \
+    echo '  export JAVA_HOME="/usr/lib/jvm/java-8"'            >> /usr/local/bin/entrypoint.sh && \
+    echo 'fi'                                                  >> /usr/local/bin/entrypoint.sh && \
+    echo 'export PATH="$JAVA_HOME/bin:$PATH"'                  >> /usr/local/bin/entrypoint.sh && \
+    echo 'exec "$@"'                                           >> /usr/local/bin/entrypoint.sh && \
     chmod +x /usr/local/bin/entrypoint.sh
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/dev/docker-build/rockylinux8/Dockerfile
+++ b/dev/docker-build/rockylinux8/Dockerfile
@@ -77,10 +77,10 @@ RUN ln -sfn /usr/lib/jvm/java-1.8.0-openjdk /usr/lib/jvm/java-8 && \
 ENV JAVA_HOME="/usr/lib/jvm/java-8"
 ENV PATH="${JAVA_HOME}/bin:${PATH}"
 
-# Entrypoint script to switch JDK at runtime based on JAVA_VERSION env var
+# Entrypoint script to switch JDK at runtime based on AURON_JAVA_VERSION env var
 RUN echo '#!/bin/bash'                                          > /usr/local/bin/entrypoint.sh && \
     echo 'source ~/.bashrc 2>/dev/null || true'                >> /usr/local/bin/entrypoint.sh && \
-    echo 'if [ "$JAVA_VERSION" = "21" ]; then'                 >> /usr/local/bin/entrypoint.sh && \
+    echo 'if [ "$AURON_JAVA_VERSION" = "21" ]; then'           >> /usr/local/bin/entrypoint.sh && \
     echo '  export JAVA_HOME="/usr/lib/jvm/java-21"'           >> /usr/local/bin/entrypoint.sh && \
     echo 'else'                                                >> /usr/local/bin/entrypoint.sh && \
     echo '  export JAVA_HOME="/usr/lib/jvm/java-8"'            >> /usr/local/bin/entrypoint.sh && \

--- a/dev/docker-build/rockylinux8/Dockerfile
+++ b/dev/docker-build/rockylinux8/Dockerfile
@@ -63,13 +63,23 @@ RUN curl https://sh.rustup.rs -sSf -o rustup-init && \
 ENV PATH="/root/.cargo/bin:${PATH}"
 
 # ---------------------------------------------------------------------
-# Install Java (OpenJDK 8)
+# Install Java (OpenJDK 8 and OpenJDK 21)
 # ---------------------------------------------------------------------
-RUN dnf -y install java-1.8.0-openjdk java-1.8.0-openjdk-devel && \
+RUN dnf -y install java-1.8.0-openjdk java-1.8.0-openjdk-devel \
+                   java-21-openjdk java-21-openjdk-devel && \
     dnf clean all && \
     rm -rf /var/cache/dnf
-ENV JAVA_HOME="/usr/lib/jvm/java-1.8.0-openjdk"
+
+# Default to JDK 8; override at runtime via JAVA_VERSION env var
+ENV JAVA_8_HOME="/usr/lib/jvm/java-1.8.0-openjdk"
+ENV JAVA_21_HOME="/usr/lib/jvm/java-21-openjdk"
+ENV JAVA_HOME="${JAVA_8_HOME}"
 ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
+RUN echo 'export JAVA_8_HOME="/usr/lib/jvm/java-1.8.0-openjdk"' >> /root/.bashrc && \
+    echo 'export JAVA_21_HOME="/usr/lib/jvm/java-21-openjdk"' >> /root/.bashrc && \
+    echo 'if [ "$JAVA_VERSION" = "21" ]; then export JAVA_HOME="$JAVA_21_HOME"; else export JAVA_HOME="$JAVA_8_HOME"; fi' >> /root/.bashrc && \
+    echo 'export PATH="$JAVA_HOME/bin:$PATH"' >> /root/.bashrc
 
 # ---------------------------------------------------------------------
 # Set working directory

--- a/dev/docker-build/rockylinux8/Dockerfile
+++ b/dev/docker-build/rockylinux8/Dockerfile
@@ -63,31 +63,25 @@ RUN curl https://sh.rustup.rs -sSf -o rustup-init && \
 ENV PATH="/root/.cargo/bin:${PATH}"
 
 # ---------------------------------------------------------------------
-# Install Java (OpenJDK 8 and OpenJDK 21)
+# Install Java (OpenJDK 8, 17, and 21)
 # ---------------------------------------------------------------------
 RUN dnf -y install java-1.8.0-openjdk java-1.8.0-openjdk-devel \
+                   java-17-openjdk java-17-openjdk-devel \
                    java-21-openjdk java-21-openjdk-devel && \
     dnf clean all && \
     rm -rf /var/cache/dnf
 
-# Create stable symlinks (Rocky 8 installs to versioned directories)
+# Create stable symlinks for JDK paths
 RUN ln -sfn /usr/lib/jvm/java-1.8.0-openjdk /usr/lib/jvm/java-8 && \
-    ln -sfn $(rpm -ql java-21-openjdk-devel | grep '/bin/javac$' | sed 's|/bin/javac||') /usr/lib/jvm/java-21
+    ln -sfn /usr/lib/jvm/java-17-openjdk /usr/lib/jvm/java-17 && \
+    ln -sfn /usr/lib/jvm/java-21-openjdk /usr/lib/jvm/java-21
 
 ENV JAVA_HOME="/usr/lib/jvm/java-8"
 ENV PATH="${JAVA_HOME}/bin:${PATH}"
 
 # Entrypoint script to switch JDK at runtime based on AURON_JAVA_VERSION env var
-RUN echo '#!/bin/bash'                                          > /usr/local/bin/entrypoint.sh && \
-    echo 'source ~/.bashrc 2>/dev/null || true'                >> /usr/local/bin/entrypoint.sh && \
-    echo 'if [ "$AURON_JAVA_VERSION" = "21" ]; then'           >> /usr/local/bin/entrypoint.sh && \
-    echo '  export JAVA_HOME="/usr/lib/jvm/java-21"'           >> /usr/local/bin/entrypoint.sh && \
-    echo 'else'                                                >> /usr/local/bin/entrypoint.sh && \
-    echo '  export JAVA_HOME="/usr/lib/jvm/java-8"'            >> /usr/local/bin/entrypoint.sh && \
-    echo 'fi'                                                  >> /usr/local/bin/entrypoint.sh && \
-    echo 'export PATH="$JAVA_HOME/bin:$PATH"'                  >> /usr/local/bin/entrypoint.sh && \
-    echo 'exec "$@"'                                           >> /usr/local/bin/entrypoint.sh && \
-    chmod +x /usr/local/bin/entrypoint.sh
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 

--- a/dev/docker-build/rockylinux8/Dockerfile
+++ b/dev/docker-build/rockylinux8/Dockerfile
@@ -70,16 +70,22 @@ RUN dnf -y install java-1.8.0-openjdk java-1.8.0-openjdk-devel \
     dnf clean all && \
     rm -rf /var/cache/dnf
 
-# Default to JDK 8; override at runtime via JAVA_VERSION env var
-ENV JAVA_8_HOME="/usr/lib/jvm/java-1.8.0-openjdk"
-ENV JAVA_21_HOME="/usr/lib/jvm/java-21-openjdk"
-ENV JAVA_HOME="${JAVA_8_HOME}"
+# Default to JDK 8; runtime switching handled via JAVA_VERSION env var in docker-compose
+ENV JAVA_HOME="/usr/lib/jvm/java-1.8.0-openjdk"
 ENV PATH="${JAVA_HOME}/bin:${PATH}"
 
-RUN echo 'export JAVA_8_HOME="/usr/lib/jvm/java-1.8.0-openjdk"' >> /root/.bashrc && \
-    echo 'export JAVA_21_HOME="/usr/lib/jvm/java-21-openjdk"' >> /root/.bashrc && \
-    echo 'if [ "$JAVA_VERSION" = "21" ]; then export JAVA_HOME="$JAVA_21_HOME"; else export JAVA_HOME="$JAVA_8_HOME"; fi' >> /root/.bashrc && \
-    echo 'export PATH="$JAVA_HOME/bin:$PATH"' >> /root/.bashrc
+# Entrypoint script to switch JDK at runtime
+RUN printf '#!/bin/bash\n\
+if [ "$JAVA_VERSION" = "21" ]; then\n\
+  export JAVA_HOME="/usr/lib/jvm/java-21-openjdk"\n\
+else\n\
+  export JAVA_HOME="/usr/lib/jvm/java-1.8.0-openjdk"\n\
+fi\n\
+export PATH="$JAVA_HOME/bin:$PATH"\n\
+exec "$@"\n' > /usr/local/bin/entrypoint.sh && \
+    chmod +x /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 
 # ---------------------------------------------------------------------
 # Set working directory

--- a/dev/docker-build/rockylinux8/entrypoint.sh
+++ b/dev/docker-build/rockylinux8/entrypoint.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+source ~/.bashrc 2>/dev/null || true
+
+# Determine JDK version:
+# - If AURON_JAVA_VERSION is set, use it directly
+# - Otherwise, auto-detect from AURON_BUILD_ARGS (Spark 4.x requires JDK 17+)
+if [ -z "$AURON_JAVA_VERSION" ]; then
+  if echo "$AURON_BUILD_ARGS" | grep -qE '\-Pspark-4\.'; then
+    AURON_JAVA_VERSION="21"
+  else
+    AURON_JAVA_VERSION="8"
+  fi
+fi
+
+case "$AURON_JAVA_VERSION" in
+  17) export JAVA_HOME="/usr/lib/jvm/java-17" ;;
+  21) export JAVA_HOME="/usr/lib/jvm/java-21" ;;
+  *)  export JAVA_HOME="/usr/lib/jvm/java-8" ;;
+esac
+export PATH="$JAVA_HOME/bin:$PATH"
+
+exec "$@"

--- a/dev/docker-build/rockylinux8/entrypoint.sh
+++ b/dev/docker-build/rockylinux8/entrypoint.sh
@@ -1,19 +1,7 @@
 #!/bin/bash
 
-source ~/.bashrc 2>/dev/null || true
-
-# Determine JDK version:
-# - If AURON_JAVA_VERSION is set, use it directly
-# - Otherwise, auto-detect from AURON_BUILD_ARGS (Spark 4.x requires JDK 17+)
-if [ -z "$AURON_JAVA_VERSION" ]; then
-  if echo "$AURON_BUILD_ARGS" | grep -qE '\-Pspark-4\.'; then
-    AURON_JAVA_VERSION="21"
-  else
-    AURON_JAVA_VERSION="8"
-  fi
-fi
-
-case "$AURON_JAVA_VERSION" in
+# Switch JDK based on AURON_JAVA_VERSION env var (default: 8)
+case "${AURON_JAVA_VERSION:-8}" in
   17) export JAVA_HOME="/usr/lib/jvm/java-17" ;;
   21) export JAVA_HOME="/usr/lib/jvm/java-21" ;;
   *)  export JAVA_HOME="/usr/lib/jvm/java-8" ;;

--- a/dev/docker-build/rockylinux8/entrypoint.sh
+++ b/dev/docker-build/rockylinux8/entrypoint.sh
@@ -1,5 +1,22 @@
 #!/bin/bash
 
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 # Switch JDK based on AURON_JAVA_VERSION env var (default: 8)
 case "${AURON_JAVA_VERSION:-8}" in
   17) export JAVA_HOME="/usr/lib/jvm/java-17" ;;


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2260

# Rationale for this change

# What changes are included in this PR?

Add Spark 4.0 and Spark 4.1 to the release build matrix across all platforms (amd64, arm, macOS), with proper version constraints and Docker image support for JDK 17+.



# Are there any user-facing changes?

# How was this patch tested?
GHA

```bash
AURON_JAVA_VERSION=17 ./auron-build.sh --docker true --image rockylinux8 --release --sparkver 4.0 --scalaver 2.13
```