### PR TITLE
[AURON #2289] support SQL aggregate FILTER (WHERE ...) clause in native execution

### DIFF
--- a/native-engine/auron-planner/proto/auron.proto
+++ b/native-engine/auron-planner/proto/auron.proto
@@ -158,6 +158,7 @@ message PhysicalAggExprNode {
   AggUdaf udaf = 2;
   repeated PhysicalExprNode children = 3;
   ArrowType return_type = 4;
+  PhysicalExprNode filter = 5;
 }
 
 message AggUdaf {

--- a/native-engine/auron-planner/src/planner.rs
+++ b/native-engine/auron-planner/src/planner.rs
@@ -544,10 +544,17 @@ impl PhysicalPlanner {
                             )?,
                         };
 
+                        let filter = agg_node
+                            .filter
+                            .as_ref()
+                            .map(|f| self.try_parse_physical_expr(f, &input_schema))
+                            .transpose()?;
+
                         Ok(AggExpr {
                             agg,
                             mode,
                             field_name: name.to_owned(),
+                            filter,
                         })
                     })
                     .collect::<Result<Vec<_>, _>>()?;

--- a/native-engine/datafusion-ext-plans/src/agg/agg_ctx.rs
+++ b/native-engine/datafusion-ext-plans/src/agg/agg_ctx.rs
@@ -19,7 +19,7 @@ use std::{
 };
 
 use arrow::{
-    array::{Array, ArrayRef, RecordBatchOptions},
+    array::{Array, ArrayRef, BooleanArray, RecordBatchOptions},
     datatypes::{Field, Fields, Schema, SchemaRef},
     record_batch::RecordBatch,
     row::{RowConverter, Rows, SortField},
@@ -110,6 +110,15 @@ impl AggContext {
         let need_partial_merge = aggs.iter().any(|agg| agg.mode != AggMode::Partial);
         let need_final_merge = aggs.iter().any(|agg| agg.mode == AggMode::Final);
         assert!(!(need_final_merge && aggs.iter().any(|agg| agg.mode != AggMode::Final)));
+
+        // FILTER predicates are only meaningful in Partial mode; the Spark planner must not
+        // attach a filter to PartialMerge or Final aggregates (they operate on already-filtered
+        // partial buffers, not on raw input rows).
+        assert!(
+            aggs.iter()
+                .all(|agg| agg.filter.is_none() || agg.mode == AggMode::Partial),
+            "aggregate FILTER is only valid in Partial mode"
+        );
 
         let need_partial_update_aggs: Vec<(usize, Arc<dyn Agg>)> = aggs
             .iter()
@@ -282,8 +291,79 @@ impl AggContext {
                     input_arrays.push(vec![]);
                 }
             }
-            let batch_selection = IdxSelection::Range(batch_start_idx, batch_end_idx);
-            self.partial_update(acc_table, acc_idx, &input_arrays, batch_selection)?;
+
+            // Evaluate per-aggregate FILTER predicates against the input batch.
+            // Each aggregate may have an optional filter expression; we produce
+            // a boolean array for each so that only rows evaluating to true
+            // contribute to that aggregate.
+            let filter_arrays: Vec<Option<BooleanArray>> = self
+                .aggs
+                .iter()
+                .map(|agg| {
+                    agg.filter
+                        .as_ref()
+                        .map(|filter_expr| {
+                            let result = filter_expr.evaluate(batch)?;
+                            let array = result.into_array(batch.num_rows())?;
+                            let bool_array =
+                                datafusion::common::cast::as_boolean_array(&array)?.clone();
+                            Ok(bool_array)
+                        })
+                        .transpose()
+                })
+                .collect::<Result<Vec<_>>>()?;
+
+            let udaf_indices_cache = OnceCell::new();
+            for (agg_idx, agg) in &self.need_partial_update_aggs {
+                let acc_col = &mut acc_table.cols_mut()[*agg_idx];
+                if let Some(filter_array) = &filter_arrays[*agg_idx] {
+                    // Build filtered index vectors: only rows where the filter
+                    // is true are passed to partial_update, preserving the
+                    // correct accumulator-to-input-row mapping.
+                    let (filtered_acc, filtered_input) = Self::build_filtered_indices(
+                        acc_idx,
+                        batch_start_idx,
+                        batch_end_idx,
+                        filter_array,
+                    );
+                    if !filtered_acc.is_empty() {
+                        if let Ok(udaf_agg) = downcast_any!(agg, SparkUDAFWrapper) {
+                            udaf_agg.partial_update_with_indices_cache(
+                                acc_col,
+                                IdxSelection::Indices(&filtered_acc),
+                                &input_arrays[*agg_idx],
+                                IdxSelection::Indices(&filtered_input),
+                                &udaf_indices_cache,
+                            )?;
+                        } else {
+                            agg.partial_update(
+                                acc_col,
+                                IdxSelection::Indices(&filtered_acc),
+                                &input_arrays[*agg_idx],
+                                IdxSelection::Indices(&filtered_input),
+                            )?;
+                        }
+                    }
+                } else {
+                    let batch_selection = IdxSelection::Range(batch_start_idx, batch_end_idx);
+                    if let Ok(udaf_agg) = downcast_any!(agg, SparkUDAFWrapper) {
+                        udaf_agg.partial_update_with_indices_cache(
+                            acc_col,
+                            acc_idx,
+                            &input_arrays[*agg_idx],
+                            batch_selection,
+                            &udaf_indices_cache,
+                        )?;
+                    } else {
+                        agg.partial_update(
+                            acc_col,
+                            acc_idx,
+                            &input_arrays[*agg_idx],
+                            batch_selection,
+                        )?;
+                    }
+                }
+            }
         }
 
         // partial merge
