### PR TITLE
[AURON #2277] [build] Fix stale auronver in build-macos-releases.yml

### DIFF
--- a/.github/workflows/build-macos-releases.yml
+++ b/.github/workflows/build-macos-releases.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       matrix:
         sparkver: [spark-3.0, spark-3.1, spark-3.2, spark-3.3, spark-3.4, spark-3.5]
-        auronver: [7.0.0-SNAPSHOT]
+        auronver: [8.0.0-SNAPSHOT]
         scalaver: [2.12, 2.13]
         javaver: [8, 21]
         runner: [macos-15]


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2277

# Rationale for this change

# What changes are included in this PR?
  Update auronver from 7.0.0-SNAPSHOT to 8.0.0-SNAPSHOT to match  build-amd64-releases.yml and build-arm-releases.yml.

# Are there any user-facing changes?

# How was this patch tested?
