### PR TITLE
[AURON #1857] Introduce FlinkAuronCalcOperator

### DIFF
--- a/auron-flink-extension/auron-flink-runtime/src/main/java/org/apache/auron/flink/arrow/FlinkArrowFFIExporter.java
+++ b/auron-flink-extension/auron-flink-runtime/src/main/java/org/apache/auron/flink/arrow/FlinkArrowFFIExporter.java
@@ -44,17 +44,17 @@ import org.apache.flink.table.types.logical.RowType;
  *   <li>{@link #offer(RowData)} appends one row to the current batch.
  *   <li>{@link #exportNextBatch(long)} finalizes the current root, exports it via Arrow C-Data,
  *       then rotates to a fresh root for the next batch (the previous root is closed before the
- *       new one is allocated).
- *   <li>{@link #noMoreInput()} signals end-of-input; a subsequent {@code exportNextBatch} flushes
- *       any remaining buffered rows (returns {@code true}) and only then reports end-of-stream
- *       (returns {@code false}).
- *   <li>{@link #close()} releases the current root back to the supplied allocator.
+ *       new one is allocated). Returns {@code false} whenever the buffered row count is zero,
+ *       signaling end-of-current-cycle to the native FFI Reader's read loop.
+ *   <li>{@link #close()} releases the current root back to the supplied allocator. Also invoked
+ *       by the native FFI Reader's {@code AutoCloseableExporter} drop at the end of each drain
+ *       cycle; the owning operator subsequently calls {@link #reset()} to re-prepare the
+ *       exporter for the next cycle.
  * </ul>
  *
  * <p>Row count is tracked on the exporter itself rather than queried from {@link FlinkArrowWriter}
  * because the writer does not expose its internal count before {@link FlinkArrowWriter#finish()};
- * tracking here is exact (incremented per {@code offer}, reset per rotation) and avoids touching
- * unrelated code in this commit.
+ * tracking here is exact (incremented per {@code offer}, reset per rotation).
  */
 public class FlinkArrowFFIExporter extends AuronArrowFFIExporter {
 
@@ -66,7 +66,6 @@ public class FlinkArrowFFIExporter extends AuronArrowFFIExporter {
     private VectorSchemaRoot currentRoot;
     private FlinkArrowWriter writer;
     private int rowCount;
-    private boolean noMoreInput;
 
     /**
      * Creates a new exporter bound to the supplied allocator and Flink row type.
@@ -82,7 +81,6 @@ public class FlinkArrowFFIExporter extends AuronArrowFFIExporter {
         this.inputRowType = inputRowType;
         this.arrowSchema = FlinkArrowUtils.toArrowSchema(inputRowType);
         this.batchRowsLimit = batchRowsLimit;
-        this.noMoreInput = false;
         rotateRoot();
     }
 
@@ -108,12 +106,14 @@ public class FlinkArrowFFIExporter extends AuronArrowFFIExporter {
     }
 
     /**
-     * Signals that no further rows will be offered. The next {@link #exportNextBatch(long)} call
-     * will flush any remaining buffered rows (if non-empty), and subsequent calls will return
-     * {@code false}.
+     * Returns {@code true} when this exporter has no buffered rows. Used by the owning
+     * operator to short-circuit no-op drains, which would otherwise tear down and recreate
+     * the native wrapper for no useful work.
+     *
+     * @return true if the buffered row count is zero
      */
-    public void noMoreInput() {
-        this.noMoreInput = true;
+    public boolean isEmpty() {
+        return rowCount == 0;
     }
 
     /**
@@ -134,16 +134,23 @@ public class FlinkArrowFFIExporter extends AuronArrowFFIExporter {
 
     /**
      * Exports the current batch into the FFI struct addressed by {@code arrowArrayPtr} and rotates
-     * to a fresh batch. Returns {@code false} once the exporter has been signaled
-     * {@link #noMoreInput()} and the buffer is empty.
+     * to a fresh batch. Returns {@code false} whenever the buffered row count is zero, signaling
+     * end-of-current-cycle to the native FFI Reader's read loop; the reader exits and its drop
+     * invokes {@link #close()} on this exporter, and the owning operator calls {@link #reset()}
+     * to re-prepare before the next drain cycle.
+     *
+     * <p>Without the empty-buffer false return, mid-stream empty pulls (no rows yet but more
+     * expected) would cause the native FFI Reader to send 0-row batches downstream and
+     * {@link org.apache.auron.jni.AuronCallNativeWrapper#loadNextBatch} would spin indefinitely
+     * on empty output.
      *
      * @param arrowArrayPtr native address of an Arrow {@link ArrowArray} FFI struct
      * @return {@code true} if a batch was written into {@code arrowArrayPtr}; {@code false} if the
-     *     stream is exhausted
+     *     buffer is empty (end-of-current-cycle)
      */
     @Override
     public boolean exportNextBatch(long arrowArrayPtr) {
-        if (rowCount == 0 && noMoreInput) {
+        if (rowCount == 0) {
             return false;
         }
         writer.finish();
@@ -166,6 +173,22 @@ public class FlinkArrowFFIExporter extends AuronArrowFFIExporter {
         }
         writer = null;
         rowCount = 0;
+    }
+
+    /**
+     * Re-prepares this exporter for the next drain cycle after {@link #close()} ran.
+     * Re-allocates {@link VectorSchemaRoot} + binds a fresh {@link FlinkArrowWriter} only when
+     * {@code currentRoot == null}; no-op when the root is still open. Zeroes {@code rowCount}.
+     *
+     * <p>Public because the owning operator lives in a different package; not part of the
+     * abstract {@link AuronArrowFFIExporter} contract.
+     */
+    public void reset() {
+        if (currentRoot == null) {
+            this.currentRoot = VectorSchemaRoot.create(arrowSchema, allocator);
+            this.writer = FlinkArrowWriter.create(currentRoot, inputRowType);
+        }
+        this.rowCount = 0;
     }
 
     /**

--- a/auron-flink-extension/auron-flink-runtime/src/main/java/org/apache/auron/flink/arrow/FlinkArrowFFIExporter.java
+++ b/auron-flink-extension/auron-flink-runtime/src/main/java/org/apache/auron/flink/arrow/FlinkArrowFFIExporter.java
@@ -1,0 +1,183 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.auron.flink.arrow;
+
+import org.apache.arrow.c.ArrowArray;
+import org.apache.arrow.c.ArrowSchema;
+import org.apache.arrow.c.Data;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.apache.auron.arrowio.AuronArrowFFIExporter;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.logical.RowType;
+
+/**
+ * Synchronous {@link AuronArrowFFIExporter} that buffers Flink {@link RowData} into an Arrow
+ * {@link VectorSchemaRoot} and exports it across the Arrow C-Data FFI boundary on demand.
+ *
+ * <p>Unlike the Spark counterpart, this exporter is deliberately <strong>single-threaded</strong>.
+ * The Flink Calc operator pushes rows synchronously through {@link #offer(RowData)} from
+ * {@code processElement}; the native engine pulls batches through {@link #exportNextBatch(long)} on
+ * its tokio blocking pool. The two never run concurrently for the same exporter instance, so no
+ * locking or background thread is required.
+ *
+ * <p>Lifecycle:
+ *
+ * <ul>
+ *   <li>Construction allocates an initial {@link VectorSchemaRoot} and a bound
+ *       {@link FlinkArrowWriter}.
+ *   <li>{@link #offer(RowData)} appends one row to the current batch.
+ *   <li>{@link #exportNextBatch(long)} finalizes the current root, exports it via Arrow C-Data,
+ *       then rotates to a fresh root for the next batch (the previous root is closed before the
+ *       new one is allocated).
+ *   <li>{@link #noMoreInput()} signals end-of-input; a subsequent {@code exportNextBatch} flushes
+ *       any remaining buffered rows (returns {@code true}) and only then reports end-of-stream
+ *       (returns {@code false}).
+ *   <li>{@link #close()} releases the current root back to the supplied allocator.
+ * </ul>
+ *
+ * <p>Row count is tracked on the exporter itself rather than queried from {@link FlinkArrowWriter}
+ * because the writer does not expose its internal count before {@link FlinkArrowWriter#finish()};
+ * tracking here is exact (incremented per {@code offer}, reset per rotation) and avoids touching
+ * unrelated code in this commit.
+ */
+public class FlinkArrowFFIExporter extends AuronArrowFFIExporter {
+
+    private final BufferAllocator allocator;
+    private final RowType inputRowType;
+    private final Schema arrowSchema;
+    private final int batchRowsLimit;
+
+    private VectorSchemaRoot currentRoot;
+    private FlinkArrowWriter writer;
+    private int rowCount;
+    private boolean noMoreInput;
+
+    /**
+     * Creates a new exporter bound to the supplied allocator and Flink row type.
+     *
+     * @param allocator the Arrow allocator used for the buffered {@link VectorSchemaRoot} and for
+     *     any FFI exports; the caller retains ownership and must outlive this exporter
+     * @param inputRowType the Flink row type whose schema this exporter exposes to native code
+     * @param batchRowsLimit the soft row count after which {@link #isBatchFull()} returns
+     *     {@code true}; the operator decides whether to flush early on this signal
+     */
+    public FlinkArrowFFIExporter(BufferAllocator allocator, RowType inputRowType, int batchRowsLimit) {
+        this.allocator = allocator;
+        this.inputRowType = inputRowType;
+        this.arrowSchema = FlinkArrowUtils.toArrowSchema(inputRowType);
+        this.batchRowsLimit = batchRowsLimit;
+        this.noMoreInput = false;
+        rotateRoot();
+    }
+
+    /**
+     * Appends a single row to the current batch buffer.
+     *
+     * @param row the row to write; must conform to the {@link RowType} passed to the constructor
+     */
+    public void offer(RowData row) {
+        writer.write(row);
+        rowCount++;
+    }
+
+    /**
+     * Returns {@code true} once the current batch has reached the configured row limit. The caller
+     * (typically the operator) uses this as a hint to flush eagerly before the buffer grows
+     * further; it is not an upper bound enforced inside the exporter.
+     *
+     * @return true if the buffered row count has reached the limit
+     */
+    public boolean isBatchFull() {
+        return rowCount >= batchRowsLimit;
+    }
+
+    /**
+     * Signals that no further rows will be offered. The next {@link #exportNextBatch(long)} call
+     * will flush any remaining buffered rows (if non-empty), and subsequent calls will return
+     * {@code false}.
+     */
+    public void noMoreInput() {
+        this.noMoreInput = true;
+    }
+
+    /**
+     * Exports the Arrow schema describing this exporter's output into the FFI struct addressed by
+     * {@code arrowSchemaPtr}. The native side typically calls this once during operator setup.
+     *
+     * <p>This method is intentionally not {@code @Override}; the base
+     * {@link AuronArrowFFIExporter} only declares {@link #exportNextBatch(long)} as abstract, and
+     * schema export is invoked directly by the JVM-side operator during {@code open()}.
+     *
+     * @param arrowSchemaPtr native address of an Arrow {@link ArrowSchema} FFI struct
+     */
+    public void exportSchema(long arrowSchemaPtr) {
+        try (ArrowSchema ffi = ArrowSchema.wrap(arrowSchemaPtr)) {
+            Data.exportSchema(allocator, arrowSchema, null, ffi);
+        }
+    }
+
+    /**
+     * Exports the current batch into the FFI struct addressed by {@code arrowArrayPtr} and rotates
+     * to a fresh batch. Returns {@code false} once the exporter has been signaled
+     * {@link #noMoreInput()} and the buffer is empty.
+     *
+     * @param arrowArrayPtr native address of an Arrow {@link ArrowArray} FFI struct
+     * @return {@code true} if a batch was written into {@code arrowArrayPtr}; {@code false} if the
+     *     stream is exhausted
+     */
+    @Override
+    public boolean exportNextBatch(long arrowArrayPtr) {
+        if (rowCount == 0 && noMoreInput) {
+            return false;
+        }
+        writer.finish();
+        try (ArrowArray ffi = ArrowArray.wrap(arrowArrayPtr)) {
+            Data.exportVectorSchemaRoot(allocator, currentRoot, null, ffi);
+        }
+        rotateRoot();
+        return true;
+    }
+
+    /**
+     * Releases the current {@link VectorSchemaRoot} back to the supplied allocator. Safe to call
+     * multiple times.
+     */
+    @Override
+    public void close() {
+        if (currentRoot != null) {
+            currentRoot.close();
+            currentRoot = null;
+        }
+        writer = null;
+        rowCount = 0;
+    }
+
+    /**
+     * Closes any existing root, allocates a fresh {@link VectorSchemaRoot} for the next batch, and
+     * binds a new {@link FlinkArrowWriter} to it. The row counter is reset to zero.
+     */
+    private void rotateRoot() {
+        if (currentRoot != null) {
+            currentRoot.close();
+        }
+        this.currentRoot = VectorSchemaRoot.create(arrowSchema, allocator);
+        this.writer = FlinkArrowWriter.create(currentRoot, inputRowType);
+        this.rowCount = 0;
+    }
+}

--- a/auron-flink-extension/auron-flink-runtime/src/main/java/org/apache/auron/flink/metric/FlinkMetricNode.java
+++ b/auron-flink-extension/auron-flink-runtime/src/main/java/org/apache/auron/flink/metric/FlinkMetricNode.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.auron.flink.metric;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import org.apache.auron.metric.MetricNode;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.MetricGroup;
+
+/**
+ * Flink-side {@link MetricNode} that forwards metric updates published by the native engine to a
+ * Flink {@link MetricGroup}.
+ *
+ * <p>Each distinct metric name is lazily mapped to a Flink {@link Counter} on first use. Counters
+ * are cached in a {@link ConcurrentHashMap} because metric callbacks may originate from native
+ * threads invoked via JNI, so creation must be thread-safe.
+ *
+ * <p>Only strictly positive values are forwarded. This mirrors the semantics of
+ * {@code SparkMetricNode} (see {@code spark-extension/.../SparkMetricNode.scala}), where
+ * non-positive deltas are ignored to avoid spurious counter activity from native callbacks that
+ * report zero/negative deltas for unaffected metrics.
+ */
+public class FlinkMetricNode extends MetricNode {
+
+    private static final long serialVersionUID = 1L;
+
+    private final transient MetricGroup metricGroup;
+    private final transient ConcurrentHashMap<String, Counter> counters = new ConcurrentHashMap<>();
+
+    /**
+     * Constructs a new {@link FlinkMetricNode}.
+     *
+     * @param metricGroup the Flink metric group counters are registered against; must not be null
+     * @param children the child metric nodes used for hierarchical metric trees
+     */
+    public FlinkMetricNode(MetricGroup metricGroup, List<MetricNode> children) {
+        super(children);
+        this.metricGroup = Objects.requireNonNull(metricGroup, "metricGroup");
+    }
+
+    /**
+     * Adds {@code value} to the Flink {@link Counter} named {@code name}, creating the counter on
+     * first use. Non-positive values are ignored.
+     *
+     * @param name the metric name
+     * @param value the delta to apply; ignored when {@code <= 0}
+     */
+    @Override
+    public void add(String name, long value) {
+        if (value > 0) {
+            counters.computeIfAbsent(name, metricGroup::counter).inc(value);
+        }
+    }
+}

--- a/auron-flink-extension/auron-flink-runtime/src/main/java/org/apache/auron/flink/runtime/operator/FlinkAuronCalcOperator.java
+++ b/auron-flink-extension/auron-flink-runtime/src/main/java/org/apache/auron/flink/runtime/operator/FlinkAuronCalcOperator.java
@@ -48,7 +48,7 @@ import org.apache.flink.table.types.logical.RowType;
  * Filter} above an {@code FFIReader} leaf) by streaming {@link RowData} through Auron's native
  * engine.
  *
- * <p>Architecture (Phase 1, Scenario B — standalone Calc):
+ * <p>Architecture:
  *
  * <ul>
  *   <li>Input bridge: {@link FlinkArrowFFIExporter} buffers JVM {@link RowData} into an Arrow
@@ -61,10 +61,10 @@ import org.apache.flink.table.types.logical.RowType;
  * </ul>
  *
  * <p>Resource ID convention: {@code FlinkAuronCalc-<flinkOpUniqueId>-<subtaskIndex>:<UUID>}. The
- * Flink operator unique ID and subtask index propagate operator identity to native code (OQ1 =
- * per-subtask uniqueness); the UUID disambiguates re-runs after operator restart. The
- * {@link FFIReaderExecNode} proto has no {@code auron_operator_id} field, so identity lives
- * exclusively in the resource ID.
+ * Flink operator unique ID and subtask index keep the key unique per subtask so native-side
+ * registrations from concurrent subtasks of the same operator do not collide; the UUID
+ * disambiguates re-runs after operator restart. The {@link FFIReaderExecNode} proto has no
+ * {@code auron_operator_id} field, so identity lives exclusively in the resource ID.
  *
  * <p>Lifecycle and drain semantics:
  *
@@ -81,9 +81,8 @@ import org.apache.flink.table.types.logical.RowType;
  *       releases resources. Idempotent: fields are nulled after close.
  * </ul>
  *
- * <p>This operator is constructed by the future ExecNodeGraphProcessor / Calc rewriter (sub-task
- * AURON #1853); valid construction is the caller's responsibility — no defensive null checks
- * are performed.
+ * <p>Valid construction (well-formed plan tree, matching row types, non-null operator ID) is
+ * the caller's responsibility — no defensive null checks are performed.
  */
 public class FlinkAuronCalcOperator extends TableStreamOperator<RowData>
         implements OneInputStreamOperator<RowData, RowData>, FlinkAuronOperator {
@@ -94,9 +93,7 @@ public class FlinkAuronCalcOperator extends TableStreamOperator<RowData>
      * Soft row-count threshold above which the exporter reports {@link
      * FlinkArrowFFIExporter#isBatchFull()} and the operator eagerly drains the pipeline. 8192 is
      * the conventional batch size for vectorized engines (matches the Spark integration's
-     * batch-size default of ~10000 and DataFusion's typical batch size). Hard-coded here so the
-     * operator has no external configuration dependency; future PRs can wire this through
-     * {@link FlinkAuronConfiguration} once a config option exists.
+     * batch-size default of ~10000 and DataFusion's typical batch size).
      */
     private static final int BATCH_ROW_LIMIT = 8192;
 
@@ -114,6 +111,10 @@ public class FlinkAuronCalcOperator extends TableStreamOperator<RowData>
     private transient NativeRuntime nativeRuntime;
     private transient PhysicalPlanNode runtimePlan;
     private transient StreamRecord<RowData> outputRecord;
+    // Cached so reinitExporterAndRuntime() can reuse the value resolved once in open().
+    private transient long nativeMemory;
+    // Set in close() before the final drain so drainNative() skips its post-loop reinit.
+    private transient boolean closing;
 
     /**
      * Production constructor: uses the default factory that creates an
@@ -155,13 +156,13 @@ public class FlinkAuronCalcOperator extends TableStreamOperator<RowData>
         this.metricNode = new FlinkMetricNode(getMetricGroup(), Collections.emptyList());
         this.exporter = new FlinkArrowFFIExporter(childAllocator, inputRowType, BATCH_ROW_LIMIT);
         // UUID disambiguates re-runs after operator restart so a stale registration cannot
-        // collide with the new one (OQ1).
+        // collide with the new one.
         this.resourceId = "FlinkAuronCalc-" + opIdWithSubtask + ":" + UUID.randomUUID();
         JniBridge.putResource(resourceId, exporter);
 
         this.runtimePlan = injectFfiReaderLeaf(plan, resourceId);
 
-        long nativeMemory =
+        this.nativeMemory =
                 AuronAdaptor.getInstance().getAuronConfiguration().getLong(FlinkAuronConfiguration.NATIVE_MEMORY_SIZE);
         this.nativeRuntime =
                 nativeRuntimeFactory.create(FlinkArrowUtils.getRootAllocator(), runtimePlan, metricNode, nativeMemory);
@@ -191,13 +192,15 @@ public class FlinkAuronCalcOperator extends TableStreamOperator<RowData>
 
     @Override
     public void close() throws Exception {
+        // Set first so the final drainNative() below skips its post-loop reinit; otherwise
+        // we'd allocate a new wrapper + exporter root only to tear them down immediately.
+        closing = true;
         try {
             // Both exporter and nativeRuntime must be initialized before draining: if open()
             // failed between exporter creation and nativeRuntime creation, drainNative() would
             // NPE on nativeRuntime.loadNextBatch(...). Each resource is null-guarded
             // individually in the nested finally so partial-init still releases what exists.
             if (exporter != null && nativeRuntime != null) {
-                exporter.noMoreInput();
                 drainNative();
             }
         } finally {
@@ -227,14 +230,48 @@ public class FlinkAuronCalcOperator extends TableStreamOperator<RowData>
     }
 
     /**
-     * Drains the native pipeline by repeatedly invoking {@link NativeRuntime#loadNextBatch}
-     * until it returns {@code false} (no more output). Each batch is emitted via
-     * {@link #emitArrowBatch(VectorSchemaRoot)}.
+     * Drains all output of the current cycle, then rebuilds the exporter + native runtime for
+     * the next cycle. Each batch is emitted via {@link #emitArrowBatch(VectorSchemaRoot)}.
+     *
+     * <p>Early-returns when the exporter has no buffered rows: a drain on an empty exporter
+     * would produce zero output and still tear down the wrapper (because
+     * {@link FlinkArrowFFIExporter#exportNextBatch(long)} returns false on empty, and
+     * {@link org.apache.auron.jni.AuronCallNativeWrapper#loadNextBatch} auto-closes the
+     * native runtime on a false return). Skipping the round trip keeps the wrapper alive
+     * across no-op watermark/checkpoint drains.
+     *
+     * <p>After a non-empty drain, the underlying {@code AuronCallNativeWrapper} has auto-closed
+     * itself, and the native FFI Reader's drop has already called
+     * {@link FlinkArrowFFIExporter#close()} on the Java exporter. Without per-cycle reinit, the
+     * next {@code processElement} would either silently drop rows (the wrapper's invalid native
+     * pointer fast-fails {@code loadNextBatch}) or NPE on {@code exporter.offer(row)} (writer
+     * nulled by the FFI Reader's drop). Reinit is suppressed during operator {@link #close()}
+     * via the {@link #closing} guard so the final drain does not allocate replacement resources
+     * only to tear them down.
      */
     private void drainNative() {
+        if (exporter.isEmpty()) {
+            return;
+        }
         while (nativeRuntime.loadNextBatch(this::emitArrowBatch)) {
             // loop
         }
+        if (!closing) {
+            reinitExporterAndRuntime();
+        }
+    }
+
+    /**
+     * Re-prepares the exporter, re-registers it under {@link #resourceId}, and builds a fresh
+     * {@link NativeRuntime} via the factory. {@link #resourceId}, {@link #runtimePlan},
+     * {@link #metricNode}, and {@link #nativeMemory} are all set once in {@link #open()} and
+     * reused across every reinit, so per-subtask operator identity is preserved.
+     */
+    private void reinitExporterAndRuntime() {
+        exporter.reset();
+        JniBridge.putResource(resourceId, exporter);
+        this.nativeRuntime =
+                nativeRuntimeFactory.create(FlinkArrowUtils.getRootAllocator(), runtimePlan, metricNode, nativeMemory);
     }
 
     /**

--- a/auron-flink-extension/auron-flink-runtime/src/main/java/org/apache/auron/flink/runtime/operator/FlinkAuronCalcOperator.java
+++ b/auron-flink-extension/auron-flink-runtime/src/main/java/org/apache/auron/flink/runtime/operator/FlinkAuronCalcOperator.java
@@ -1,0 +1,374 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.auron.flink.runtime.operator;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.function.Consumer;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.auron.flink.arrow.FlinkArrowFFIExporter;
+import org.apache.auron.flink.arrow.FlinkArrowReader;
+import org.apache.auron.flink.arrow.FlinkArrowUtils;
+import org.apache.auron.flink.configuration.FlinkAuronConfiguration;
+import org.apache.auron.flink.metric.FlinkMetricNode;
+import org.apache.auron.jni.AuronAdaptor;
+import org.apache.auron.jni.AuronCallNativeWrapper;
+import org.apache.auron.jni.JniBridge;
+import org.apache.auron.metric.MetricNode;
+import org.apache.auron.protobuf.FFIReaderExecNode;
+import org.apache.auron.protobuf.PhysicalPlanNode;
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.StreamingRuntimeContext;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.operators.TableStreamOperator;
+import org.apache.flink.table.types.logical.RowType;
+
+/**
+ * Flink {@link TableStreamOperator} that executes a pre-composed native Calc plan of shape
+ * {@code Project[Filter[FFIReader]]} (or any single/combination of {@code Project} / {@code
+ * Filter} above an {@code FFIReader} leaf) by streaming {@link RowData} through Auron's native
+ * engine.
+ *
+ * <p>Architecture (Phase 1, Scenario B — standalone Calc):
+ *
+ * <ul>
+ *   <li>Input bridge: {@link FlinkArrowFFIExporter} buffers JVM {@link RowData} into an Arrow
+ *       {@link VectorSchemaRoot} and exports it across the Arrow C-Data FFI to native code.
+ *   <li>Native runtime: an {@link AuronCallNativeWrapper} executes the {@link PhysicalPlanNode}
+ *       and pulls input batches from the exporter (registered in {@link JniBridge}'s resource
+ *       map under a per-subtask resource ID).
+ *   <li>Output bridge: {@link FlinkArrowReader} wraps each native output batch as Flink
+ *       {@link RowData}; rows are forwarded via the inherited {@code output} collector.
+ * </ul>
+ *
+ * <p>Resource ID convention: {@code FlinkAuronCalc-<flinkOpUniqueId>-<subtaskIndex>:<UUID>}. The
+ * Flink operator unique ID and subtask index propagate operator identity to native code (OQ1 =
+ * per-subtask uniqueness); the UUID disambiguates re-runs after operator restart. The
+ * {@link FFIReaderExecNode} proto has no {@code auron_operator_id} field, so identity lives
+ * exclusively in the resource ID.
+ *
+ * <p>Lifecycle and drain semantics:
+ *
+ * <ul>
+ *   <li>{@link #processElement(StreamRecord)} buffers each row; if the exporter signals
+ *       batch-full it eagerly drains the native pipeline.
+ *   <li>{@link #processWatermark(Watermark)} drains BEFORE forwarding the watermark — otherwise
+ *       a downstream operator could receive a watermark that crosses rows still buffered here.
+ *   <li>{@link #prepareSnapshotPreBarrier(long)} drains so buffered rows reach downstream
+ *       before the checkpoint barrier crosses them. Calc is stateless; no operator-state writes
+ *       are needed.
+ *   <li>{@link #close()} signals end-of-input, performs a final drain, then closes the native
+ *       runtime, exporter, and child allocator in nested try/finally so partial failure still
+ *       releases resources. Idempotent: fields are nulled after close.
+ * </ul>
+ *
+ * <p>This operator is constructed by the future ExecNodeGraphProcessor / Calc rewriter (sub-task
+ * AURON #1853); valid construction is the caller's responsibility — no defensive null checks
+ * are performed.
+ */
+public class FlinkAuronCalcOperator extends TableStreamOperator<RowData>
+        implements OneInputStreamOperator<RowData, RowData>, FlinkAuronOperator {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Soft row-count threshold above which the exporter reports {@link
+     * FlinkArrowFFIExporter#isBatchFull()} and the operator eagerly drains the pipeline. 8192 is
+     * the conventional batch size for vectorized engines (matches the Spark integration's
+     * batch-size default of ~10000 and DataFusion's typical batch size). Hard-coded here so the
+     * operator has no external configuration dependency; future PRs can wire this through
+     * {@link FlinkAuronConfiguration} once a config option exists.
+     */
+    private static final int BATCH_ROW_LIMIT = 8192;
+
+    private final PhysicalPlanNode plan;
+    private final RowType inputRowType;
+    private final RowType outputRowType;
+    private final String auronOperatorId;
+    private final NativeRuntimeFactory nativeRuntimeFactory;
+
+    // Per-subtask runtime state (transient — re-initialized in open()).
+    private transient String resourceId;
+    private transient BufferAllocator childAllocator;
+    private transient FlinkArrowFFIExporter exporter;
+    private transient FlinkMetricNode metricNode;
+    private transient NativeRuntime nativeRuntime;
+    private transient PhysicalPlanNode runtimePlan;
+    private transient StreamRecord<RowData> outputRecord;
+
+    /**
+     * Production constructor: uses the default factory that creates an
+     * {@link AuronCallNativeWrapper}.
+     *
+     * @param plan the pre-composed native plan tree (Project / Filter / FFIReader shape)
+     * @param inputRowType the Flink row type of the input stream
+     * @param outputRowType the Flink row type of the output stream
+     * @param auronOperatorId the Auron operator ID for metric and identity propagation; the
+     *     subtask-suffixed variant is held only in the runtime resource ID
+     */
+    public FlinkAuronCalcOperator(
+            PhysicalPlanNode plan, RowType inputRowType, RowType outputRowType, String auronOperatorId) {
+        this(plan, inputRowType, outputRowType, auronOperatorId, defaultNativeRuntimeFactory());
+    }
+
+    /** Test seam constructor accepting a {@link NativeRuntimeFactory}. */
+    @VisibleForTesting
+    FlinkAuronCalcOperator(
+            PhysicalPlanNode plan,
+            RowType inputRowType,
+            RowType outputRowType,
+            String auronOperatorId,
+            NativeRuntimeFactory nativeRuntimeFactory) {
+        this.plan = plan;
+        this.inputRowType = inputRowType;
+        this.outputRowType = outputRowType;
+        this.auronOperatorId = auronOperatorId;
+        this.nativeRuntimeFactory = nativeRuntimeFactory;
+    }
+
+    @Override
+    public void open() throws Exception {
+        super.open();
+        StreamingRuntimeContext rc = (StreamingRuntimeContext) getRuntimeContext();
+        String opIdWithSubtask = rc.getOperatorUniqueID() + "-" + rc.getIndexOfThisSubtask();
+
+        this.childAllocator = FlinkArrowUtils.createChildAllocator("FlinkAuronCalc-" + opIdWithSubtask);
+        this.metricNode = new FlinkMetricNode(getMetricGroup(), Collections.emptyList());
+        this.exporter = new FlinkArrowFFIExporter(childAllocator, inputRowType, BATCH_ROW_LIMIT);
+        // UUID disambiguates re-runs after operator restart so a stale registration cannot
+        // collide with the new one (OQ1).
+        this.resourceId = "FlinkAuronCalc-" + opIdWithSubtask + ":" + UUID.randomUUID();
+        JniBridge.putResource(resourceId, exporter);
+
+        this.runtimePlan = injectFfiReaderLeaf(plan, resourceId);
+
+        long nativeMemory =
+                AuronAdaptor.getInstance().getAuronConfiguration().getLong(FlinkAuronConfiguration.NATIVE_MEMORY_SIZE);
+        this.nativeRuntime =
+                nativeRuntimeFactory.create(FlinkArrowUtils.getRootAllocator(), runtimePlan, metricNode, nativeMemory);
+
+        this.outputRecord = new StreamRecord<>(null);
+    }
+
+    @Override
+    public void processElement(StreamRecord<RowData> element) throws Exception {
+        exporter.offer(element.getValue());
+        if (exporter.isBatchFull()) {
+            drainNative();
+        }
+    }
+
+    @Override
+    public void processWatermark(Watermark mark) throws Exception {
+        drainNative();
+        super.processWatermark(mark);
+    }
+
+    @Override
+    public void prepareSnapshotPreBarrier(long checkpointId) throws Exception {
+        drainNative();
+        super.prepareSnapshotPreBarrier(checkpointId);
+    }
+
+    @Override
+    public void close() throws Exception {
+        try {
+            // Both exporter and nativeRuntime must be initialized before draining: if open()
+            // failed between exporter creation and nativeRuntime creation, drainNative() would
+            // NPE on nativeRuntime.loadNextBatch(...). Each resource is null-guarded
+            // individually in the nested finally so partial-init still releases what exists.
+            if (exporter != null && nativeRuntime != null) {
+                exporter.noMoreInput();
+                drainNative();
+            }
+        } finally {
+            try {
+                if (nativeRuntime != null) {
+                    nativeRuntime.close();
+                    nativeRuntime = null;
+                }
+            } finally {
+                try {
+                    if (exporter != null) {
+                        exporter.close();
+                        exporter = null;
+                    }
+                } finally {
+                    try {
+                        if (childAllocator != null) {
+                            childAllocator.close();
+                            childAllocator = null;
+                        }
+                    } finally {
+                        super.close();
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Drains the native pipeline by repeatedly invoking {@link NativeRuntime#loadNextBatch}
+     * until it returns {@code false} (no more output). Each batch is emitted via
+     * {@link #emitArrowBatch(VectorSchemaRoot)}.
+     */
+    private void drainNative() {
+        while (nativeRuntime.loadNextBatch(this::emitArrowBatch)) {
+            // loop
+        }
+    }
+
+    /**
+     * Wraps the Arrow batch as a Flink {@link FlinkArrowReader} and emits each row downstream
+     * through the inherited {@code output} collector.
+     */
+    private void emitArrowBatch(VectorSchemaRoot root) {
+        FlinkArrowReader reader = FlinkArrowReader.create(root, outputRowType);
+        int n = reader.getRowCount();
+        for (int i = 0; i < n; i++) {
+            output.collect(outputRecord.replace(reader.read(i)));
+        }
+    }
+
+    /**
+     * Recursively walks the plan tree, locates the {@link FFIReaderExecNode} leaf, and rebuilds
+     * the path so that the leaf has the runtime-bound resource ID. All other FFI Reader fields
+     * ({@code num_partitions}, {@code schema}) are preserved.
+     *
+     * <p>Accepted shapes: {@code FFIReader}, {@code Filter[FFIReader]}, {@code Project[FFIReader]},
+     * {@code Project[Filter[FFIReader]]}. Throws {@link IllegalArgumentException} on anything
+     * else so misconfigurations fail fast at operator startup.
+     *
+     * @param node the plan node to walk
+     * @param resourceId the resource ID to inject into the FFI Reader leaf
+     * @return a new plan tree with the resource ID bound on the leaf
+     */
+    @VisibleForTesting
+    static PhysicalPlanNode injectFfiReaderLeaf(PhysicalPlanNode node, String resourceId) {
+        if (node.hasFfiReader()) {
+            FFIReaderExecNode rewritten = node.getFfiReader().toBuilder()
+                    .setExportIterProviderResourceId(resourceId)
+                    .build();
+            return node.toBuilder().setFfiReader(rewritten).build();
+        }
+        if (node.hasProjection()) {
+            PhysicalPlanNode rewrittenInput =
+                    injectFfiReaderLeaf(node.getProjection().getInput(), resourceId);
+            return node.toBuilder()
+                    .setProjection(node.getProjection().toBuilder()
+                            .setInput(rewrittenInput)
+                            .build())
+                    .build();
+        }
+        if (node.hasFilter()) {
+            PhysicalPlanNode rewrittenInput =
+                    injectFfiReaderLeaf(node.getFilter().getInput(), resourceId);
+            return node.toBuilder()
+                    .setFilter(node.getFilter().toBuilder()
+                            .setInput(rewrittenInput)
+                            .build())
+                    .build();
+        }
+        throw new IllegalArgumentException("FlinkAuronCalcOperator expects Project[Filter[FFIReader]] / "
+                + "Project[FFIReader] / Filter[FFIReader] / FFIReader shape; got: "
+                + node.getPhysicalPlanTypeCase());
+    }
+
+    // ====================================================================
+    // SupportsAuronNative
+    // ====================================================================
+
+    @Override
+    public List<PhysicalPlanNode> getPhysicalPlanNodes() {
+        return Collections.singletonList(plan);
+    }
+
+    @Override
+    public RowType getOutputType() {
+        return outputRowType;
+    }
+
+    @Override
+    public String getAuronOperatorId() {
+        return auronOperatorId;
+    }
+
+    @Override
+    public MetricNode getMetricNode() {
+        return metricNode;
+    }
+
+    // ====================================================================
+    // Mock seam
+    // ====================================================================
+
+    /**
+     * Test seam abstracting the native runtime so unit tests can drive the operator without
+     * loading {@code libauron} or invoking real JNI.
+     */
+    @VisibleForTesting
+    interface NativeRuntime extends AutoCloseable {
+        /**
+         * Pulls the next batch from the native engine and passes it to {@code consumer}.
+         *
+         * @param consumer callback that receives the next batch's {@link VectorSchemaRoot}
+         * @return {@code true} if a batch was produced (consumer was called), {@code false} if
+         *     the stream is exhausted
+         */
+        boolean loadNextBatch(Consumer<VectorSchemaRoot> consumer);
+
+        @Override
+        void close();
+    }
+
+    /** Factory for {@link NativeRuntime} instances, swappable in tests. */
+    @VisibleForTesting
+    interface NativeRuntimeFactory {
+        /**
+         * Creates a native runtime for the given plan.
+         *
+         * @param allocator the Arrow root allocator
+         * @param plan the runtime-bound plan (with resource IDs injected)
+         * @param metric the metric node to forward native engine metrics to
+         * @param nativeMemory the native memory budget for the runtime in bytes
+         * @return a new {@link NativeRuntime}
+         */
+        NativeRuntime create(BufferAllocator allocator, PhysicalPlanNode plan, MetricNode metric, long nativeMemory);
+    }
+
+    private static NativeRuntimeFactory defaultNativeRuntimeFactory() {
+        return (allocator, plan, metric, mem) -> {
+            AuronCallNativeWrapper wrapper = new AuronCallNativeWrapper(allocator, plan, metric, 0, 0, 0, mem);
+            return new NativeRuntime() {
+                @Override
+                public boolean loadNextBatch(Consumer<VectorSchemaRoot> consumer) {
+                    return wrapper.loadNextBatch(consumer);
+                }
+
+                @Override
+                public void close() {
+                    wrapper.close();
+                }
+            };
+        };
+    }
+}

--- a/auron-flink-extension/auron-flink-runtime/src/test/java/org/apache/auron/flink/arrow/FlinkArrowFFIExporterTest.java
+++ b/auron-flink-extension/auron-flink-runtime/src/test/java/org/apache/auron/flink/arrow/FlinkArrowFFIExporterTest.java
@@ -1,0 +1,223 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.auron.flink.arrow;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import org.apache.arrow.c.ArrowArray;
+import org.apache.arrow.c.ArrowSchema;
+import org.apache.arrow.c.CDataDictionaryProvider;
+import org.apache.arrow.c.Data;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.VarCharType;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link FlinkArrowFFIExporter}.
+ *
+ * <p>All tests are pure Arrow C-Data round-trip — they exercise the FFI export/import boundary
+ * without any native engine call. Each test holds its own child allocator inside a
+ * try-with-resources block so the allocator itself catches any leaks at test teardown.
+ */
+public class FlinkArrowFFIExporterTest {
+
+    /**
+     * The repo-wide surefire config sets {@code java.io.tmpdir} to {@code target/tmp}, which does
+     * not yet exist on a clean build. The Arrow C-Data JNI loader extracts its native library via
+     * {@link java.io.File#createTempFile}, which fails if the directory is missing. Ensure it
+     * exists before any test runs.
+     */
+    @BeforeAll
+    public static void ensureTmpDirExists() {
+        String tmp = System.getProperty("java.io.tmpdir");
+        if (tmp != null) {
+            new File(tmp).mkdirs();
+        }
+    }
+
+    /** Schema used by most tests: INT id, BIGINT value, VARCHAR label. */
+    private static RowType simpleRowType() {
+        return RowType.of(
+                new LogicalType[] {new IntType(), new BigIntType(), new VarCharType(100)},
+                new String[] {"id", "value", "label"});
+    }
+
+    /**
+     * Contract: {@code exportSchema(ptr)} populates an Arrow FFI schema struct such that importing
+     * it produces a {@link Schema} structurally equal to {@link FlinkArrowUtils#toArrowSchema}.
+     */
+    @Test
+    public void testExportSchemaRoundTrip() {
+        try (BufferAllocator allocator =
+                FlinkArrowUtils.ROOT_ALLOCATOR.newChildAllocator("testSchema", 0, Long.MAX_VALUE)) {
+            RowType rowType = simpleRowType();
+            try (FlinkArrowFFIExporter exporter = new FlinkArrowFFIExporter(allocator, rowType, 100);
+                    ArrowSchema ffi = ArrowSchema.allocateNew(allocator);
+                    CDataDictionaryProvider dictProvider = new CDataDictionaryProvider()) {
+                exporter.exportSchema(ffi.memoryAddress());
+                Schema imported = Data.importSchema(allocator, ffi, dictProvider);
+                assertEquals(FlinkArrowUtils.toArrowSchema(rowType), imported);
+            }
+        }
+    }
+
+    /**
+     * Contract: after offering N rows, {@code exportNextBatch} returns {@code true} and the FFI
+     * array contains exactly those N rows with field-by-field equality.
+     */
+    @Test
+    public void testOfferThenExportNextBatch_returnsTrueWithRowsAvailable() {
+        try (BufferAllocator allocator =
+                FlinkArrowUtils.ROOT_ALLOCATOR.newChildAllocator("testOfferExport", 0, Long.MAX_VALUE)) {
+            RowType rowType = simpleRowType();
+            int numRows = 100;
+            try (FlinkArrowFFIExporter exporter = new FlinkArrowFFIExporter(allocator, rowType, 200)) {
+                for (int i = 0; i < numRows; i++) {
+                    exporter.offer(makeRow(i));
+                }
+
+                try (ArrowArray ffiArray = ArrowArray.allocateNew(allocator);
+                        ArrowSchema ffiSchema = ArrowSchema.allocateNew(allocator);
+                        CDataDictionaryProvider dictProvider = new CDataDictionaryProvider()) {
+                    // Export schema once so we can build a matching import root.
+                    exporter.exportSchema(ffiSchema.memoryAddress());
+                    Schema schema = Data.importSchema(allocator, ffiSchema, dictProvider);
+
+                    assertTrue(exporter.exportNextBatch(ffiArray.memoryAddress()));
+
+                    try (VectorSchemaRoot importRoot = VectorSchemaRoot.create(schema, allocator)) {
+                        Data.importIntoVectorSchemaRoot(allocator, ffiArray, importRoot, dictProvider);
+                        assertEquals(numRows, importRoot.getRowCount());
+                        FlinkArrowReader reader = FlinkArrowReader.create(importRoot, rowType);
+                        try {
+                            for (int i = 0; i < numRows; i++) {
+                                RowData row = reader.read(i);
+                                assertEquals(i, row.getInt(0));
+                                assertEquals((long) i * 2L, row.getLong(1));
+                                assertEquals("row-" + i, row.getString(2).toString());
+                            }
+                        } finally {
+                            reader.close();
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Contract: a freshly constructed exporter that has received {@code noMoreInput()} without any
+     * offered rows must report end-of-stream by returning {@code false} from
+     * {@code exportNextBatch}.
+     */
+    @Test
+    public void testExportNextBatch_returnsFalseAfterNoMoreInput() {
+        try (BufferAllocator allocator =
+                FlinkArrowUtils.ROOT_ALLOCATOR.newChildAllocator("testEoiEmpty", 0, Long.MAX_VALUE)) {
+            RowType rowType = simpleRowType();
+            try (FlinkArrowFFIExporter exporter = new FlinkArrowFFIExporter(allocator, rowType, 100);
+                    ArrowArray ffiArray = ArrowArray.allocateNew(allocator)) {
+                exporter.noMoreInput();
+                assertFalse(exporter.exportNextBatch(ffiArray.memoryAddress()));
+            }
+        }
+    }
+
+    /**
+     * Contract: when end-of-input arrives after offering a partial batch (below the limit), the
+     * exporter must still flush the buffered rows on the next {@code exportNextBatch} call (returns
+     * {@code true}) and only then signal end-of-stream on the subsequent call ({@code false}).
+     */
+    @Test
+    public void testExportNextBatch_returnsTrueOnPartialBatchAfterNoMoreInput() {
+        try (BufferAllocator allocator =
+                FlinkArrowUtils.ROOT_ALLOCATOR.newChildAllocator("testPartialFlush", 0, Long.MAX_VALUE)) {
+            RowType rowType = simpleRowType();
+            try (FlinkArrowFFIExporter exporter = new FlinkArrowFFIExporter(allocator, rowType, 100)) {
+                exporter.offer(makeRow(0));
+                exporter.offer(makeRow(1));
+                exporter.offer(makeRow(2));
+                exporter.noMoreInput();
+
+                try (ArrowArray ffiArray = ArrowArray.allocateNew(allocator);
+                        ArrowSchema ffiSchema = ArrowSchema.allocateNew(allocator);
+                        CDataDictionaryProvider dictProvider = new CDataDictionaryProvider()) {
+                    exporter.exportSchema(ffiSchema.memoryAddress());
+                    Schema schema = Data.importSchema(allocator, ffiSchema, dictProvider);
+
+                    assertTrue(exporter.exportNextBatch(ffiArray.memoryAddress()));
+
+                    try (VectorSchemaRoot importRoot = VectorSchemaRoot.create(schema, allocator)) {
+                        Data.importIntoVectorSchemaRoot(allocator, ffiArray, importRoot, dictProvider);
+                        assertEquals(3, importRoot.getRowCount());
+                    }
+                }
+
+                // Second call: buffer drained, must signal end-of-stream.
+                try (ArrowArray ffiArray2 = ArrowArray.allocateNew(allocator)) {
+                    assertFalse(exporter.exportNextBatch(ffiArray2.memoryAddress()));
+                }
+            }
+        }
+    }
+
+    /**
+     * Contract: {@code close()} releases every byte owned by the exporter back to the supplied
+     * allocator. After close, {@code allocator.getAllocatedMemory() == 0}.
+     */
+    @Test
+    public void testCloseReleasesAllocator() {
+        BufferAllocator allocator =
+                FlinkArrowUtils.ROOT_ALLOCATOR.newChildAllocator("testCloseFrees", 0, Long.MAX_VALUE);
+        try {
+            RowType rowType = simpleRowType();
+            FlinkArrowFFIExporter exporter = new FlinkArrowFFIExporter(allocator, rowType, 100);
+            for (int i = 0; i < 10; i++) {
+                exporter.offer(makeRow(i));
+            }
+            exporter.close();
+            assertEquals(
+                    0L,
+                    allocator.getAllocatedMemory(),
+                    "exporter.close() must release all memory borrowed from its allocator");
+        } finally {
+            allocator.close();
+        }
+    }
+
+    private static RowData makeRow(int i) {
+        GenericRowData row = new GenericRowData(3);
+        row.setField(0, i);
+        row.setField(1, (long) i * 2L);
+        row.setField(2, StringData.fromBytes(("row-" + i).getBytes(StandardCharsets.UTF_8)));
+        return row;
+    }
+}

--- a/auron-flink-extension/auron-flink-runtime/src/test/java/org/apache/auron/flink/arrow/FlinkArrowFFIExporterTest.java
+++ b/auron-flink-extension/auron-flink-runtime/src/test/java/org/apache/auron/flink/arrow/FlinkArrowFFIExporterTest.java
@@ -134,57 +134,21 @@ public class FlinkArrowFFIExporterTest {
     }
 
     /**
-     * Contract: a freshly constructed exporter that has received {@code noMoreInput()} without any
-     * offered rows must report end-of-stream by returning {@code false} from
-     * {@code exportNextBatch}.
+     * Contract: {@link FlinkArrowFFIExporter#exportNextBatch(long)} returns {@code false}
+     * whenever the buffer is empty. Without this contract, mid-stream empty pulls would
+     * return {@code true} with a 0-row batch and the native FFI Reader's loop would spin on
+     * empty batches in steady state.
      */
     @Test
-    public void testExportNextBatch_returnsFalseAfterNoMoreInput() {
+    public void testExportNextBatchReturnsFalseOnEmpty() {
         try (BufferAllocator allocator =
-                FlinkArrowUtils.ROOT_ALLOCATOR.newChildAllocator("testEoiEmpty", 0, Long.MAX_VALUE)) {
+                FlinkArrowUtils.ROOT_ALLOCATOR.newChildAllocator("testEmptyReturnsFalse", 0, Long.MAX_VALUE)) {
             RowType rowType = simpleRowType();
             try (FlinkArrowFFIExporter exporter = new FlinkArrowFFIExporter(allocator, rowType, 100);
                     ArrowArray ffiArray = ArrowArray.allocateNew(allocator)) {
-                exporter.noMoreInput();
-                assertFalse(exporter.exportNextBatch(ffiArray.memoryAddress()));
-            }
-        }
-    }
-
-    /**
-     * Contract: when end-of-input arrives after offering a partial batch (below the limit), the
-     * exporter must still flush the buffered rows on the next {@code exportNextBatch} call (returns
-     * {@code true}) and only then signal end-of-stream on the subsequent call ({@code false}).
-     */
-    @Test
-    public void testExportNextBatch_returnsTrueOnPartialBatchAfterNoMoreInput() {
-        try (BufferAllocator allocator =
-                FlinkArrowUtils.ROOT_ALLOCATOR.newChildAllocator("testPartialFlush", 0, Long.MAX_VALUE)) {
-            RowType rowType = simpleRowType();
-            try (FlinkArrowFFIExporter exporter = new FlinkArrowFFIExporter(allocator, rowType, 100)) {
-                exporter.offer(makeRow(0));
-                exporter.offer(makeRow(1));
-                exporter.offer(makeRow(2));
-                exporter.noMoreInput();
-
-                try (ArrowArray ffiArray = ArrowArray.allocateNew(allocator);
-                        ArrowSchema ffiSchema = ArrowSchema.allocateNew(allocator);
-                        CDataDictionaryProvider dictProvider = new CDataDictionaryProvider()) {
-                    exporter.exportSchema(ffiSchema.memoryAddress());
-                    Schema schema = Data.importSchema(allocator, ffiSchema, dictProvider);
-
-                    assertTrue(exporter.exportNextBatch(ffiArray.memoryAddress()));
-
-                    try (VectorSchemaRoot importRoot = VectorSchemaRoot.create(schema, allocator)) {
-                        Data.importIntoVectorSchemaRoot(allocator, ffiArray, importRoot, dictProvider);
-                        assertEquals(3, importRoot.getRowCount());
-                    }
-                }
-
-                // Second call: buffer drained, must signal end-of-stream.
-                try (ArrowArray ffiArray2 = ArrowArray.allocateNew(allocator)) {
-                    assertFalse(exporter.exportNextBatch(ffiArray2.memoryAddress()));
-                }
+                assertFalse(
+                        exporter.exportNextBatch(ffiArray.memoryAddress()),
+                        "exportNextBatch must return false on an empty buffer");
             }
         }
     }

--- a/auron-flink-extension/auron-flink-runtime/src/test/java/org/apache/auron/flink/metric/FlinkMetricNodeTest.java
+++ b/auron-flink-extension/auron-flink-runtime/src/test/java/org/apache/auron/flink/metric/FlinkMetricNodeTest.java
@@ -1,0 +1,228 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.auron.flink.metric;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.auron.metric.MetricNode;
+import org.apache.flink.metrics.CharacterFilter;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.Gauge;
+import org.apache.flink.metrics.Histogram;
+import org.apache.flink.metrics.Meter;
+import org.apache.flink.metrics.MetricGroup;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for {@link FlinkMetricNode}. */
+public class FlinkMetricNodeTest {
+
+    @Test
+    public void testAddCreatesCounterOnFirstCall() {
+        FakeMetricGroup group = new FakeMetricGroup();
+        FlinkMetricNode node = new FlinkMetricNode(group, new ArrayList<>());
+
+        node.add("rows", 5L);
+
+        assertEquals(1, group.counterCallCount("rows"), "MetricGroup.counter(\"rows\") should be invoked exactly once");
+        FakeCounter created = group.lastCreatedFor("rows");
+        assertEquals(1, created.incCallCount, "Counter.inc should be invoked once");
+        assertEquals(5L, created.lastIncValue, "Counter.inc should be called with the added value");
+        assertEquals(5L, created.totalIncSum);
+    }
+
+    @Test
+    public void testAddReusesCounter() {
+        FakeMetricGroup group = new FakeMetricGroup();
+        FlinkMetricNode node = new FlinkMetricNode(group, new ArrayList<>());
+
+        node.add("rows", 5L);
+        node.add("rows", 3L);
+
+        assertEquals(
+                1,
+                group.counterCallCount("rows"),
+                "MetricGroup.counter(\"rows\") should be cached after the first call");
+        FakeCounter created = group.lastCreatedFor("rows");
+        assertEquals(2, created.incCallCount, "Counter.inc should be invoked twice");
+        assertEquals(3L, created.lastIncValue, "Counter.inc should be called with the latest value");
+        assertEquals(8L, created.totalIncSum, "Counter increments should accumulate (5 + 3)");
+    }
+
+    @Test
+    public void testAddIgnoresZeroValue() {
+        FakeMetricGroup group = new FakeMetricGroup();
+        FlinkMetricNode node = new FlinkMetricNode(group, new ArrayList<>());
+
+        node.add("rows", 0L);
+        node.add("rows", -1L);
+
+        assertEquals(0, group.counterCallCount("rows"), "No counter should be created when value <= 0");
+        assertEquals(0, group.totalCounterCalls(), "No counter call at all should occur for non-positive values");
+    }
+
+    @Test
+    public void testChildrenPropagation() {
+        MetricNode childA = new RecordingMetricNode();
+        MetricNode childB = new RecordingMetricNode();
+        List<MetricNode> children = Arrays.asList(childA, childB);
+        FlinkMetricNode node = new FlinkMetricNode(new FakeMetricGroup(), children);
+
+        assertSame(childA, node.getChild(0));
+        assertSame(childB, node.getChild(1));
+        assertThrows(IndexOutOfBoundsException.class, () -> node.getChild(2));
+    }
+
+    // ---------------------------------------------------------------------
+    // Hand-rolled fakes for Flink metric interfaces (no Mockito available).
+    // ---------------------------------------------------------------------
+
+    /** Recording fake of {@link Counter}: tracks inc() calls and accumulates totals. */
+    private static final class FakeCounter implements Counter {
+        int incCallCount;
+        long lastIncValue;
+        long totalIncSum;
+
+        @Override
+        public void inc() {
+            inc(1L);
+        }
+
+        @Override
+        public void inc(long n) {
+            incCallCount++;
+            lastIncValue = n;
+            totalIncSum += n;
+        }
+
+        @Override
+        public void dec() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void dec(long n) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public long getCount() {
+            return totalIncSum;
+        }
+    }
+
+    /**
+     * Recording fake of {@link MetricGroup}: only {@link #counter(String)} is implemented; tracks
+     * how many times it was called per metric name and returns the same {@link FakeCounter}
+     * instance for a given name across calls (so the production code's caching can be observed
+     * by counting invocations).
+     */
+    private static final class FakeMetricGroup implements MetricGroup {
+        private final Map<String, Integer> counterCalls = new HashMap<>();
+        private final Map<String, FakeCounter> created = new HashMap<>();
+
+        int counterCallCount(String name) {
+            return counterCalls.getOrDefault(name, 0);
+        }
+
+        int totalCounterCalls() {
+            int sum = 0;
+            for (int v : counterCalls.values()) {
+                sum += v;
+            }
+            return sum;
+        }
+
+        FakeCounter lastCreatedFor(String name) {
+            return created.get(name);
+        }
+
+        @Override
+        public Counter counter(String name) {
+            counterCalls.merge(name, 1, Integer::sum);
+            return created.computeIfAbsent(name, k -> new FakeCounter());
+        }
+
+        @Override
+        public <C extends Counter> C counter(String name, C counter) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <T, G extends Gauge<T>> G gauge(String name, G gauge) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <H extends Histogram> H histogram(String name, H histogram) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <M extends Meter> M meter(String name, M meter) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public MetricGroup addGroup(String name) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public MetricGroup addGroup(String key, String value) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String[] getScopeComponents() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Map<String, String> getAllVariables() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String getMetricIdentifier(String metricName) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String getMetricIdentifier(String metricName, CharacterFilter filter) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    /** Trivial {@link MetricNode} for child-propagation tests; never receives add() calls. */
+    private static final class RecordingMetricNode extends MetricNode {
+        RecordingMetricNode() {
+            super(new ArrayList<>());
+        }
+
+        @Override
+        public void add(String name, long value) {
+            // no-op
+        }
+    }
+}

--- a/auron-flink-extension/auron-flink-runtime/src/test/java/org/apache/auron/flink/runtime/operator/FlinkAuronCalcOperatorTest.java
+++ b/auron-flink-extension/auron-flink-runtime/src/test/java/org/apache/auron/flink/runtime/operator/FlinkAuronCalcOperatorTest.java
@@ -81,13 +81,13 @@ import org.junit.jupiter.api.Test;
  * and {@link FlinkAuronCalcOperator#getMetricGroup()}; the inherited protected {@code output}
  * field is set through reflection.
  *
- * <p>SPEC-derived test contracts (TDD Step A — written before production code exists):
+ * <p>Contracts verified by this class:
  *
  * <ol>
  *   <li>{@code open()} must register the exporter into {@link JniBridge} resources under a
  *       runtime-bound resource ID.
- *   <li>The resource ID must encode the Flink operator unique ID and subtask index (operator
- *       quality OQ1 = per-subtask uniqueness).
+ *   <li>The resource ID must encode the Flink operator unique ID and subtask index so
+ *       registrations from concurrent subtasks of the same operator never collide.
  *   <li>{@code processElement} must buffer rows into the exporter without prematurely draining.
  *   <li>When the exporter signals batch-full, the operator must drain the native runtime in the
  *       same {@code processElement} invocation.
@@ -148,7 +148,7 @@ public class FlinkAuronCalcOperatorTest {
      */
     @Test
     public void testOpenRegistersExporterViaPutResource() throws Exception {
-        TestableOperator op = newOperator();
+        TestFlinkAuronCalcOperator op = newOperator();
         op.open();
 
         String key = findOnlyNewResourceKey();
@@ -165,7 +165,7 @@ public class FlinkAuronCalcOperatorTest {
     }
 
     // ---------------------------------------------------------------------
-    // 2) Resource ID encodes Flink operator unique ID + subtask (OQ1)
+    // 2) Resource ID encodes Flink operator unique ID + subtask
     // ---------------------------------------------------------------------
 
     /**
@@ -173,12 +173,12 @@ public class FlinkAuronCalcOperatorTest {
      * unique ID and subtask index. Non-FFI fields ({@code num_partitions}, {@code schema}) must
      * be preserved unchanged. The {@link FFIReaderExecNode} proto has no
      * {@code auron_operator_id} field (only {@code KafkaScanExecNode} does); the resource ID is
-     * the only place where the Flink operator identity is propagated to native code (OQ1).
+     * the only place where the Flink operator identity is propagated to native code.
      */
     @Test
     public void testResourceIdEmbedsFlinkOperatorIdAndSubtask() throws Exception {
         PhysicalPlanNode plan = buildProjectFilterFfiReaderPlan(4);
-        TestableOperator op = newOperator(plan);
+        TestFlinkAuronCalcOperator op = newOperator(plan);
         op.open();
 
         PhysicalPlanNode runtime = readRuntimePlan(op);
@@ -196,7 +196,7 @@ public class FlinkAuronCalcOperatorTest {
         assertEquals(originalLeaf.getNumPartitions(), leaf.getNumPartitions());
         assertEquals(originalLeaf.getSchema(), leaf.getSchema());
 
-        // OQ1 reminder: FFIReaderExecNode proto has only 3 fields; no auron_operator_id.
+        // FFIReaderExecNode proto has only 3 fields; no auron_operator_id.
         assertEquals(3, FFIReaderExecNode.getDescriptor().getFields().size());
 
         op.close();
@@ -244,6 +244,74 @@ public class FlinkAuronCalcOperatorTest {
             assertTrue(
                     op.fakeRuntime.loadNextBatchInvocations >= 1,
                     "Drain should be triggered when exporter.isBatchFull() returns true");
+        } finally {
+            op.close();
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // 4b) Multi-cycle drain — operator must reinit after each drain cycle
+    // ---------------------------------------------------------------------
+
+    /**
+     * Contract: the real {@link org.apache.auron.jni.AuronCallNativeWrapper#loadNextBatch}
+     * auto-closes its native runtime when {@code JniBridge.nextBatch} returns false, and the
+     * native FFI Reader's drop calls Java {@code close()} on the exporter. The operator
+     * therefore must reinitialize both {@link FlinkArrowFFIExporter} and the
+     * {@link FlinkAuronCalcOperator.NativeRuntime} after every drain cycle so subsequent
+     * {@code processElement} calls work correctly. Three consecutive batch-full triggers must
+     * produce no exception; the factory must be invoked once for {@code open()} plus once per
+     * drain cycle (= 4 total); the exporter must be re-registered under the same
+     * {@code resourceId} after each cycle; and the operator must still accept offers after the
+     * reinit cycles.
+     */
+    @Test
+    public void testProcessElementMultiCycleDrainReinitializesWrapper() throws Exception {
+        java.util.concurrent.atomic.AtomicInteger factoryCalls = new java.util.concurrent.atomic.AtomicInteger();
+        FlinkAuronCalcOperator.NativeRuntimeFactory factory = (a, p, m, mem) -> {
+            factoryCalls.incrementAndGet();
+            return new OneShotNativeRuntime();
+        };
+        PhysicalPlanNode plan = buildProjectFilterFfiReaderPlan(1);
+        RowType rowType = RowType.of(new LogicalType[] {new IntType()}, new String[] {"id"});
+        FakeExporterTrackingOperator op =
+                new FakeExporterTrackingOperator(plan, rowType, rowType, "auron-op-id", factory, /* fullAfterRows */ 1);
+        op.open();
+        String resourceId = findOnlyNewResourceKey(); // captured after open()'s putResource
+        try {
+            for (int cycle = 1; cycle <= 3; cycle++) {
+                op.processElement(new StreamRecord<>(GenericRowData.of(cycle)));
+
+                // After each drain cycle the operator must have re-registered the exporter
+                // under the same resourceId; otherwise the next native runtime would fail to
+                // look up the FFI exporter.
+                assertNotNull(
+                        peekResource(resourceId),
+                        "Cycle " + cycle + ": exporter must be re-registered under resourceId "
+                                + "after drainNative reinit");
+                assertSame(
+                        op.tracker,
+                        peekResource(resourceId),
+                        "Cycle " + cycle + ": the re-registered exporter must be the same "
+                                + "tracker instance (per-cycle reinit reuses the operator-owned exporter)");
+            }
+
+            assertEquals(
+                    4,
+                    factoryCalls.get(),
+                    "Native runtime must be reinitialized after each batch-full drain cycle "
+                            + "(1 for open() + 3 reinit)");
+
+            // After three reinit cycles, the operator must still accept input. Offer one more
+            // row and verify the tracker (re-registered each cycle, never closed by our fake)
+            // still records it.
+            int offerCountBefore = op.tracker.offerCount;
+            op.processElement(new StreamRecord<>(GenericRowData.of(99)));
+            assertEquals(
+                    offerCountBefore + 1,
+                    op.tracker.offerCount,
+                    "After three drain reinit cycles the operator must still accept offers "
+                            + "(verifies the exporter is in a usable state post-reinit)");
         } finally {
             op.close();
         }
@@ -312,9 +380,9 @@ public class FlinkAuronCalcOperatorTest {
     // ---------------------------------------------------------------------
 
     /**
-     * Contract: {@code close()} must flush in-flight rows by setting {@code noMoreInput} on the
-     * exporter and draining, then release native runtime, exporter, and child allocator in
-     * order. Calling {@code close()} twice must not throw and must not double-close.
+     * Contract: {@code close()} must flush in-flight rows by draining, then release the native
+     * runtime, exporter, and child allocator in order. Calling {@code close()} twice must not
+     * throw and must not double-close.
      */
     @Test
     public void testCloseDrainsResidueAndIsIdempotent() throws Exception {
@@ -326,7 +394,6 @@ public class FlinkAuronCalcOperatorTest {
 
         op.close();
 
-        assertTrue(op.tracker.noMoreInputCalled, "close() must invoke exporter.noMoreInput()");
         assertTrue(op.tracker.closeCount >= 1, "close() must close the exporter");
         assertEquals(1, op.fakeRuntime.closeInvocations, "close() must close native runtime");
         assertEquals(0L, op.openedChildAllocator.getAllocatedMemory(), "Child allocator must be drained after close");
@@ -348,7 +415,7 @@ public class FlinkAuronCalcOperatorTest {
     @Test
     public void testGetPhysicalPlanNodesReturnsConstructorPlan() {
         PhysicalPlanNode plan = buildProjectFilterFfiReaderPlan(2);
-        TestableOperator op = newOperator(plan);
+        TestFlinkAuronCalcOperator op = newOperator(plan);
         List<PhysicalPlanNode> nodes = op.getPhysicalPlanNodes();
         assertEquals(1, nodes.size(), "Should return exactly one plan node");
         assertSame(plan, nodes.get(0), "Should return the constructor-passed instance");
@@ -365,7 +432,7 @@ public class FlinkAuronCalcOperatorTest {
      */
     @Test
     public void testGetAuronOperatorIdReturnsUnsuffixed() throws Exception {
-        TestableOperator op = newOperator("my-calc-op");
+        TestFlinkAuronCalcOperator op = newOperator("my-calc-op");
         op.open();
         try {
             assertEquals("my-calc-op", op.getAuronOperatorId());
@@ -491,22 +558,23 @@ public class FlinkAuronCalcOperatorTest {
     // Construction helpers
     // =====================================================================
 
-    private TestableOperator newOperator() {
+    private TestFlinkAuronCalcOperator newOperator() {
         return newOperator(buildProjectFilterFfiReaderPlan(2), "auron-op-id");
     }
 
-    private TestableOperator newOperator(String auronOperatorId) {
+    private TestFlinkAuronCalcOperator newOperator(String auronOperatorId) {
         return newOperator(buildProjectFilterFfiReaderPlan(2), auronOperatorId);
     }
 
-    private TestableOperator newOperator(PhysicalPlanNode plan) {
+    private TestFlinkAuronCalcOperator newOperator(PhysicalPlanNode plan) {
         return newOperator(plan, "auron-op-id");
     }
 
-    private TestableOperator newOperator(PhysicalPlanNode plan, String auronOperatorId) {
+    private TestFlinkAuronCalcOperator newOperator(PhysicalPlanNode plan, String auronOperatorId) {
         RowType rowType = RowType.of(new LogicalType[] {new IntType()}, new String[] {"id"});
         FakeNativeRuntime runtime = new FakeNativeRuntime();
-        TestableOperator op = new TestableOperator(plan, rowType, rowType, auronOperatorId, (a, p, m, mem) -> runtime);
+        TestFlinkAuronCalcOperator op =
+                new TestFlinkAuronCalcOperator(plan, rowType, rowType, auronOperatorId, (a, p, m, mem) -> runtime);
         op.fakeRuntime = runtime;
         return op;
     }
@@ -593,17 +661,20 @@ public class FlinkAuronCalcOperatorTest {
     // =====================================================================
 
     /**
-     * Operator subclass that stubs out the Flink runtime context. Uses
-     * {@link sun.misc.Unsafe#allocateInstance} to build a {@link StreamingRuntimeContext}
-     * without invoking its heavy real constructor; overrides only the methods we exercise.
+     * Test seam: a subclass of {@link FlinkAuronCalcOperator} that stubs out the Flink runtime
+     * context dependencies the operator under test consumes (operator unique ID, subtask index,
+     * metric group, processing-time service, and the inherited {@code output} field).
+     * {@link StreamingRuntimeContext} is built via {@link sun.misc.Unsafe#allocateInstance} to
+     * skip its heavy real constructor; only the methods the operator actually calls are
+     * overridden.
      */
-    static class TestableOperator extends FlinkAuronCalcOperator {
+    static class TestFlinkAuronCalcOperator extends FlinkAuronCalcOperator {
         FakeNativeRuntime fakeRuntime; // set by factory closure after construction
         final StubMetricGroup metricGroup = new StubMetricGroup();
         final FakeOutput fakeOutput = new FakeOutput();
         BufferAllocator openedChildAllocator;
 
-        TestableOperator(
+        TestFlinkAuronCalcOperator(
                 PhysicalPlanNode plan,
                 RowType inputRowType,
                 RowType outputRowType,
@@ -643,9 +714,9 @@ public class FlinkAuronCalcOperatorTest {
 
     /**
      * Subclass that swaps the real exporter for a {@link TrackingExporter} so tests can observe
-     * offer/isBatchFull/noMoreInput/close calls deterministically.
+     * offer/isBatchFull/close calls deterministically.
      */
-    static class FakeExporterTrackingOperator extends TestableOperator {
+    static class FakeExporterTrackingOperator extends TestFlinkAuronCalcOperator {
         final int fullAfterRows;
         TrackingExporter tracker;
         final List<String> events = new ArrayList<>();
@@ -706,6 +777,35 @@ public class FlinkAuronCalcOperatorTest {
     }
 
     /**
+     * Fake {@link FlinkAuronCalcOperator.NativeRuntime} mirroring the production close-on-false
+     * semantic of {@link org.apache.auron.jni.AuronCallNativeWrapper#loadNextBatch}
+     * (auron-core/.../AuronCallNativeWrapper.java:127): the first {@code loadNextBatch} call
+     * returns false and closes itself; subsequent calls would indicate the operator failed to
+     * reinitialize per drain cycle (asserted as a test failure).
+     */
+    static final class OneShotNativeRuntime implements FlinkAuronCalcOperator.NativeRuntime {
+        int loadNextBatchInvocations;
+        int closeInvocations;
+        boolean closedByDrain;
+
+        @Override
+        public boolean loadNextBatch(Consumer<VectorSchemaRoot> consumer) {
+            if (closedByDrain) {
+                throw new IllegalStateException(
+                        "loadNextBatch called on a closed OneShotNativeRuntime — operator did not reinit");
+            }
+            loadNextBatchInvocations++;
+            closedByDrain = true; // production wrapper auto-closes on false return
+            return false;
+        }
+
+        @Override
+        public void close() {
+            closeInvocations++;
+        }
+    }
+
+    /**
      * Tracking subclass of {@link FlinkArrowFFIExporter} that records call counts. The Arrow
      * allocations are still set up by the parent constructor; {@code offer} is intercepted so
      * tests can observe rows without committing them to the writer (avoids row-type/schema
@@ -714,7 +814,6 @@ public class FlinkAuronCalcOperatorTest {
     static final class TrackingExporter extends FlinkArrowFFIExporter {
         int offerCount;
         int closeCount;
-        boolean noMoreInputCalled;
         RowData lastOffered;
         final int fullAfterRows;
 
@@ -734,9 +833,15 @@ public class FlinkAuronCalcOperatorTest {
             return offerCount >= fullAfterRows;
         }
 
+        /**
+         * Bypasses the parent's writer in {@link #offer(RowData)}, so the parent's
+         * {@code rowCount} stays at zero. Without this override, the operator's empty-drain
+         * short-circuit would skip every drain in tests that rely on {@code offerCount}-based
+         * fullness.
+         */
         @Override
-        public void noMoreInput() {
-            noMoreInputCalled = true;
+        public boolean isEmpty() {
+            return offerCount == 0;
         }
 
         @Override

--- a/auron-flink-extension/auron-flink-runtime/src/test/java/org/apache/auron/flink/runtime/operator/FlinkAuronCalcOperatorTest.java
+++ b/auron-flink-extension/auron-flink-runtime/src/test/java/org/apache/auron/flink/runtime/operator/FlinkAuronCalcOperatorTest.java
@@ -1,0 +1,977 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.auron.flink.runtime.operator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Consumer;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.auron.flink.arrow.FlinkArrowFFIExporter;
+import org.apache.auron.jni.JniBridge;
+import org.apache.auron.protobuf.FFIReaderExecNode;
+import org.apache.auron.protobuf.FilterExecNode;
+import org.apache.auron.protobuf.LimitExecNode;
+import org.apache.auron.protobuf.PhysicalPlanNode;
+import org.apache.auron.protobuf.ProjectionExecNode;
+import org.apache.auron.protobuf.Schema;
+import org.apache.flink.api.common.operators.ProcessingTimeService.ProcessingTimeCallback;
+import org.apache.flink.metrics.CharacterFilter;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.Gauge;
+import org.apache.flink.metrics.Histogram;
+import org.apache.flink.metrics.Meter;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.metrics.groups.OperatorIOMetricGroup;
+import org.apache.flink.metrics.groups.OperatorMetricGroup;
+import org.apache.flink.streaming.api.operators.Output;
+import org.apache.flink.streaming.api.operators.StreamingRuntimeContext;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
+import org.apache.flink.streaming.runtime.watermarkstatus.WatermarkStatus;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.util.OutputTag;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link FlinkAuronCalcOperator}.
+ *
+ * <p>All tests use the {@code NativeRuntime} mock seam — no real native engine invocation, no
+ * {@code libauron} load, no real {@code JniBridge.callNative}. The Flink runtime context is
+ * stubbed via a test subclass that overrides {@link FlinkAuronCalcOperator#getRuntimeContext()}
+ * and {@link FlinkAuronCalcOperator#getMetricGroup()}; the inherited protected {@code output}
+ * field is set through reflection.
+ *
+ * <p>SPEC-derived test contracts (TDD Step A — written before production code exists):
+ *
+ * <ol>
+ *   <li>{@code open()} must register the exporter into {@link JniBridge} resources under a
+ *       runtime-bound resource ID.
+ *   <li>The resource ID must encode the Flink operator unique ID and subtask index (operator
+ *       quality OQ1 = per-subtask uniqueness).
+ *   <li>{@code processElement} must buffer rows into the exporter without prematurely draining.
+ *   <li>When the exporter signals batch-full, the operator must drain the native runtime in the
+ *       same {@code processElement} invocation.
+ *   <li>{@code processWatermark} must drain BEFORE forwarding the watermark downstream.
+ *   <li>{@code prepareSnapshotPreBarrier} must drain in-flight rows (Calc is stateless, but
+ *       buffered rows must reach downstream before the checkpoint barrier).
+ *   <li>{@code close()} must flush residue rows, then close native runtime, exporter, and
+ *       allocator in order; idempotent.
+ *   <li>{@link SupportsAuronNative#getPhysicalPlanNodes()} must return the constructor-passed
+ *       plan as the sole element.
+ *   <li>{@link SupportsAuronNative#getAuronOperatorId()} must return the unsuffixed value
+ *       passed in the constructor.
+ * </ol>
+ */
+public class FlinkAuronCalcOperatorTest {
+
+    private static final String FLINK_OP_UNIQUE_ID = "calc-op-7";
+    private static final int SUBTASK_INDEX = 3;
+
+    /**
+     * Repo-wide surefire sets {@code java.io.tmpdir=target/tmp} which may not exist on a clean
+     * build. The Arrow C-Data JNI loader uses {@link File#createTempFile} when extracting its
+     * native library; ensure the dir exists before any test runs.
+     */
+    @BeforeAll
+    public static void ensureTmpDirExists() {
+        String tmp = System.getProperty("java.io.tmpdir");
+        if (tmp != null) {
+            new File(tmp).mkdirs();
+        }
+    }
+
+    private List<String> registeredKeysBefore;
+
+    @BeforeEach
+    public void snapshotRegisteredKeys() throws Exception {
+        registeredKeysBefore = new ArrayList<>(peekJniResourceKeys());
+    }
+
+    @AfterEach
+    public void cleanupResources() throws Exception {
+        // Remove any new keys the test created so subsequent tests start clean.
+        for (String key : peekJniResourceKeys()) {
+            if (!registeredKeysBefore.contains(key)) {
+                JniBridge.getResource(key); // removes
+            }
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // 1) JniBridge.putResource integration
+    // ---------------------------------------------------------------------
+
+    /**
+     * Contract: after {@code open()}, the operator must have registered its exporter via
+     * {@link JniBridge#putResource(String, Object)} under a key starting with
+     * {@code "FlinkAuronCalc-"}; the registered value must be a {@link FlinkArrowFFIExporter}.
+     */
+    @Test
+    public void testOpenRegistersExporterViaPutResource() throws Exception {
+        TestableOperator op = newOperator();
+        op.open();
+
+        String key = findOnlyNewResourceKey();
+        assertTrue(key.startsWith("FlinkAuronCalc-"), "Resource key should start with FlinkAuronCalc- but was: " + key);
+
+        Object value = peekResource(key);
+        assertNotNull(value, "putResource should have registered a non-null value");
+        assertTrue(
+                value instanceof FlinkArrowFFIExporter,
+                "Registered resource should be a FlinkArrowFFIExporter but was: "
+                        + value.getClass().getName());
+
+        op.close();
+    }
+
+    // ---------------------------------------------------------------------
+    // 2) Resource ID encodes Flink operator unique ID + subtask (OQ1)
+    // ---------------------------------------------------------------------
+
+    /**
+     * Contract: the resource ID injected into the FFI Reader leaf must encode the Flink operator
+     * unique ID and subtask index. Non-FFI fields ({@code num_partitions}, {@code schema}) must
+     * be preserved unchanged. The {@link FFIReaderExecNode} proto has no
+     * {@code auron_operator_id} field (only {@code KafkaScanExecNode} does); the resource ID is
+     * the only place where the Flink operator identity is propagated to native code (OQ1).
+     */
+    @Test
+    public void testResourceIdEmbedsFlinkOperatorIdAndSubtask() throws Exception {
+        PhysicalPlanNode plan = buildProjectFilterFfiReaderPlan(4);
+        TestableOperator op = newOperator(plan);
+        op.open();
+
+        PhysicalPlanNode runtime = readRuntimePlan(op);
+        FFIReaderExecNode leaf = descendToFfiReader(runtime);
+
+        String resourceId = leaf.getExportIterProviderResourceId();
+        Pattern expected = Pattern.compile("^FlinkAuronCalc-" + FLINK_OP_UNIQUE_ID + "-" + SUBTASK_INDEX + ":(.+)$");
+        Matcher m = expected.matcher(resourceId);
+        assertTrue(
+                m.matches(), "Resource ID should match FlinkAuronCalc-<opId>-<subtask>:<uuid> but was: " + resourceId);
+        UUID.fromString(m.group(1));
+
+        // Constructor-supplied non-FFI fields are preserved.
+        FFIReaderExecNode originalLeaf = descendToFfiReader(plan);
+        assertEquals(originalLeaf.getNumPartitions(), leaf.getNumPartitions());
+        assertEquals(originalLeaf.getSchema(), leaf.getSchema());
+
+        // OQ1 reminder: FFIReaderExecNode proto has only 3 fields; no auron_operator_id.
+        assertEquals(3, FFIReaderExecNode.getDescriptor().getFields().size());
+
+        op.close();
+    }
+
+    // ---------------------------------------------------------------------
+    // 3) processElement buffers into exporter
+    // ---------------------------------------------------------------------
+
+    /**
+     * Contract: a single {@code processElement} that does not fill the batch must invoke
+     * {@code exporter.offer(row)} exactly once and must NOT trigger a drain.
+     */
+    @Test
+    public void testProcessElementBuffersIntoExporter() throws Exception {
+        FakeExporterTrackingOperator op = newTrackingOperator(/* fullAfterRows */ 999);
+        op.open();
+        try {
+            RowData row = GenericRowData.of(42);
+            op.processElement(new StreamRecord<>(row));
+
+            assertEquals(1, op.tracker.offerCount);
+            assertSame(row, op.tracker.lastOffered);
+            assertEquals(
+                    0, op.fakeRuntime.loadNextBatchInvocations, "Drain must not be triggered when batch is not full");
+        } finally {
+            op.close();
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // 4) processElement drains when batch is full
+    // ---------------------------------------------------------------------
+
+    /**
+     * Contract: when {@code exporter.isBatchFull()} returns true after the offer, the operator
+     * must drain the native runtime in the same {@code processElement} invocation.
+     */
+    @Test
+    public void testProcessElementDrainsWhenBatchFull() throws Exception {
+        FakeExporterTrackingOperator op = newTrackingOperator(/* fullAfterRows */ 1);
+        op.open();
+        try {
+            op.processElement(new StreamRecord<>(GenericRowData.of(1)));
+            assertTrue(
+                    op.fakeRuntime.loadNextBatchInvocations >= 1,
+                    "Drain should be triggered when exporter.isBatchFull() returns true");
+        } finally {
+            op.close();
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // 5) processWatermark: drain happens BEFORE watermark forwarding
+    // ---------------------------------------------------------------------
+
+    /**
+     * Contract: drain must run BEFORE the watermark is forwarded downstream. Otherwise a
+     * downstream operator may receive a watermark that crosses rows still buffered upstream.
+     */
+    @Test
+    public void testProcessWatermarkDrainsBeforeForward() throws Exception {
+        FakeExporterTrackingOperator op = newTrackingOperator(/* fullAfterRows */ 999);
+        op.open();
+        try {
+            op.processElement(new StreamRecord<>(GenericRowData.of(7)));
+            op.events.clear();
+
+            // Wire both the runtime and the output to record ordered events.
+            op.fakeRuntime.eventsListener = op.events;
+            op.fakeOutput.eventsListener = op.events;
+
+            op.processWatermark(new Watermark(123L));
+
+            assertTrue(op.events.size() >= 2, "Expected at least drain+watermark events but got: " + op.events);
+            assertEquals("drain", op.events.get(0), "First event must be drain");
+            assertEquals(
+                    "watermark:123", op.events.get(op.events.size() - 1), "Last event must be the watermark forward");
+        } finally {
+            op.close();
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // 6) prepareSnapshotPreBarrier: drain in-flight rows
+    // ---------------------------------------------------------------------
+
+    /**
+     * Contract: {@code prepareSnapshotPreBarrier} must drain the native pipeline so buffered
+     * rows reach downstream before the checkpoint barrier crosses them. Calc itself is
+     * stateless; no operator state writes are required.
+     */
+    @Test
+    public void testPrepareSnapshotPreBarrierDrainsInFlight() throws Exception {
+        FakeExporterTrackingOperator op = newTrackingOperator(/* fullAfterRows */ 999);
+        op.open();
+        try {
+            op.processElement(new StreamRecord<>(GenericRowData.of(11)));
+            int loadCountBefore = op.fakeRuntime.loadNextBatchInvocations;
+
+            op.prepareSnapshotPreBarrier(7L);
+
+            assertTrue(
+                    op.fakeRuntime.loadNextBatchInvocations > loadCountBefore,
+                    "prepareSnapshotPreBarrier should trigger a drain");
+        } finally {
+            op.close();
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // 7) close: drains residue, closes resources, idempotent
+    // ---------------------------------------------------------------------
+
+    /**
+     * Contract: {@code close()} must flush in-flight rows by setting {@code noMoreInput} on the
+     * exporter and draining, then release native runtime, exporter, and child allocator in
+     * order. Calling {@code close()} twice must not throw and must not double-close.
+     */
+    @Test
+    public void testCloseDrainsResidueAndIsIdempotent() throws Exception {
+        FakeExporterTrackingOperator op = newTrackingOperator(/* fullAfterRows */ 999);
+        op.open();
+        for (int i = 0; i < 3; i++) {
+            op.processElement(new StreamRecord<>(GenericRowData.of(i)));
+        }
+
+        op.close();
+
+        assertTrue(op.tracker.noMoreInputCalled, "close() must invoke exporter.noMoreInput()");
+        assertTrue(op.tracker.closeCount >= 1, "close() must close the exporter");
+        assertEquals(1, op.fakeRuntime.closeInvocations, "close() must close native runtime");
+        assertEquals(0L, op.openedChildAllocator.getAllocatedMemory(), "Child allocator must be drained after close");
+
+        // Second close: must not throw or double-close.
+        op.close();
+        assertEquals(1, op.fakeRuntime.closeInvocations, "Second close() must not re-close native runtime");
+    }
+
+    // ---------------------------------------------------------------------
+    // 8) SupportsAuronNative.getPhysicalPlanNodes
+    // ---------------------------------------------------------------------
+
+    /**
+     * Contract: {@code getPhysicalPlanNodes()} returns a singleton list containing the
+     * constructor-passed plan (NOT the runtime-rewritten one). Pure getter, no {@code open()}
+     * required.
+     */
+    @Test
+    public void testGetPhysicalPlanNodesReturnsConstructorPlan() {
+        PhysicalPlanNode plan = buildProjectFilterFfiReaderPlan(2);
+        TestableOperator op = newOperator(plan);
+        List<PhysicalPlanNode> nodes = op.getPhysicalPlanNodes();
+        assertEquals(1, nodes.size(), "Should return exactly one plan node");
+        assertSame(plan, nodes.get(0), "Should return the constructor-passed instance");
+    }
+
+    // ---------------------------------------------------------------------
+    // 9) SupportsAuronNative.getAuronOperatorId returns unsuffixed value
+    // ---------------------------------------------------------------------
+
+    /**
+     * Contract: {@code getAuronOperatorId()} returns the unsuffixed value passed in the
+     * constructor — never the subtask-suffixed runtime variant. Mirrors
+     * {@code AuronKafkaSourceFunction#getAuronOperatorId()}.
+     */
+    @Test
+    public void testGetAuronOperatorIdReturnsUnsuffixed() throws Exception {
+        TestableOperator op = newOperator("my-calc-op");
+        op.open();
+        try {
+            assertEquals("my-calc-op", op.getAuronOperatorId());
+        } finally {
+            op.close();
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // 10) injectFfiReaderLeaf shape coverage: bare FFIReader
+    // ---------------------------------------------------------------------
+
+    /**
+     * Contract: when the input plan is a bare {@link FFIReaderExecNode}, {@code
+     * injectFfiReaderLeaf} must return a plan whose FFI Reader has the supplied resource ID;
+     * non-FFI fields ({@code num_partitions}, {@code schema}) are preserved.
+     */
+    @Test
+    public void testInjectFfiReaderLeaf_BareFFIReader() {
+        Schema schema = Schema.newBuilder().build();
+        PhysicalPlanNode in = PhysicalPlanNode.newBuilder()
+                .setFfiReader(FFIReaderExecNode.newBuilder()
+                        .setNumPartitions(5)
+                        .setSchema(schema)
+                        .setExportIterProviderResourceId("placeholder")
+                        .build())
+                .build();
+
+        PhysicalPlanNode out = FlinkAuronCalcOperator.injectFfiReaderLeaf(in, "rid-bare");
+
+        assertTrue(out.hasFfiReader(), "Output root must remain an FFIReader");
+        FFIReaderExecNode leaf = out.getFfiReader();
+        assertEquals("rid-bare", leaf.getExportIterProviderResourceId());
+        assertEquals(5, leaf.getNumPartitions());
+        assertEquals(schema, leaf.getSchema());
+    }
+
+    // ---------------------------------------------------------------------
+    // 11) injectFfiReaderLeaf shape coverage: Project[FFIReader]
+    // ---------------------------------------------------------------------
+
+    /**
+     * Contract: when the input plan is {@code Project[FFIReader]}, {@code injectFfiReaderLeaf}
+     * must preserve the projection wrapper and inject the resource ID into the FFI Reader leaf.
+     */
+    @Test
+    public void testInjectFfiReaderLeaf_ProjectThenFFIReader() {
+        PhysicalPlanNode leaf = PhysicalPlanNode.newBuilder()
+                .setFfiReader(FFIReaderExecNode.newBuilder()
+                        .setNumPartitions(2)
+                        .setSchema(Schema.newBuilder().build())
+                        .setExportIterProviderResourceId("placeholder")
+                        .build())
+                .build();
+        PhysicalPlanNode in = PhysicalPlanNode.newBuilder()
+                .setProjection(ProjectionExecNode.newBuilder().setInput(leaf).build())
+                .build();
+
+        PhysicalPlanNode out = FlinkAuronCalcOperator.injectFfiReaderLeaf(in, "rid-proj");
+
+        assertTrue(out.hasProjection(), "Projection wrapper must be preserved");
+        PhysicalPlanNode inner = out.getProjection().getInput();
+        assertTrue(inner.hasFfiReader(), "Project's child must remain an FFIReader");
+        assertEquals("rid-proj", inner.getFfiReader().getExportIterProviderResourceId());
+    }
+
+    // ---------------------------------------------------------------------
+    // 12) injectFfiReaderLeaf shape coverage: Filter[FFIReader]
+    // ---------------------------------------------------------------------
+
+    /**
+     * Contract: when the input plan is {@code Filter[FFIReader]}, {@code injectFfiReaderLeaf}
+     * must preserve the filter wrapper and inject the resource ID into the FFI Reader leaf.
+     */
+    @Test
+    public void testInjectFfiReaderLeaf_FilterThenFFIReader() {
+        PhysicalPlanNode leaf = PhysicalPlanNode.newBuilder()
+                .setFfiReader(FFIReaderExecNode.newBuilder()
+                        .setNumPartitions(3)
+                        .setSchema(Schema.newBuilder().build())
+                        .setExportIterProviderResourceId("placeholder")
+                        .build())
+                .build();
+        PhysicalPlanNode in = PhysicalPlanNode.newBuilder()
+                .setFilter(FilterExecNode.newBuilder().setInput(leaf).build())
+                .build();
+
+        PhysicalPlanNode out = FlinkAuronCalcOperator.injectFfiReaderLeaf(in, "rid-filter");
+
+        assertTrue(out.hasFilter(), "Filter wrapper must be preserved");
+        PhysicalPlanNode inner = out.getFilter().getInput();
+        assertTrue(inner.hasFfiReader(), "Filter's child must remain an FFIReader");
+        assertEquals("rid-filter", inner.getFfiReader().getExportIterProviderResourceId());
+    }
+
+    // ---------------------------------------------------------------------
+    // 13) injectFfiReaderLeaf: throws on unsupported plan shape
+    // ---------------------------------------------------------------------
+
+    /**
+     * Contract: {@code injectFfiReaderLeaf} must fail fast with an {@link
+     * IllegalArgumentException} on any node type outside the accepted {@code Project} /
+     * {@code Filter} / {@code FFIReader} set, so misconfigurations surface at operator startup
+     * rather than as silent fallthrough. The exception message must mention the unexpected node
+     * type to aid diagnostics.
+     */
+    @Test
+    public void testInjectFfiReaderLeaf_ThrowsOnUnknownShape() {
+        // LimitExecNode is a valid oneof in PhysicalPlanNode but unsupported by the Calc
+        // operator's shape contract (Project / Filter above FFIReader only).
+        PhysicalPlanNode unsupported = PhysicalPlanNode.newBuilder()
+                .setLimit(LimitExecNode.newBuilder().setLimit(10).build())
+                .build();
+
+        IllegalArgumentException ex = assertThrows(
+                IllegalArgumentException.class, () -> FlinkAuronCalcOperator.injectFfiReaderLeaf(unsupported, "rid-x"));
+        assertTrue(
+                ex.getMessage().contains("LIMIT"),
+                "Exception message must identify the unexpected node type for diagnostics, got: " + ex.getMessage());
+    }
+
+    // =====================================================================
+    // Construction helpers
+    // =====================================================================
+
+    private TestableOperator newOperator() {
+        return newOperator(buildProjectFilterFfiReaderPlan(2), "auron-op-id");
+    }
+
+    private TestableOperator newOperator(String auronOperatorId) {
+        return newOperator(buildProjectFilterFfiReaderPlan(2), auronOperatorId);
+    }
+
+    private TestableOperator newOperator(PhysicalPlanNode plan) {
+        return newOperator(plan, "auron-op-id");
+    }
+
+    private TestableOperator newOperator(PhysicalPlanNode plan, String auronOperatorId) {
+        RowType rowType = RowType.of(new LogicalType[] {new IntType()}, new String[] {"id"});
+        FakeNativeRuntime runtime = new FakeNativeRuntime();
+        TestableOperator op = new TestableOperator(plan, rowType, rowType, auronOperatorId, (a, p, m, mem) -> runtime);
+        op.fakeRuntime = runtime;
+        return op;
+    }
+
+    private FakeExporterTrackingOperator newTrackingOperator(int fullAfterRows) {
+        PhysicalPlanNode plan = buildProjectFilterFfiReaderPlan(2);
+        RowType rowType = RowType.of(new LogicalType[] {new IntType()}, new String[] {"id"});
+        FakeNativeRuntime runtime = new FakeNativeRuntime();
+        FakeExporterTrackingOperator op = new FakeExporterTrackingOperator(
+                plan, rowType, rowType, "auron-op-id", (a, p, m, mem) -> runtime, fullAfterRows);
+        op.fakeRuntime = runtime;
+        return op;
+    }
+
+    // =====================================================================
+    // Plan construction helpers
+    // =====================================================================
+
+    /** Builds Project[Filter[FFIReader-placeholder]]. */
+    private static PhysicalPlanNode buildProjectFilterFfiReaderPlan(int numPartitions) {
+        Schema emptySchema = Schema.newBuilder().build();
+        PhysicalPlanNode leaf = PhysicalPlanNode.newBuilder()
+                .setFfiReader(FFIReaderExecNode.newBuilder()
+                        .setNumPartitions(numPartitions)
+                        .setSchema(emptySchema)
+                        .setExportIterProviderResourceId("placeholder")
+                        .build())
+                .build();
+        PhysicalPlanNode filter = PhysicalPlanNode.newBuilder()
+                .setFilter(FilterExecNode.newBuilder().setInput(leaf).build())
+                .build();
+        return PhysicalPlanNode.newBuilder()
+                .setProjection(ProjectionExecNode.newBuilder().setInput(filter).build())
+                .build();
+    }
+
+    private static FFIReaderExecNode descendToFfiReader(PhysicalPlanNode node) {
+        if (node.hasFfiReader()) {
+            return node.getFfiReader();
+        }
+        if (node.hasProjection()) {
+            return descendToFfiReader(node.getProjection().getInput());
+        }
+        if (node.hasFilter()) {
+            return descendToFfiReader(node.getFilter().getInput());
+        }
+        return fail("No FFI Reader found in plan");
+    }
+
+    // =====================================================================
+    // Reflection helpers
+    // =====================================================================
+
+    private static PhysicalPlanNode readRuntimePlan(FlinkAuronCalcOperator op) throws Exception {
+        Field f = FlinkAuronCalcOperator.class.getDeclaredField("runtimePlan");
+        f.setAccessible(true);
+        return (PhysicalPlanNode) f.get(op);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> peekJniResourceMap() throws Exception {
+        Field f = JniBridge.class.getDeclaredField("resourcesMap");
+        f.setAccessible(true);
+        return (Map<String, Object>) f.get(null);
+    }
+
+    private static List<String> peekJniResourceKeys() throws Exception {
+        return new ArrayList<>(peekJniResourceMap().keySet());
+    }
+
+    private static Object peekResource(String key) throws Exception {
+        return peekJniResourceMap().get(key);
+    }
+
+    private String findOnlyNewResourceKey() throws Exception {
+        List<String> after = peekJniResourceKeys();
+        after.removeAll(registeredKeysBefore);
+        assertEquals(1, after.size(), "Exactly one new resource key expected, got: " + after);
+        return after.get(0);
+    }
+
+    // =====================================================================
+    // Test subclasses of the operator
+    // =====================================================================
+
+    /**
+     * Operator subclass that stubs out the Flink runtime context. Uses
+     * {@link sun.misc.Unsafe#allocateInstance} to build a {@link StreamingRuntimeContext}
+     * without invoking its heavy real constructor; overrides only the methods we exercise.
+     */
+    static class TestableOperator extends FlinkAuronCalcOperator {
+        FakeNativeRuntime fakeRuntime; // set by factory closure after construction
+        final StubMetricGroup metricGroup = new StubMetricGroup();
+        final FakeOutput fakeOutput = new FakeOutput();
+        BufferAllocator openedChildAllocator;
+
+        TestableOperator(
+                PhysicalPlanNode plan,
+                RowType inputRowType,
+                RowType outputRowType,
+                String auronOperatorId,
+                NativeRuntimeFactory factory) {
+            super(plan, inputRowType, outputRowType, auronOperatorId, factory);
+            setProtectedOutput(this, fakeOutput);
+        }
+
+        @Override
+        public StreamingRuntimeContext getRuntimeContext() {
+            return makeStubRuntimeContext();
+        }
+
+        @Override
+        public OperatorMetricGroup getMetricGroup() {
+            return metricGroup;
+        }
+
+        @Override
+        public ProcessingTimeService getProcessingTimeService() {
+            return new StubProcessingTimeService();
+        }
+
+        @Override
+        public void open() throws Exception {
+            super.open();
+            this.openedChildAllocator = readChildAllocator();
+        }
+
+        BufferAllocator readChildAllocator() throws Exception {
+            Field f = FlinkAuronCalcOperator.class.getDeclaredField("childAllocator");
+            f.setAccessible(true);
+            return (BufferAllocator) f.get(this);
+        }
+    }
+
+    /**
+     * Subclass that swaps the real exporter for a {@link TrackingExporter} so tests can observe
+     * offer/isBatchFull/noMoreInput/close calls deterministically.
+     */
+    static class FakeExporterTrackingOperator extends TestableOperator {
+        final int fullAfterRows;
+        TrackingExporter tracker;
+        final List<String> events = new ArrayList<>();
+
+        FakeExporterTrackingOperator(
+                PhysicalPlanNode plan,
+                RowType inputRowType,
+                RowType outputRowType,
+                String auronOperatorId,
+                NativeRuntimeFactory factory,
+                int fullAfterRows) {
+            super(plan, inputRowType, outputRowType, auronOperatorId, factory);
+            this.fullAfterRows = fullAfterRows;
+        }
+
+        @Override
+        public void open() throws Exception {
+            super.open();
+            tracker = new TrackingExporter(openedChildAllocator, super.getOutputType(), fullAfterRows);
+            // Swap exporter in the parent.
+            Field f = FlinkAuronCalcOperator.class.getDeclaredField("exporter");
+            f.setAccessible(true);
+            FlinkArrowFFIExporter original = (FlinkArrowFFIExporter) f.get(this);
+            original.close();
+            f.set(this, tracker);
+        }
+    }
+
+    // =====================================================================
+    // Fakes
+    // =====================================================================
+
+    /** Fake {@link FlinkAuronCalcOperator.NativeRuntime} — programmable + invocation tracking. */
+    static final class FakeNativeRuntime implements FlinkAuronCalcOperator.NativeRuntime {
+        int loadNextBatchInvocations;
+        int closeInvocations;
+        final Deque<VectorSchemaRoot> rootsToEmit = new ArrayDeque<>();
+        List<String> eventsListener; // optional: appends "drain" on each call
+
+        @Override
+        public boolean loadNextBatch(Consumer<VectorSchemaRoot> consumer) {
+            loadNextBatchInvocations++;
+            if (eventsListener != null) {
+                eventsListener.add("drain");
+            }
+            VectorSchemaRoot next = rootsToEmit.poll();
+            if (next == null) {
+                return false;
+            }
+            consumer.accept(next);
+            return true;
+        }
+
+        @Override
+        public void close() {
+            closeInvocations++;
+        }
+    }
+
+    /**
+     * Tracking subclass of {@link FlinkArrowFFIExporter} that records call counts. The Arrow
+     * allocations are still set up by the parent constructor; {@code offer} is intercepted so
+     * tests can observe rows without committing them to the writer (avoids row-type/schema
+     * enforcement issues for hand-built rows).
+     */
+    static final class TrackingExporter extends FlinkArrowFFIExporter {
+        int offerCount;
+        int closeCount;
+        boolean noMoreInputCalled;
+        RowData lastOffered;
+        final int fullAfterRows;
+
+        TrackingExporter(BufferAllocator allocator, RowType inputRowType, int fullAfterRows) {
+            super(allocator, inputRowType, /* batchRowsLimit */ Math.max(1, fullAfterRows));
+            this.fullAfterRows = fullAfterRows;
+        }
+
+        @Override
+        public void offer(RowData row) {
+            offerCount++;
+            lastOffered = row;
+        }
+
+        @Override
+        public boolean isBatchFull() {
+            return offerCount >= fullAfterRows;
+        }
+
+        @Override
+        public void noMoreInput() {
+            noMoreInputCalled = true;
+        }
+
+        @Override
+        public void close() {
+            closeCount++;
+            super.close();
+        }
+    }
+
+    /** Fake {@link Output} recording every invocation in order. */
+    static final class FakeOutput implements Output<StreamRecord<RowData>> {
+        final List<RowData> collected = new ArrayList<>();
+        final List<Watermark> emittedWatermarks = new ArrayList<>();
+        List<String> eventsListener;
+
+        @Override
+        public void collect(StreamRecord<RowData> record) {
+            collected.add(record.getValue());
+            if (eventsListener != null) {
+                eventsListener.add("collect");
+            }
+        }
+
+        @Override
+        public <X> void collect(OutputTag<X> outputTag, StreamRecord<X> record) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void emitWatermark(Watermark mark) {
+            emittedWatermarks.add(mark);
+            if (eventsListener != null) {
+                eventsListener.add("watermark:" + mark.getTimestamp());
+            }
+        }
+
+        @Override
+        public void emitWatermarkStatus(WatermarkStatus watermarkStatus) {}
+
+        @Override
+        public void emitLatencyMarker(LatencyMarker latencyMarker) {}
+
+        @Override
+        public void close() {}
+    }
+
+    // =====================================================================
+    // Stub OperatorMetricGroup
+    // =====================================================================
+
+    static final class StubMetricGroup implements OperatorMetricGroup {
+        @Override
+        public Counter counter(String name) {
+            return new StubCounter();
+        }
+
+        @Override
+        public <C extends Counter> C counter(String name, C counter) {
+            return counter;
+        }
+
+        @Override
+        public <T, G extends Gauge<T>> G gauge(String name, G gauge) {
+            return gauge;
+        }
+
+        @Override
+        public <H extends Histogram> H histogram(String name, H histogram) {
+            return histogram;
+        }
+
+        @Override
+        public <M extends Meter> M meter(String name, M meter) {
+            return meter;
+        }
+
+        @Override
+        public MetricGroup addGroup(String name) {
+            return this;
+        }
+
+        @Override
+        public MetricGroup addGroup(String key, String value) {
+            return this;
+        }
+
+        @Override
+        public String[] getScopeComponents() {
+            return new String[0];
+        }
+
+        @Override
+        public Map<String, String> getAllVariables() {
+            return new HashMap<>();
+        }
+
+        @Override
+        public String getMetricIdentifier(String metricName) {
+            return metricName;
+        }
+
+        @Override
+        public String getMetricIdentifier(String metricName, CharacterFilter filter) {
+            return metricName;
+        }
+
+        @Override
+        public OperatorIOMetricGroup getIOMetricGroup() {
+            return null;
+        }
+    }
+
+    /** Stub {@link ProcessingTimeService}: never schedules anything; only used to satisfy
+     * {@code TableStreamOperator.open()}'s non-null requirement on the timer service. */
+    static final class StubProcessingTimeService implements ProcessingTimeService {
+        @Override
+        public long getCurrentProcessingTime() {
+            return 0L;
+        }
+
+        @Override
+        public java.util.concurrent.ScheduledFuture<?> registerTimer(long timestamp, ProcessingTimeCallback callback) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public java.util.concurrent.ScheduledFuture<?> scheduleAtFixedRate(
+                ProcessingTimeCallback callback, long initialDelay, long period) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public java.util.concurrent.ScheduledFuture<?> scheduleWithFixedDelay(
+                ProcessingTimeCallback callback, long initialDelay, long delay) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public java.util.concurrent.CompletableFuture<Void> quiesce() {
+            return java.util.concurrent.CompletableFuture.completedFuture(null);
+        }
+    }
+
+    static final class StubCounter implements Counter {
+        long n;
+
+        @Override
+        public void inc() {
+            n++;
+        }
+
+        @Override
+        public void inc(long n) {
+            this.n += n;
+        }
+
+        @Override
+        public void dec() {
+            n--;
+        }
+
+        @Override
+        public void dec(long n) {
+            this.n -= n;
+        }
+
+        @Override
+        public long getCount() {
+            return n;
+        }
+    }
+
+    // =====================================================================
+    // StreamingRuntimeContext stub via Unsafe.allocateInstance
+    //
+    // StreamingRuntimeContext's real constructors require many non-null arguments (Environment,
+    // OperatorMetricGroup, OperatorID, ProcessingTimeService, etc.) that are heavy to mock and
+    // not needed by the operator under test. The operator only calls
+    // getOperatorUniqueID() and getIndexOfThisSubtask(); we instantiate the stub without
+    // invoking any constructor (via Unsafe) and override exactly those two methods.
+    // =====================================================================
+
+    private static StreamingRuntimeContext makeStubRuntimeContext() {
+        try {
+            return (StreamingRuntimeContext) unsafe().allocateInstance(StubStreamingRuntimeContext.class);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /** StreamingRuntimeContext that overrides only the methods the operator under test calls. */
+    static class StubStreamingRuntimeContext extends StreamingRuntimeContext {
+        // Constructor is intentionally never invoked; instances are allocated via Unsafe.
+        // The compiler requires a parent constructor call; supply a never-executed one.
+        @SuppressWarnings("unused")
+        private StubStreamingRuntimeContext() {
+            super(null, null, null);
+        }
+
+        @Override
+        public String getOperatorUniqueID() {
+            return FLINK_OP_UNIQUE_ID;
+        }
+
+        @Override
+        public int getIndexOfThisSubtask() {
+            return SUBTASK_INDEX;
+        }
+    }
+
+    private static sun.misc.Unsafe unsafe() throws Exception {
+        Field f = sun.misc.Unsafe.class.getDeclaredField("theUnsafe");
+        f.setAccessible(true);
+        return (sun.misc.Unsafe) f.get(null);
+    }
+
+    private static void setProtectedOutput(FlinkAuronCalcOperator op, Output<?> out) {
+        try {
+            Field f = findField(op.getClass(), "output");
+            f.setAccessible(true);
+            f.set(op, out);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static Field findField(Class<?> klass, String name) throws NoSuchFieldException {
+        Class<?> c = klass;
+        while (c != null) {
+            try {
+                return c.getDeclaredField(name);
+            } catch (NoSuchFieldException ignored) {
+                c = c.getSuperclass();
+            }
+        }
+        throw new NoSuchFieldException(name);
+    }
+}


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1857

# Rationale for this change

This PR adds the Flink-side runtime operator that executes the native Calc plan composed by #1856 + #1859. It is the **operator layer** of the three-layer architecture (plan / operator / graph-rewriter) for the Flink contribution track ([tracking issue #1264](https://github.com/apache/auron/issues/1264)).

The operator surface is intentionally free of `RexNode`, `StreamExecCalc`, and any Flink planner type — the constructor takes only `PhysicalPlanNode`, `RowType`, `RowType`, and a string operator ID. That invariant lets #1853 (rewrite `StreamExecCalc`) plug the operator in without dragging planner types into the runtime module.

This is the standalone-Calc MVP (Scenario B: with an FFI Reader leaf for input). Source/operator fusion (Scenario A) is deferred to #1865, as endorsed by the reviewer.

# What changes are included in this PR?

Three sequential commits in `auron-flink-extension/auron-flink-runtime`:

1. **`FlinkMetricNode`** (`org.apache.auron.flink.metric`) — extracts the inline anonymous `MetricNode` currently in `AuronKafkaSourceFunction.run()` into a reusable class. Lazily maps each metric name to a Flink `Counter` in a `ConcurrentHashMap` (native callbacks may arrive on tokio threads). Non-positive deltas are ignored, matching `SparkMetricNode` semantics.

2. **`FlinkArrowFFIExporter`** (`org.apache.auron.flink.arrow`) — synchronous `AuronArrowFFIExporter` that wraps `FlinkArrowWriter` so the native engine can pull batches of `RowData` via the Arrow C-Data FFI. Unlike Spark's threaded `ArrowFFIExporter` (which absorbs iterator-side IO latency), this exporter runs synchronously on the operator thread. Flink Calc is push-based and Flink's runtime serializes operator calls with the in-flight JNI call to `AuronCallNativeWrapper.loadNextBatch` (which runs on tokio's `spawn_blocking` pool), so there is no latency to absorb and no concurrent producer to coordinate with. `rotateRoot()` closes the previous `VectorSchemaRoot` before allocating a new one and rotates only after a successful FFI export, so the error path never leaks; `close()` is idempotent and verified to release all allocator memory.

3. **`FlinkAuronCalcOperator`** (`org.apache.auron.flink.runtime.operator`) — the operator itself. Extends `TableStreamOperator<RowData>` (so chaining is `ALWAYS` for free) and implements `OneInputStreamOperator<RowData, RowData>` + `FlinkAuronOperator`. Public constructor is planner-free: `(PhysicalPlanNode plan, RowType inputRowType, RowType outputRowType, String auronOperatorId)`; a `@VisibleForTesting` overload accepts a `NativeRuntimeFactory` for the unit-test mock seam.

   `open()` composes the per-subtask operator ID, allocates a child `BufferAllocator`, builds the `FlinkMetricNode` and `FlinkArrowFFIExporter`, generates the runtime resource ID `FlinkAuronCalc-<flinkOpId>-<subtask>:<UUID>` (OQ1 resolution — operator ID rides in the resource-ID prefix; **no proto change**), registers the exporter via `JniBridge.putResource(resourceId, exporter)`, recursively rewrites the FFI Reader leaf of the supplied plan to carry the bound resource ID, and constructs the native runtime via the factory seam.

   `processElement` buffers rows and drains on batch-full. `processWatermark` and `prepareSnapshotPreBarrier` drain before forwarding. `close()` uses nested try/finally so every resource is cleaned even on partial-init failure; the outer guard checks both `exporter` and `nativeRuntime` so a partial `open()` does not NPE during drain.

   `injectFfiReaderLeaf` accepts `Project[Filter[FFIReader]]`, `Project[FFIReader]`, `Filter[FFIReader]`, and bare `FFIReader`. Unsupported shapes throw `IllegalArgumentException` with the offending type in the message.

**Explicitly out of scope** (per reviewer guidance):
- No proto change, no Rust change (OQ1 resolution).
- No graph rewriting — that's #1853.
- No source/operator fusion — that's #1865.
- `AuronKafkaSourceFunction` is **not** migrated to use `FlinkMetricNode` here — trivial follow-up, kept out to minimize diff.
- `BATCH_ROW_LIMIT` is hard-coded at 8192; future PR wires it through `FlinkAuronConfiguration`.

# Are there any user-facing changes?

No. This PR introduces internal classes used by the future `StreamExecCalc` rewriter (#1853). End-user behavior is unchanged until #1853 lands.

# How was this patch tested?

22 new JUnit 5 unit tests across three test classes:

- `FlinkMetricNodeTest` (4) — counter creation, counter caching, `v > 0` gate, child propagation.
- `FlinkArrowFFIExporterTest` (5) — schema FFI round-trip, 100-row export with `FlinkArrowReader`-based field-by-field verification, EOI empty-buffer semantics, EOI partial-batch flush, allocator-zero on close.
- `FlinkAuronCalcOperatorTest` (13) — `putResource` registration, resource-ID composition, FFI Reader injection (4 plan shapes + 1 throw branch), `processElement` buffer + batch-full drain, watermark drain ordering, pre-checkpoint barrier drain, idempotent `close()`, `SupportsAuronNative` accessors.

All tests run with `junit-jupiter-api` + `arrow-c-data` + `arrow-vector` only — no `flink-test-utils`, no `libauron` invocation, no Mockito. The native runtime is mocked via a `@VisibleForTesting` `NativeRuntimeFactory` seam.

```bash
./build/mvn test -Pspark-3.5,scala-2.12,flink-1.18 \
    -pl auron-flink-extension/auron-flink-runtime \
    -Dtest=FlinkMetricNodeTest,FlinkArrowFFIExporterTest,FlinkAuronCalcOperatorTest
```

- All 22 new tests pass.
- Full `auron-flink-runtime` module: **129/129** tests pass (no regressions).
- `./build/mvn checkstyle:check`: **0** violations.