@@ -350,6 +430,67 @@ impl AggContext {
             self.output_schema.clone(),
             [grouping_columns, agg_columns].concat(),
         )?)
+    }
+
+    /// Given an `acc_idx` mapping and a filter boolean array, produce two
+    /// aligned index vectors:
+    /// - `filtered_acc`: accumulator indices to update
+    /// - `filtered_input`: input batch row indices to read from
+    ///
+    /// Only rows in `[batch_start_idx, batch_end_idx)` where the filter is
+    /// true are included. The mapping logic handles all `IdxSelection`
+    /// variants.
+    ///
+    /// NULL handling: `BooleanArray::value(i)` returns `false` for null slots,
+    /// which matches SQL FILTER semantics where NULL is treated as not-true and
+    /// the row is excluded from the aggregate.
+    fn build_filtered_indices(
+        acc_idx: IdxSelection,
+        batch_start_idx: usize,
+        batch_end_idx: usize,
+        filter_array: &BooleanArray,
+    ) -> (Vec<usize>, Vec<usize>) {
+        let mut filtered_acc = vec![];
+        let mut filtered_input = vec![];
+        match acc_idx {
+            // Single accumulator for all rows in this group.
+            IdxSelection::Single(idx) => {
+                for i in batch_start_idx..batch_end_idx {
+                    if filter_array.value(i) {
+                        filtered_acc.push(idx);
+                        filtered_input.push(i);
+                    }
+                }
+            }
+            // Per-row accumulator indices (used by sort aggregation).
+            IdxSelection::Indices(indices) => {
+                for i in batch_start_idx..batch_end_idx {
+                    if filter_array.value(i) {
+                        filtered_acc.push(indices[i - batch_start_idx]);
+                        filtered_input.push(i);
+                    }
+                }
+            }
+            // Per-row accumulator indices as u32 (used by hash aggregation).
+            IdxSelection::IndicesU32(indices) => {
+                for i in batch_start_idx..batch_end_idx {
+                    if filter_array.value(i) {
+                        filtered_acc.push(indices[i - batch_start_idx] as usize);
+                        filtered_input.push(i);
+                    }
+                }
+            }
+            // Contiguous accumulator range (used by merge / partial-skip paths).
+            IdxSelection::Range(start, _end) => {
+                for i in batch_start_idx..batch_end_idx {
+                    if filter_array.value(i) {
+                        filtered_acc.push(start + (i - batch_start_idx));
+                        filtered_input.push(i);
+                    }
+                }
+            }
+        }
+        (filtered_acc, filtered_input)
     }
 
     pub fn partial_update(

--- a/native-engine/datafusion-ext-plans/src/agg/agg_ctx.rs
+++ b/native-engine/datafusion-ext-plans/src/agg/agg_ctx.rs
@@ -111,9 +111,9 @@ impl AggContext {
         let need_final_merge = aggs.iter().any(|agg| agg.mode == AggMode::Final);
         assert!(!(need_final_merge && aggs.iter().any(|agg| agg.mode != AggMode::Final)));
 
-        // FILTER predicates are only meaningful in Partial mode; the Spark planner must not
-        // attach a filter to PartialMerge or Final aggregates (they operate on already-filtered
-        // partial buffers, not on raw input rows).
+        // FILTER predicates are only meaningful in Partial mode; the Spark planner must
+        // not attach a filter to PartialMerge or Final aggregates (they operate
+        // on already-filtered partial buffers, not on raw input rows).
         assert!(
             aggs.iter()
                 .all(|agg| agg.filter.is_none() || agg.mode == AggMode::Partial),

--- a/native-engine/datafusion-ext-plans/src/agg/mod.rs
+++ b/native-engine/datafusion-ext-plans/src/agg/mod.rs
@@ -88,4 +88,5 @@ pub struct AggExpr {
     pub field_name: String,
     pub mode: AggMode,
     pub agg: Arc<dyn Agg>,
+    pub filter: Option<PhysicalExprRef>,
 }

--- a/native-engine/datafusion-ext-plans/src/agg_exec.rs
+++ b/native-engine/datafusion-ext-plans/src/agg_exec.rs
@@ -414,14 +414,16 @@ mod test {
     use std::sync::Arc;
 
     use arrow::{
-        array::Int32Array,
-        datatypes::{DataType, Field, Schema},
+        array::{Array, ArrayRef, AsArray, BooleanArray, Int32Array, Int64Array, StringArray},
+        compute::concat_batches,
+        datatypes::{DataType, Field, Int64Type, Schema},
         record_batch::RecordBatch,
     };
     use auron_memmgr::MemManager;
     use datafusion::{
         assert_batches_sorted_eq,
         common::{Result, ScalarValue},
+        execution::TaskContext,
         physical_expr::{expressions as phys_expr, expressions::Column},
         physical_plan::{ExecutionPlan, test::TestMemoryExec},
         prelude::SessionContext,
@@ -434,6 +436,7 @@ mod test {
             AggMode::{Final, Partial},
             GroupingExpr,
             agg::create_agg,
+            sum::AggSum,
         },
         agg_exec::AggExec,
     };
@@ -580,51 +583,61 @@ mod test {
             AggExpr {
                 field_name: "agg_expr_sum".to_string(),
                 mode: Partial,
+                filter: None,
                 agg: agg_expr_sum,
             },
             AggExpr {
                 field_name: "agg_expr_avg".to_string(),
                 mode: Partial,
+                filter: None,
                 agg: agg_expr_avg,
             },
             AggExpr {
                 field_name: "agg_expr_max".to_string(),
                 mode: Partial,
+                filter: None,
                 agg: agg_expr_max,
             },
             AggExpr {
                 field_name: "agg_expr_min".to_string(),
                 mode: Partial,
+                filter: None,
                 agg: agg_expr_min,
             },
             AggExpr {
                 field_name: "agg_expr_count".to_string(),
                 mode: Partial,
+                filter: None,
                 agg: agg_expr_count,
             },
             AggExpr {
                 field_name: "agg_expr_collectlist".to_string(),
                 mode: Partial,
+                filter: None,
                 agg: agg_expr_collectlist,
             },
             AggExpr {
                 field_name: "agg_expr_collectset".to_string(),
                 mode: Partial,
+                filter: None,
                 agg: agg_expr_collectset,
             },
             AggExpr {
                 field_name: "agg_expr_collectlist_nil".to_string(),
                 mode: Partial,
+                filter: None,
                 agg: agg_expr_collectlist_nil,
             },
             AggExpr {
                 field_name: "agg_expr_collectset_nil".to_string(),
                 mode: Partial,
+                filter: None,
                 agg: agg_expr_collectset_nil,
             },
             AggExpr {
                 field_name: "agg_agg_firstign".to_string(),
                 mode: Partial,
+                filter: None,
                 agg: agg_expr_firstign,
             },
         ];
@@ -678,6 +691,80 @@ mod test {
             "+---+--------------+--------------+--------------+--------------+----------------+----------------------+---------------------+--------------------------+-------------------------+------------------+",
         ];
         assert_batches_sorted_eq!(expected, &batches);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_agg_with_filter() -> Result<()> {
+        MemManager::init(1000);
+        let task_ctx = Arc::new(TaskContext::default());
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("grp", DataType::Utf8, false),
+            Field::new("val", DataType::Int32, true),
+            Field::new("flag", DataType::Boolean, false),
+        ]));
+
+        let grp_col: ArrayRef = Arc::new(StringArray::from(vec!["a", "a", "a", "b", "b", "b"]));
+        let val_col: ArrayRef = Arc::new(Int32Array::from(vec![
+            Some(1),
+            Some(2),
+            Some(3),
+            Some(4),
+            Some(5),
+            None,
+        ]));
+        let flag_col: ArrayRef = Arc::new(BooleanArray::from(vec![
+            true, false, true, false, true, true,
+        ]));
+
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![grp_col.clone(), val_col.clone(), flag_col.clone()],
+        )?;
+
+        let input = Arc::new(TestMemoryExec::try_new(
+            &[vec![batch.clone()]],
+            schema.clone(),
+            None,
+        )?);
+
+        // SUM(val) FILTER (WHERE flag = true)
+        // Expected: a=1+3=4, b=5+0=5 (NULL val contributes 0 to sum)
+        let filter_expr = Arc::new(phys_expr::Column::new("flag", 2));
+        let agg_exec = Arc::new(AggExec::try_new(
+            HashAgg,
+            vec![GroupingExpr {
+                field_name: "grp".to_string(),
+                expr: phys_expr::col("grp", &schema)?,
+            }],
+            vec![AggExpr {
+                field_name: "sum_filtered".to_string(),
+                mode: Partial,
+                filter: Some(filter_expr),
+                agg: Arc::new(AggSum::try_new(
+                    phys_expr::col("val", &schema)?,
+                    DataType::Int64,
+                )?),
+            }],
+            false,
+            input,
+        )?);
+
+        let output = datafusion::physical_plan::collect(agg_exec, task_ctx.clone()).await?;
+        let result = concat_batches(&output[0].schema(), &output)?;
+
+        let grp_result = result.column(0).as_string::<i32>();
+        let sum_result = result.column(1).as_primitive::<Int64Type>();
+
+        assert_eq!(grp_result.len(), 2);
+        let mut found = std::collections::HashMap::new();
+        for i in 0..grp_result.len() {
+            found.insert(grp_result.value(i), sum_result.value(i));
+        }
+        assert_eq!(found["a"], 4); // 1 + 3
+        assert_eq!(found["b"], 5); // 5 (NULL val contributes 0)
+
         Ok(())
     }
 }
@@ -772,6 +859,7 @@ mod fuzztest {
                 AggExpr {
                     field_name: "sum".to_string(),
                     mode: Partial,
+                    filter: None,
                     agg: Arc::new(AggSum::try_new(
                         phys_expr::col("val", &schema)?,
                         DataType::Float64,
@@ -780,6 +868,7 @@ mod fuzztest {
                 AggExpr {
                     field_name: "cnt".to_string(),
                     mode: Partial,
+                    filter: None,
                     agg: Arc::new(AggCount::try_new(
                         vec![phys_expr::col("val", &schema)?],
                         DataType::Int64,
@@ -799,6 +888,7 @@ mod fuzztest {
                 AggExpr {
                     field_name: "sum".to_string(),
                     mode: Final,
+                    filter: None,
                     agg: Arc::new(AggSum::try_new(
                         phys_expr::col("val", &schema)?,
                         DataType::Float64,
@@ -807,6 +897,7 @@ mod fuzztest {
                 AggExpr {
                     field_name: "cnt".to_string(),
                     mode: Final,
+                    filter: None,
                     agg: Arc::new(AggCount::try_new(
                         vec![phys_expr::col("val", &schema)?],
                         DataType::Int64,

--- a/spark-extension-shims-spark/src/main/scala/org/apache/spark/sql/auron/ShimsImpl.scala
+++ b/spark-extension-shims-spark/src/main/scala/org/apache/spark/sql/auron/ShimsImpl.scala
@@ -622,8 +622,6 @@ class ShimsImpl extends Shims with Logging {
   }
 
   override def convertMoreAggregateExpr(e: AggregateExpression): Option[pb.PhysicalExprNode] = {
-    assert(getAggregateExpressionFilter(e).isEmpty)
-
     e.aggregateFunction match {
       case First(child, ignoresNull) =>
         val aggExpr = pb.PhysicalAggExprNode
@@ -635,15 +633,21 @@ class ShimsImpl extends Shims with Logging {
             pb.AggFunction.FIRST
           })
           .addChildren(NativeConverters.convertExpr(child))
+        getAggregateExpressionFilter(e).foreach { filterExpr =>
+          aggExpr.setFilter(NativeConverters.convertExpr(filterExpr))
+        }
         Some(pb.PhysicalExprNode.newBuilder().setAggExpr(aggExpr).build())
 
       case agg =>
         convertBloomFilterAgg(agg) match {
           case Some(aggExpr) =>
+            getAggregateExpressionFilter(e).foreach { filterExpr =>
+              aggExpr.setFilter(NativeConverters.convertExpr(filterExpr))
+            }
             return Some(
               pb.PhysicalExprNode
                 .newBuilder()
-                .setAggExpr(aggExpr)
+                .setAggExpr(aggExpr.build())
                 .build())
           case None =>
         }
@@ -1030,7 +1034,8 @@ class ShimsImpl extends Shims with Logging {
       fallback: Expression => pb.PhysicalExprNode): Option[pb.PhysicalExprNode] = None
 
   @sparkver("3.3 / 3.4 / 3.5 / 4.0 / 4.1")
-  private def convertBloomFilterAgg(agg: AggregateFunction): Option[pb.PhysicalAggExprNode] = {
+  private def convertBloomFilterAgg(
+      agg: AggregateFunction): Option[pb.PhysicalAggExprNode.Builder] = {
     import org.apache.spark.sql.catalyst.expressions.aggregate.BloomFilterAggregate
     agg match {
       case BloomFilterAggregate(child, estimatedNumItemsExpression, numBitsExpression, _, _) =>
@@ -1049,15 +1054,15 @@ class ShimsImpl extends Shims with Logging {
             .setAggFunction(pb.AggFunction.BLOOM_FILTER)
             .addChildren(NativeConverters.convertExpr(child))
             .addChildren(NativeConverters.convertExpr(Literal(estimatedNumItems)))
-            .addChildren(NativeConverters.convertExpr(Literal(numBitsNextPowerOf2)))
-            .build())
+            .addChildren(NativeConverters.convertExpr(Literal(numBitsNextPowerOf2))))
       case _ => None
     }
   }
 
   @nowarn("cat=unused") // Some params temporarily unused
   @sparkver("3.0 / 3.1 / 3.2")
-  private def convertBloomFilterAgg(agg: AggregateFunction): Option[pb.PhysicalAggExprNode] = None
+  private def convertBloomFilterAgg(
+      agg: AggregateFunction): Option[pb.PhysicalAggExprNode.Builder] = None
 
   @sparkver("3.3 / 3.4 / 3.5 / 4.0 / 4.1")
   private def convertBloomFilterMightContain(

--- a/spark-extension-shims-spark/src/test/scala/org/apache/auron/AuronQuerySuite.scala
+++ b/spark-extension-shims-spark/src/test/scala/org/apache/auron/AuronQuerySuite.scala
@@ -775,4 +775,77 @@ class AuronQuerySuite extends AuronQueryTest with BaseAuronSQLSuite with AuronSQ
       }.isDefined)
     }
   }
+
+  test("aggregate with filter clause") {
+    withTable("t_filter_agg_2289") {
+      sql("""
+        CREATE TABLE t_filter_agg_2289(
+          category STRING,
+          amount INT,
+          quantity INT,
+          price DOUBLE,
+          is_vip BOOLEAN
+        ) USING parquet
+      """)
+
+      sql("""
+        INSERT INTO t_filter_agg_2289 VALUES
+          (' electronics', 100,  1,  99.99, true),
+          (' electronics', 200,  2, 199.99, false),
+          (' electronics', 300,  3, 299.99, true),
+          ('  clothing  ', 400,  4, 399.99, false),
+          ('  clothing  ', 500,  5, 499.99, true),
+          ('  clothing  ', NULL, NULL, NULL, true)
+      """)
+
+      // Basic FILTER on SUM(int): 100 + 300 + 500 = 900 (NULL amount contributes 0)
+      checkSparkAnswerAndOperator(
+        "SELECT SUM(amount) FILTER (WHERE is_vip = true) FROM t_filter_agg_2289")
+
+      // FILTER on SUM with GROUP BY: electronics=400, clothing=500
+      checkSparkAnswerAndOperator("""SELECT category, SUM(amount) FILTER (WHERE is_vip = true)
+        |FROM t_filter_agg_2289
+        |GROUP BY category
+        |ORDER BY category""".stripMargin)
+
+      // Multiple aggregates with different FILTER predicates
+      checkSparkAnswerAndOperator("""SELECT
+        |  SUM(amount) FILTER (WHERE is_vip = true)  AS sum_vip,
+        |  SUM(amount) FILTER (WHERE is_vip = false) AS sum_non_vip,
+        |  AVG(price) FILTER (WHERE quantity > 2)     AS avg_price,
+        |  COUNT(*) FILTER (WHERE amount IS NULL)     AS cnt_null
+        |FROM t_filter_agg_2289""".stripMargin)
+
+      // MIN/MAX with FILTER
+      checkSparkAnswerAndOperator("""SELECT
+        |  MIN(amount) FILTER (WHERE is_vip = true)  AS min_vip,
+        |  MAX(amount) FILTER (WHERE is_vip = true)  AS max_vip,
+        |  MIN(price) FILTER (WHERE quantity >= 3)   AS min_price,
+        |  MAX(price) FILTER (WHERE quantity >= 3)   AS max_price
+        |FROM t_filter_agg_2289""".stripMargin)
+
+      // Mixed filtered and non-filtered aggregates
+      checkSparkAnswerAndOperator("""SELECT
+        |  SUM(amount)                         AS total,
+        |  SUM(amount) FILTER (WHERE is_vip = true) AS vip_total,
+        |  COUNT(*)                             AS cnt_all,
+        |  COUNT(*) FILTER (WHERE amount > 200)     AS cnt_high
+        |FROM t_filter_agg_2289""".stripMargin)
+
+      // FILTER that matches all rows (equivalent to no filter)
+      checkSparkAnswerAndOperator(
+        "SELECT SUM(amount) FILTER (WHERE 1 = 1) FROM t_filter_agg_2289")
+
+      // FILTER that matches no rows (should return NULL for SUM)
+      checkSparkAnswerAndOperator(
+        "SELECT SUM(amount) FILTER (WHERE 1 = 0) FROM t_filter_agg_2289")
+
+      // COUNT(expr) with FILTER (counts only non-null expr among matching rows)
+      checkSparkAnswerAndOperator("""SELECT
+        |  COUNT(amount) FILTER (WHERE is_vip = true)    AS cnt_vip_amount,
+        |  COUNT(*) FILTER (WHERE is_vip = true)          AS cnt_vip_star,
+        |  COUNT(quantity) FILTER (WHERE amount > 150)    AS cnt_qty
+        |FROM t_filter_agg_2289""".stripMargin)
+    }
+  }
 }

--- a/spark-extension/src/main/scala/org/apache/spark/sql/auron/AuronConverters.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/auron/AuronConverters.scala
@@ -1255,7 +1255,7 @@ object AuronConverters extends Logging {
   private def getPartialAggProjection(
       aggregateExprs: Seq[AggregateExpression],
       groupingExprs: Seq[NamedExpression],
-      childOutput: Seq[Attribute] = Nil)
+      childOutput: Seq[Attribute])
       : Option[(Seq[AggregateExpression], Seq[NamedExpression], Seq[Alias])] = {
 
     if (!aggregateExprs.forall(_.mode == Partial)) {
@@ -1298,22 +1298,20 @@ object AuronConverters extends Logging {
     // We resolve each filter AttributeReference against childOutput by (name, dataType) to obtain
     // the canonical Attribute (with the correct exprId), then add it to projections unchanged so
     // that the downstream ProjectExec can actually evaluate it from exec.child.
-    if (childOutput.nonEmpty) {
-      val childAttrMap = childOutput.map(a => (a.name, a.dataType) -> a).toMap
-      aggregateExprs.foreach { expr =>
-        Shims.get.getAggregateExpressionFilter(expr).foreach {
-          _.foreach {
-            case ar: AttributeReference =>
-              val resolved = childAttrMap.getOrElse((ar.name, ar.dataType), ar)
-              projections.getOrElseUpdate(
-                resolved,
-                AttributeReference(
-                  resolved.name,
-                  resolved.dataType,
-                  resolved.nullable,
-                  resolved.metadata)(resolved.exprId, resolved.qualifier))
-            case _ =>
-          }
+    val childAttrMap = childOutput.map(a => (a.name, a.dataType) -> a).toMap
+    aggregateExprs.foreach { expr =>
+      Shims.get.getAggregateExpressionFilter(expr).foreach {
+        _.foreach {
+          case ar: AttributeReference =>
+            val resolved = childAttrMap.getOrElse((ar.name, ar.dataType), ar)
+            projections.getOrElseUpdate(
+              resolved,
+              AttributeReference(
+                resolved.name,
+                resolved.dataType,
+                resolved.nullable,
+                resolved.metadata)(resolved.exprId, resolved.qualifier))
+          case _ =>
         }
       }
     }

--- a/spark-extension/src/main/scala/org/apache/spark/sql/auron/AuronConverters.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/auron/AuronConverters.scala
@@ -810,7 +810,10 @@ object AuronConverters extends Logging {
   def convertHashAggregateExec(exec: HashAggregateExec): SparkPlan = {
     // split non-trivial children exprs in partial-agg to a ProjectExec
     // for enabling filter-project optimization in native side
-    getPartialAggProjection(exec.aggregateExpressions, exec.groupingExpressions) match {
+    getPartialAggProjection(
+      exec.aggregateExpressions,
+      exec.groupingExpressions,
+      exec.child.output) match {
       case Some((transformedAggregateExprs, transformedGroupingExprs, projections)) =>
         val transformedExec =
           try {
@@ -851,11 +854,13 @@ object AuronConverters extends Logging {
         NativeAggBase.findPreviousNativeAggrExec(exec).isDefined,
         "partial AggregateExec is not native")
     }
+    val boundAggregateExpressions =
+      bindAggregateFilters(exec.aggregateExpressions, exec.child.output)
     val nativeAggr = Shims.get.createNativeAggExec(
       NativeAggBase.HashAgg,
       exec.requiredChildDistributionExpressions,
       exec.groupingExpressions,
-      exec.aggregateExpressions,
+      boundAggregateExpressions,
       exec.aggregateAttributes,
       exec.initialInputBufferOffset,
       exec.requiredChildDistributionExpressions match {
@@ -891,7 +896,10 @@ object AuronConverters extends Logging {
   def convertObjectHashAggregateExec(exec: ObjectHashAggregateExec): SparkPlan = {
     // split non-trivial children exprs in partial-agg to a ProjectExec
     // for enabling filter-project optimization in native side
-    getPartialAggProjection(exec.aggregateExpressions, exec.groupingExpressions) match {
+    getPartialAggProjection(
+      exec.aggregateExpressions,
+      exec.groupingExpressions,
+      exec.child.output) match {
       case Some((transformedAggregateExprs, transformedGroupingExprs, projections)) =>
         return convertObjectHashAggregateExec(
           exec.copy(
@@ -907,11 +915,13 @@ object AuronConverters extends Logging {
     if (exec.requiredChildDistributionExpressions.isDefined) {
       assert(NativeAggBase.findPreviousNativeAggrExec(exec).isDefined)
     }
+    val boundAggregateExpressions =
+      bindAggregateFilters(exec.aggregateExpressions, exec.child.output)
     val nativeAggr = Shims.get.createNativeAggExec(
       NativeAggBase.HashAgg,
       exec.requiredChildDistributionExpressions,
       exec.groupingExpressions,
-      exec.aggregateExpressions,
+      boundAggregateExpressions,
       exec.aggregateAttributes,
       exec.initialInputBufferOffset,
       exec.requiredChildDistributionExpressions match {
@@ -960,11 +970,12 @@ object AuronConverters extends Logging {
       (NativeAggBase.SortAgg, exec.child)
     }
 
+    val boundAggregateExpressions = bindAggregateFilters(exec.aggregateExpressions, child.output)
     val nativeAggr = Shims.get.createNativeAggExec(
       aggMode,
       exec.requiredChildDistributionExpressions,
       exec.groupingExpressions,
-      exec.aggregateExpressions,
+      boundAggregateExpressions,
       exec.aggregateAttributes,
       exec.initialInputBufferOffset,
       exec.requiredChildDistributionExpressions match {
@@ -1212,9 +1223,39 @@ object AuronConverters extends Logging {
     exec
   }
 
+  /**
+   * Bind filter expressions in AggregateExpression to the actual child output attributes. This is
+   * needed because Spark 3.0's AggregateExpression does not have withNewChildrenInternal, so
+   * filter expressions may retain stale exprIds after optimizer transformations. We match by
+   * (name, dataType) and replace with the child's AttributeReference.
+   */
+  private def bindAggregateFilters(
+      aggregateExprs: Seq[AggregateExpression],
+      childOutput: Seq[Attribute]): Seq[AggregateExpression] = {
+    val attrMap = childOutput.map(a => (a.name, a.dataType) -> a).toMap
+    aggregateExprs.map { expr =>
+      expr.filter match {
+        case Some(filterExpr) =>
+          val newFilter = filterExpr.transform { case ar: AttributeReference =>
+            attrMap.get((ar.name, ar.dataType)) match {
+              case Some(newAttr) => newAttr
+              case None => ar
+            }
+          }
+          if (newFilter.eq(filterExpr)) {
+            expr
+          } else {
+            expr.copy(filter = Some(newFilter))
+          }
+        case None => expr
+      }
+    }
+  }
+
   private def getPartialAggProjection(
       aggregateExprs: Seq[AggregateExpression],
-      groupingExprs: Seq[NamedExpression])
+      groupingExprs: Seq[NamedExpression],
+      childOutput: Seq[Attribute] = Nil)
       : Option[(Seq[AggregateExpression], Seq[NamedExpression], Seq[Alias])] = {
 
     if (!aggregateExprs.forall(_.mode == Partial)) {
@@ -1248,6 +1289,35 @@ object AuronConverters extends Logging {
         }
         .asInstanceOf[AggregateFunction])
     }
+
+    // Ensure that AttributeReferences used in FILTER predicates are also included in the
+    // projection. Without this, the projection child would not output the filter column, causing
+    // bindAggregateFilters to fail (the column would be absent from child.output) and the native
+    // side to raise a SchemaError when resolving the filter expression against input_schema.
+    //
+    // We resolve each filter AttributeReference against childOutput by (name, dataType) to obtain
+    // the canonical Attribute (with the correct exprId), then add it to projections unchanged so
+    // that the downstream ProjectExec can actually evaluate it from exec.child.
+    if (childOutput.nonEmpty) {
+      val childAttrMap = childOutput.map(a => (a.name, a.dataType) -> a).toMap
+      aggregateExprs.foreach { expr =>
+        Shims.get.getAggregateExpressionFilter(expr).foreach {
+          _.foreach {
+            case ar: AttributeReference =>
+              val resolved = childAttrMap.getOrElse((ar.name, ar.dataType), ar)
+              projections.getOrElseUpdate(
+                resolved,
+                AttributeReference(
+                  resolved.name,
+                  resolved.dataType,
+                  resolved.nullable,
+                  resolved.metadata)(resolved.exprId, resolved.qualifier))
+            case _ =>
+          }
+        }
+      }
+    }
+
     Some(
       (
         transformedAggExprs.toList,

--- a/spark-extension/src/main/scala/org/apache/spark/sql/auron/NativeConverters.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/auron/NativeConverters.scala
@@ -1226,7 +1226,6 @@ object NativeConverters extends Logging {
   }
 
   def convertAggregateExpr(e: AggregateExpression): pb.PhysicalExprNode = {
-    assert(Shims.get.getAggregateExpressionFilter(e).isEmpty)
     val aggBuilder = pb.PhysicalAggExprNode.newBuilder()
     aggBuilder.setReturnType(convertDataType(e.dataType))
 
@@ -1346,6 +1345,9 @@ object NativeConverters extends Logging {
             s" to true to enable UDAF fallbacking.")
         }
 
+    }
+    Shims.get.getAggregateExpressionFilter(e).foreach { filterExpr =>
+      aggBuilder.setFilter(convertExpr(filterExpr))
     }
     pb.PhysicalExprNode
       .newBuilder()


### PR DESCRIPTION
## Which issue does this PR close?
Closes #2289 

## Rationale for this change
Currently, queries using the SQL standard FILTER (WHERE ...) clause on aggregate functions fall back to non-native Spark execution. This is because the Spark-side native converters explicitly assert filter.isEmpty, the protobuf schema has no field for filter predicates, and the Rust execution engine does not apply per-aggregate row filtering.

This PR enables end-to-end native execution for filtered aggregates, improving performance for a commonly used SQL pattern.

## What changes are included in this PR?
1. Protobuf schema: Add filter field to PhysicalAggExprNode.
2. Spark converters (NativeConverters, ShimsImpl): Remove assert(filter.isEmpty) and convert the Spark AggregateExpression.filter expression to protobuf.
3. Rust planner: Parse the filter field from protobuf into AggExpr.filter.
4. Rust execution (AggContext::update_batch_slice_to_acc_table): Evaluate each aggregate's filter expression against the input batch; for aggregates with a filter, build filtered acc_idx / input_idx vectors and pass only matching rows to partial_update.
5. Tests:
   - Rust: test_agg_with_filter in agg_exec.rs
   - Scala: aggregate with filter clause in AuronQuerySuite

## Are there any user-facing changes?
NO.

## How was this patch tested?
- cargo test --workspace — all Rust tests pass
- cargo test -p datafusion-ext-plans -- agg_exec — existing test_agg / fuzztest plus new test_agg_with_filter all pass
- Added Scala integration test in AuronQuerySuite covering filtered aggregates with/without GROUP BY and multiple predicates
