### PR TITLE
[AURON #2291] Make auron-flink-assembly the structural deployment jar

### DIFF
--- a/.github/workflows/flink.yml
+++ b/.github/workflows/flink.yml
@@ -42,7 +42,6 @@ jobs:
         flinkver: [ "1.18" ]
         javaver: [ "8" ]
         scalaver: [ "2.12" ]
-        module: [ "auron-flink-extension/auron-flink-planner" ]
         sparkver: [ "spark-3.5" ]
 
     steps:
@@ -56,12 +55,15 @@ jobs:
         java-version: ${{ matrix.javaver }}
         cache: 'maven'
 
-    - name: Test Flink Module
-      run: ./build/mvn -B test -pl ${{ matrix.module }} -am -Pscala-${{ matrix.scalaver }} -Pflink-${{ matrix.flinkver }} -P${{ matrix.sparkver }} -Prelease
+    - name: Test Flink modules and verify the assembly jar
+      run: ./build/mvn -B verify -pl auron-flink-extension/auron-flink-assembly -am -Pscala-${{ matrix.scalaver }} -Pflink-${{ matrix.flinkver }} -P${{ matrix.sparkver }} -Prelease
 
     - name: Upload reports
       if: failure()
       uses: actions/upload-artifact@v7
       with:
-        name: ${{ matrix.module }}-test-report
-        path: ${{ matrix.module }}/target/surefire-reports
+        name: auron-flink-test-report
+        path: |
+          auron-flink-extension/auron-flink-planner/target/surefire-reports
+          auron-flink-extension/auron-flink-runtime/target/surefire-reports
+          auron-flink-extension/auron-flink-assembly/target/failsafe-reports

--- a/auron-flink-extension/auron-flink-assembly/pom.xml
+++ b/auron-flink-extension/auron-flink-assembly/pom.xml
@@ -71,6 +71,13 @@
                 <exclude>META-INF/*.RSA</exclude>
               </excludes>
             </filter>
+            <!-- Drop Flink's stock StreamExecCalc so only Auron's override remains in the jar. -->
+            <filter>
+              <artifact>org.apache.flink:flink-table-planner_2.12</artifact>
+              <excludes>
+                <exclude>org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecCalc.class</exclude>
+              </excludes>
+            </filter>
           </filters>
         </configuration>
         <executions>

--- a/auron-flink-extension/auron-flink-assembly/pom.xml
+++ b/auron-flink-extension/auron-flink-assembly/pom.xml
@@ -61,6 +61,13 @@
             <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
               <resource>META-INF/services/org.apache.flink.table.factories.TableFactory</resource>
             </transformer>
+            <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer">
+              <projectName>Apache Auron (Incubating)</projectName>
+              <organizationName>The Apache Software Foundation</organizationName>
+              <organizationURL>https://www.apache.org/</organizationURL>
+              <inceptionYear>2025</inceptionYear>
+            </transformer>
+            <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer" />
           </transformers>
           <filters>
             <filter>
@@ -69,6 +76,28 @@
                 <exclude>META-INF/*.SF</exclude>
                 <exclude>META-INF/*.DSA</exclude>
                 <exclude>META-INF/*.RSA</exclude>
+                <!-- Drop dependency-supplied jar-root NOTICE files. The notice transformer
+                     aggregates each dependency's META-INF/NOTICE into the final NOTICE, but it
+                     never reads a dependency's jar-root NOTICE (e.g. kafka-clients), so that
+                     required attribution is folded into this module's META-INF/NOTICE by hand
+                     instead. Excluding the jar-root copies keeps them from shipping verbatim. -->
+                <exclude>NOTICE</exclude>
+                <exclude>NOTICE.txt</exclude>
+                <exclude>NOTICE.md</exclude>
+              </excludes>
+            </filter>
+            <!-- kafka-clients and icu4j each ship a jar-root LICENSE; drop those copies so
+                 this module's jar-root LICENSE is the only top-level LICENSE in the uber jar. -->
+            <filter>
+              <artifact>org.apache.kafka:kafka-clients</artifact>
+              <excludes>
+                <exclude>LICENSE</exclude>
+              </excludes>
+            </filter>
+            <filter>
+              <artifact>com.ibm.icu:icu4j</artifact>
+              <excludes>
+                <exclude>LICENSE</exclude>
               </excludes>
             </filter>
             <!-- Drop Flink's stock StreamExecCalc so only Auron's override remains in the jar. -->

--- a/auron-flink-extension/auron-flink-assembly/pom.xml
+++ b/auron-flink-extension/auron-flink-assembly/pom.xml
@@ -108,7 +108,11 @@
                 <exclude>LICENSE</exclude>
               </excludes>
             </filter>
-            <!-- Drop Flink's stock StreamExecCalc so only Auron's override remains in the jar. -->
+            <!-- Drop Flink's stock StreamExecCalc so only Auron's override remains in the jar.
+                 Every Auron ExecNode override needs its own <exclude> here; otherwise the stock
+                 Flink copy wins the shade. AssemblyJarStructureIT, driven by the override registry
+                 META-INF/auron/shadowed-flink-execnodes.txt, fails the build if an exclude is
+                 missing. -->
             <filter>
               <artifact>org.apache.flink:flink-table-planner_2.12</artifact>
               <excludes>

--- a/auron-flink-extension/auron-flink-assembly/pom.xml
+++ b/auron-flink-extension/auron-flink-assembly/pom.xml
@@ -37,6 +37,14 @@
       <artifactId>auron-flink-planner</artifactId>
       <version>${project.version}</version>
     </dependency>
+
+    <!-- Test dependencies -->
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>${junit.jupiter.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -115,6 +123,21 @@
               <goal>shade</goal>
             </goals>
             <phase>package</phase>
+          </execution>
+        </executions>
+      </plugin>
+      <!-- Run AssemblyJarStructureIT in the verify phase, after the shade has produced the
+           uber jar in the package phase, so the test inspects the actual built artifact. -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>${maven.plugin.surefire.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
           </execution>
         </executions>
       </plugin>

--- a/auron-flink-extension/auron-flink-assembly/src/main/resources/LICENSE
+++ b/auron-flink-extension/auron-flink-assembly/src/main/resources/LICENSE
@@ -1,0 +1,268 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+===============================================================================
+THIRD-PARTY COMPONENTS BUNDLED IN THIS BINARY ARTIFACT
+===============================================================================
+
+This binary artifact bundles a modified copy of Apache Flink flink-table-planner
+and the third-party dependencies that the planner itself bundles. Most of those
+dependencies are licensed under the Apache License 2.0 (above) and are listed in
+the accompanying NOTICE file. The dependencies below are licensed under terms
+other than the Apache License 2.0.
+
+-------------------------------------------------------------------------------
+Unicode/ICU License
+-------------------------------------------------------------------------------
+
+The following bundled dependency is available under the Unicode/ICU License,
+the full text of which is available at
+https://raw.githubusercontent.com/unicode-org/icu/master/icu4c/LICENSE:
+
+- com.ibm.icu:icu4j
+
+-------------------------------------------------------------------------------
+3-Clause BSD License
+-------------------------------------------------------------------------------
+
+The following bundled dependencies are available under the 3-Clause BSD License,
+the full text of which is available at
+https://opensource.org/licenses/BSD-3-Clause:
+
+- com.google.protobuf:protobuf-java
+- com.esotericsoftware.kryo:kryo
+- com.esotericsoftware.minlog:minlog
+- org.codehaus.janino:janino
+- org.codehaus.janino:commons-compiler
+
+-------------------------------------------------------------------------------
+2-Clause BSD License
+-------------------------------------------------------------------------------
+
+The following bundled dependency is available under the 2-Clause BSD License,
+the full text of which is available at
+https://opensource.org/licenses/BSD-2-Clause:
+
+- com.github.luben:zstd-jni
+
+-------------------------------------------------------------------------------
+Eclipse Public License v2.0
+-------------------------------------------------------------------------------
+
+The following bundled dependency is available under the Eclipse Public License
+v2.0, the full text of which is available at
+https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt:
+
+- org.locationtech.jts:jts-core
+
+-------------------------------------------------------------------------------
+MIT License
+-------------------------------------------------------------------------------
+
+The following bundled dependency is available under the MIT License, the full
+text of which is available at
+http://www.opensource.org/licenses/mit-license.php:
+
+- org.checkerframework:checker-qual
+

--- a/auron-flink-extension/auron-flink-assembly/src/main/resources/META-INF/NOTICE
+++ b/auron-flink-extension/auron-flink-assembly/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,17 @@
+The class org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecCalc in
+this artifact is a modified version developed by Apache Auron: it redirects Calc
+execution to Auron's native engine. It replaces the stock flink-table-planner class
+of the same name (Apache License 2.0, Section 4(b)).
+
+This artifact bundles org.apache.kafka:kafka-clients, whose required attribution
+is reproduced below (kafka-clients ships it in its jar-root NOTICE):
+
+  This project contains the following code copied from Apache Hadoop:
+  clients/src/main/java/org/apache/kafka/common/utils/PureJavaCrc32C.java
+  Some portions of this file Copyright (c) 2004-2006 Intel Corporation and licensed
+  under the BSD license.
+
+  The streams-scala module was donated by Lightbend and the original code was
+  copyrighted by them:
+  Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+  Copyright (C) 2017-2018 Alexis Seigneurin.

--- a/auron-flink-extension/auron-flink-assembly/src/test/java/org/apache/auron/flink/assembly/AssemblyJarStructureIT.java
+++ b/auron-flink-extension/auron-flink-assembly/src/test/java/org/apache/auron/flink/assembly/AssemblyJarStructureIT.java
@@ -38,82 +38,79 @@ import org.junit.jupiter.api.Test;
 /**
  * Structural smoke test for the shaded {@code auron-flink-assembly} uber jar.
  *
- * <p>The assembly bundles Flink's {@code flink-table-planner} content together with Auron's
- * override of {@code StreamExecCalc} (same fully-qualified class name). Because a jar holds at most
- * one entry per path, the assembly always contains exactly one {@code StreamExecCalc.class} — but
- * <em>which</em> copy survives the shade is what matters. The deployment guarantee A2 relies on is
- * that the surviving copy is <em>Auron's</em>, so that native Calc activation is structural rather
- * than dependent on shade artifact-processing order.
+ * <p>The assembly bundles Flink's {@code flink-table-planner} content together with Auron's overrides
+ * of selected Flink {@code ExecNode} classes (each shipped under the stock Flink fully-qualified
+ * class name). Because a jar holds at most one entry per path, the assembly contains exactly one
+ * entry for each override path — but <em>which</em> copy survives the shade is what matters. The
+ * deployment guarantee A2 relies on is that the surviving copy is <em>Auron's</em>, so that native
+ * activation is structural rather than dependent on shade artifact-processing order.
  *
- * <p>This test asserts the structural <em>outcome</em>: the surviving {@code StreamExecCalc} carries
- * Auron's bytecode marker, the full planner is bundled (not just Auron's one class), and the ASF
- * NOTICE names both products. The load-bearing-ness of the shade {@code <filters>} exclude that
- * produces this outcome is verified separately by the manual A/B procedure documented in the
- * reviewhelper — this test certifies the result that exclude must achieve.
+ * <p>This test asserts the structural <em>outcome</em>, driven by the override registry
+ * {@code META-INF/auron/shadowed-flink-execnodes.txt}: every registered override survives as a single
+ * class entry carrying Auron's {@code FlinkAuronExecNode} marker, the full planner is bundled (not
+ * just Auron's overrides), and the ASF NOTICE names both products. A developer who adds an override +
+ * marker + registry entry but forgets the matching per-class {@code <exclude>} in the assembly shade
+ * {@code <filters>} would let Flink's stock copy win the collision; the surviving class then lacks the
+ * marker and this test fails. The test certifies the result the exclude must achieve, not the shade
+ * mechanism itself.
  *
  * <p>Inspection is purely byte-level via {@link JarFile}: no classloading, and Flink is not on the
  * test classpath.
  */
 class AssemblyJarStructureIT {
 
-    private static final String STREAM_EXEC_CALC_ENTRY =
-            "org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecCalc.class";
-
-    /**
-     * Internal-name marker that appears in the constant pool of Auron's {@code StreamExecCalc} (it
-     * imports and constructs {@code FlinkAuronCalcOperator}). Flink's stock {@code StreamExecCalc}
-     * has no reference to any Auron type, so this byte sequence distinguishes the two copies.
-     */
-    private static final byte[] AURON_MARKER =
-            "org/apache/auron/flink/runtime/operator/FlinkAuronCalcOperator".getBytes(StandardCharsets.UTF_8);
+    private static final String OVERRIDE_REGISTRY_ENTRY = "META-INF/auron/shadowed-flink-execnodes.txt";
 
     private static final String STREAM_EXEC_PREFIX = "org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExec";
 
-    @Test
-    void exactlyOneStreamExecCalc() throws IOException {
-        try (JarFile jar = openAssemblyJar()) {
-            int count = 0;
-            Enumeration<JarEntry> entries = jar.entries();
-            while (entries.hasMoreElements()) {
-                if (STREAM_EXEC_CALC_ENTRY.equals(entries.nextElement().getName())) {
-                    count++;
-                }
-            }
-            assertEquals(1, count, "Expected exactly one " + STREAM_EXEC_CALC_ENTRY + " entry, found " + count);
-        }
-    }
+    /**
+     * Internal name of the {@code FlinkAuronExecNode} marker interface that every Auron override
+     * implements. Its constant-pool reference is present in any Auron override and absent from every
+     * stock Flink class (stock Flink references no Auron type), so this byte sequence distinguishes
+     * an Auron copy from a stock copy of the same class path.
+     */
+    private static final byte[] AURON_EXEC_NODE_MARKER =
+            "org/apache/auron/flink/table/planner/FlinkAuronExecNode".getBytes(StandardCharsets.UTF_8);
 
     @Test
-    void streamExecCalcIsAuron() throws IOException {
+    void everyRegisteredOverrideIsAuron() throws IOException {
         try (JarFile jar = openAssemblyJar()) {
-            JarEntry entry = jar.getJarEntry(STREAM_EXEC_CALC_ENTRY);
-            assertNotNull(entry, "Assembly jar is missing " + STREAM_EXEC_CALC_ENTRY);
-            byte[] classBytes = readEntry(jar, entry);
-            assertTrue(
-                    indexOf(classBytes, AURON_MARKER) >= 0,
-                    "The bundled StreamExecCalc is not Auron's: its bytecode does not reference "
-                            + "FlinkAuronCalcOperator. Flink's stock copy must have shadowed Auron's "
-                            + "override — the determinism filter is not effective.");
+            List<String> overrides = readOverrideRegistry(jar);
+            for (String fqcn : overrides) {
+                String entryPath = fqcn.replace('.', '/') + ".class";
+                int count = countEntries(jar, entryPath);
+                assertEquals(1, count, "Expected exactly one " + entryPath + " entry, found " + count);
+                byte[] classBytes = readEntry(jar, jar.getJarEntry(entryPath));
+                assertTrue(
+                        indexOf(classBytes, AURON_EXEC_NODE_MARKER) >= 0,
+                        "The bundled "
+                                + fqcn
+                                + " is not Auron's: its bytecode does not reference FlinkAuronExecNode. "
+                                + "Flink's stock copy must have shadowed Auron's override — the shade "
+                                + "<filters> <exclude> for this class is missing or ineffective.");
+            }
         }
     }
 
     @Test
     void flinkPlannerContentBundled() throws IOException {
         try (JarFile jar = openAssemblyJar()) {
+            List<String> overridePaths = new ArrayList<>();
+            for (String fqcn : readOverrideRegistry(jar)) {
+                overridePaths.add(fqcn.replace('.', '/') + ".class");
+            }
             boolean otherStreamExecPresent = false;
             Enumeration<JarEntry> entries = jar.entries();
             while (entries.hasMoreElements()) {
                 String name = entries.nextElement().getName();
-                if (name.startsWith(STREAM_EXEC_PREFIX)
-                        && name.endsWith(".class")
-                        && !name.equals(STREAM_EXEC_CALC_ENTRY)) {
+                if (name.startsWith(STREAM_EXEC_PREFIX) && name.endsWith(".class") && !overridePaths.contains(name)) {
                     otherStreamExecPresent = true;
                     break;
                 }
             }
             assertTrue(
                     otherStreamExecPresent,
-                    "Assembly jar contains no StreamExec* class other than StreamExecCalc — the Flink "
+                    "Assembly jar contains no StreamExec* class other than Auron's overrides — the Flink "
                             + "planner content does not appear to be bundled.");
         }
     }
@@ -130,6 +127,38 @@ class AssemblyJarStructureIT {
                     "META-INF/NOTICE does not name \"Apache Flink\" — the bundled, modified planner "
                             + "content is not attributed.");
         }
+    }
+
+    private static List<String> readOverrideRegistry(JarFile jar) throws IOException {
+        JarEntry entry = jar.getJarEntry(OVERRIDE_REGISTRY_ENTRY);
+        assertNotNull(
+                entry,
+                "Assembly jar is missing the override registry "
+                        + OVERRIDE_REGISTRY_ENTRY
+                        + " — the auron-flink-planner resource did not survive the shade.");
+        String text = new String(readEntry(jar, entry), StandardCharsets.UTF_8);
+        List<String> overrides = new ArrayList<>();
+        for (String line : text.split("\n")) {
+            String trimmed = line.trim();
+            if (!trimmed.isEmpty() && !trimmed.startsWith("#")) {
+                overrides.add(trimmed);
+            }
+        }
+        assertTrue(
+                !overrides.isEmpty(),
+                "Override registry " + OVERRIDE_REGISTRY_ENTRY + " lists no override class names.");
+        return overrides;
+    }
+
+    private static int countEntries(JarFile jar, String entryPath) {
+        int count = 0;
+        Enumeration<JarEntry> entries = jar.entries();
+        while (entries.hasMoreElements()) {
+            if (entryPath.equals(entries.nextElement().getName())) {
+                count++;
+            }
+        }
+        return count;
     }
 
     private static JarFile openAssemblyJar() throws IOException {

--- a/auron-flink-extension/auron-flink-assembly/src/test/java/org/apache/auron/flink/assembly/AssemblyJarStructureIT.java
+++ b/auron-flink-extension/auron-flink-assembly/src/test/java/org/apache/auron/flink/assembly/AssemblyJarStructureIT.java
@@ -1,0 +1,203 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.auron.flink.assembly;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Structural smoke test for the shaded {@code auron-flink-assembly} uber jar.
+ *
+ * <p>The assembly bundles Flink's {@code flink-table-planner} content together with Auron's
+ * override of {@code StreamExecCalc} (same fully-qualified class name). Because a jar holds at most
+ * one entry per path, the assembly always contains exactly one {@code StreamExecCalc.class} — but
+ * <em>which</em> copy survives the shade is what matters. The deployment guarantee A2 relies on is
+ * that the surviving copy is <em>Auron's</em>, so that native Calc activation is structural rather
+ * than dependent on shade artifact-processing order.
+ *
+ * <p>This test asserts the structural <em>outcome</em>: the surviving {@code StreamExecCalc} carries
+ * Auron's bytecode marker, the full planner is bundled (not just Auron's one class), and the ASF
+ * NOTICE names both products. The load-bearing-ness of the shade {@code <filters>} exclude that
+ * produces this outcome is verified separately by the manual A/B procedure documented in the
+ * reviewhelper — this test certifies the result that exclude must achieve.
+ *
+ * <p>Inspection is purely byte-level via {@link JarFile}: no classloading, and Flink is not on the
+ * test classpath.
+ */
+class AssemblyJarStructureIT {
+
+    private static final String STREAM_EXEC_CALC_ENTRY =
+            "org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecCalc.class";
+
+    /**
+     * Internal-name marker that appears in the constant pool of Auron's {@code StreamExecCalc} (it
+     * imports and constructs {@code FlinkAuronCalcOperator}). Flink's stock {@code StreamExecCalc}
+     * has no reference to any Auron type, so this byte sequence distinguishes the two copies.
+     */
+    private static final byte[] AURON_MARKER =
+            "org/apache/auron/flink/runtime/operator/FlinkAuronCalcOperator".getBytes(StandardCharsets.UTF_8);
+
+    private static final String STREAM_EXEC_PREFIX = "org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExec";
+
+    @Test
+    void exactlyOneStreamExecCalc() throws IOException {
+        try (JarFile jar = openAssemblyJar()) {
+            int count = 0;
+            Enumeration<JarEntry> entries = jar.entries();
+            while (entries.hasMoreElements()) {
+                if (STREAM_EXEC_CALC_ENTRY.equals(entries.nextElement().getName())) {
+                    count++;
+                }
+            }
+            assertEquals(1, count, "Expected exactly one " + STREAM_EXEC_CALC_ENTRY + " entry, found " + count);
+        }
+    }
+
+    @Test
+    void streamExecCalcIsAuron() throws IOException {
+        try (JarFile jar = openAssemblyJar()) {
+            JarEntry entry = jar.getJarEntry(STREAM_EXEC_CALC_ENTRY);
+            assertNotNull(entry, "Assembly jar is missing " + STREAM_EXEC_CALC_ENTRY);
+            byte[] classBytes = readEntry(jar, entry);
+            assertTrue(
+                    indexOf(classBytes, AURON_MARKER) >= 0,
+                    "The bundled StreamExecCalc is not Auron's: its bytecode does not reference "
+                            + "FlinkAuronCalcOperator. Flink's stock copy must have shadowed Auron's "
+                            + "override — the determinism filter is not effective.");
+        }
+    }
+
+    @Test
+    void flinkPlannerContentBundled() throws IOException {
+        try (JarFile jar = openAssemblyJar()) {
+            boolean otherStreamExecPresent = false;
+            Enumeration<JarEntry> entries = jar.entries();
+            while (entries.hasMoreElements()) {
+                String name = entries.nextElement().getName();
+                if (name.startsWith(STREAM_EXEC_PREFIX)
+                        && name.endsWith(".class")
+                        && !name.equals(STREAM_EXEC_CALC_ENTRY)) {
+                    otherStreamExecPresent = true;
+                    break;
+                }
+            }
+            assertTrue(
+                    otherStreamExecPresent,
+                    "Assembly jar contains no StreamExec* class other than StreamExecCalc — the Flink "
+                            + "planner content does not appear to be bundled.");
+        }
+    }
+
+    @Test
+    void noticeNamesAuronAndFlink() throws IOException {
+        try (JarFile jar = openAssemblyJar()) {
+            JarEntry notice = jar.getJarEntry("META-INF/NOTICE");
+            assertNotNull(notice, "Assembly jar is missing META-INF/NOTICE");
+            String text = new String(readEntry(jar, notice), StandardCharsets.UTF_8);
+            assertTrue(text.contains("Apache Auron"), "META-INF/NOTICE does not name \"Apache Auron\"");
+            assertTrue(
+                    text.contains("Apache Flink"),
+                    "META-INF/NOTICE does not name \"Apache Flink\" — the bundled, modified planner "
+                            + "content is not attributed.");
+        }
+    }
+
+    private static JarFile openAssemblyJar() throws IOException {
+        Path targetDir = Paths.get(System.getProperty("user.dir"), "target");
+        if (!Files.isDirectory(targetDir)) {
+            fail("Module target/ directory not found at "
+                    + targetDir
+                    + " — the assembly jar must be built (package phase) before this test runs.");
+        }
+        List<Path> candidates = new ArrayList<>();
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(targetDir, "auron-flink-assembly-*.jar")) {
+            for (Path path : stream) {
+                String name = path.getFileName().toString();
+                if (name.endsWith("-tests.jar") || name.endsWith("-sources.jar") || name.startsWith("original-")) {
+                    continue;
+                }
+                candidates.add(path);
+            }
+        }
+        if (candidates.size() != 1) {
+            fail("Expected exactly one shaded auron-flink-assembly-*.jar in "
+                    + targetDir
+                    + ", found "
+                    + candidates.size()
+                    + ": "
+                    + candidates
+                    + ". A mis-ordered phase (test before package) or a stale target/ is the "
+                    + "likely cause.");
+        }
+        return new JarFile(candidates.get(0).toFile());
+    }
+
+    private static byte[] readEntry(JarFile jar, JarEntry entry) throws IOException {
+        try (InputStream in = jar.getInputStream(entry)) {
+            return readAllBytes(in);
+        }
+    }
+
+    private static byte[] readAllBytes(InputStream in) throws IOException {
+        byte[] buffer = new byte[8192];
+        int total = 0;
+        int read;
+        while ((read = in.read(buffer, total, buffer.length - total)) != -1) {
+            total += read;
+            if (total == buffer.length) {
+                byte[] grown = new byte[buffer.length * 2];
+                System.arraycopy(buffer, 0, grown, 0, total);
+                buffer = grown;
+            }
+        }
+        byte[] result = new byte[total];
+        System.arraycopy(buffer, 0, result, 0, total);
+        return result;
+    }
+
+    private static int indexOf(byte[] haystack, byte[] needle) {
+        if (needle.length == 0 || haystack.length < needle.length) {
+            return -1;
+        }
+        outer:
+        for (int i = 0; i <= haystack.length - needle.length; i++) {
+            for (int j = 0; j < needle.length; j++) {
+                if (haystack[i + j] != needle[j]) {
+                    continue outer;
+                }
+            }
+            return i;
+        }
+        return -1;
+    }
+}

--- a/auron-flink-extension/auron-flink-planner/src/main/java/org/apache/auron/flink/table/planner/FlinkAuronExecNode.java
+++ b/auron-flink-extension/auron-flink-planner/src/main/java/org/apache/auron/flink/table/planner/FlinkAuronExecNode.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.auron.flink.table.planner;
+
+/**
+ * Marker interface every Auron override of a Flink {@code ExecNode} must implement.
+ *
+ * <p>An Auron override ships under Flink's own fully-qualified class name so that, with
+ * {@code auron-flink-planner} ahead of {@code flink-table-planner} on the classpath, Flink's
+ * planner constructs Auron's class instead of the stock one. Because stock Flink classes never
+ * reference any Auron type, the presence of this interface on a class is an unambiguous signal that
+ * Auron's copy — not Flink's — is the one in effect. The build-time structural tests rely on that
+ * signal to verify every override is present and won the shade in the deployment jar.
+ *
+ * <p>When adding a new Auron override of a Flink {@code ExecNode}, follow all three steps:
+ *
+ * <ol>
+ *   <li>Ship the override class under the stock Flink {@code ExecNode}'s fully-qualified class name
+ *       and have it {@code implement} this interface.
+ *   <li>List the override's fully-qualified class name in
+ *       {@code META-INF/auron/shadowed-flink-execnodes.txt}, the override registry.
+ *   <li>Add a matching {@code <exclude>} for the stock class to the shade {@code <filters>} in
+ *       {@code auron-flink-assembly/pom.xml}, so the stock copy is dropped from the deployment jar
+ *       and Auron's copy wins structurally.
+ * </ol>
+ */
+public interface FlinkAuronExecNode {}

--- a/auron-flink-extension/auron-flink-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecCalc.java
+++ b/auron-flink-extension/auron-flink-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecCalc.java
@@ -25,6 +25,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import javax.annotation.Nullable;
 import org.apache.auron.flink.configuration.FlinkAuronConfiguration;
 import org.apache.auron.flink.runtime.operator.FlinkAuronCalcOperator;
+import org.apache.auron.flink.table.planner.FlinkAuronExecNode;
 import org.apache.auron.flink.table.planner.UnsupportedFlinkNodeRecorder;
 import org.apache.auron.flink.table.planner.converter.ConverterContext;
 import org.apache.auron.flink.table.planner.converter.FlinkNodeConverterFactory;
@@ -87,7 +88,7 @@ import org.slf4j.LoggerFactory;
         version = 1,
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
-public class StreamExecCalc extends CommonExecCalc implements StreamExecNode<RowData> {
+public class StreamExecCalc extends CommonExecCalc implements StreamExecNode<RowData>, FlinkAuronExecNode {
 
     private static final Logger LOG = LoggerFactory.getLogger(StreamExecCalc.class);
 

--- a/auron-flink-extension/auron-flink-planner/src/main/resources/META-INF/auron/shadowed-flink-execnodes.txt
+++ b/auron-flink-extension/auron-flink-planner/src/main/resources/META-INF/auron/shadowed-flink-execnodes.txt
@@ -1,0 +1,21 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Registry of Auron overrides of Flink ExecNodes, one fully-qualified class name per line.
+# Each listed class ships under the stock Flink class name, implements FlinkAuronExecNode, and has
+# a matching <exclude> in auron-flink-assembly/pom.xml's shade <filters>. Blank lines and lines
+# starting with '#' are ignored.
+org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecCalc

--- a/auron-flink-extension/auron-flink-planner/src/test/java/org/apache/auron/flink/table/planner/ShadowedExecNodeRegistryTest.java
+++ b/auron-flink-extension/auron-flink-planner/src/test/java/org/apache/auron/flink/table/planner/ShadowedExecNodeRegistryTest.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.auron.flink.table.planner;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.UncheckedIOException;
+import java.lang.reflect.Modifier;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Enforces the override contract documented on {@link FlinkAuronExecNode}: every Auron override of a
+ * Flink {@code ExecNode} compiled under {@code org.apache.flink.table.planner.plan.nodes.exec} must
+ * implement the marker interface, and the override registry
+ * {@code META-INF/auron/shadowed-flink-execnodes.txt} must list exactly those override classes.
+ *
+ * <p>Scanning compiled classes (rather than a hand-maintained list) means a developer who adds a new
+ * override but forgets to implement the marker, or forgets to register it, fails the build here
+ * rather than discovering a silently-stock {@code ExecNode} at deployment time.
+ */
+class ShadowedExecNodeRegistryTest {
+
+    private static final String EXEC_PACKAGE = "org.apache.flink.table.planner.plan.nodes.exec";
+
+    private static final String REGISTRY_RESOURCE = "/META-INF/auron/shadowed-flink-execnodes.txt";
+
+    @Test
+    void everyOverrideImplementsMarker() {
+        for (Class<?> c : concreteTopLevelExecClasses()) {
+            assertTrue(
+                    FlinkAuronExecNode.class.isAssignableFrom(c),
+                    "Override class " + c.getName() + " under " + EXEC_PACKAGE
+                            + " does not implement " + FlinkAuronExecNode.class.getName()
+                            + ". Every Auron override of a Flink ExecNode must implement this marker "
+                            + "interface so the build can verify it won the shade.");
+        }
+    }
+
+    @Test
+    void registryMatchesMarkerSet() {
+        Set<String> markerSet = new TreeSet<>();
+        for (Class<?> c : concreteTopLevelExecClasses()) {
+            if (FlinkAuronExecNode.class.isAssignableFrom(c)) {
+                markerSet.add(c.getName());
+            }
+        }
+        Set<String> registry = new TreeSet<>(readRegistry());
+
+        Set<String> implementedButUnregistered = new TreeSet<>(markerSet);
+        implementedButUnregistered.removeAll(registry);
+        Set<String> registeredButNotImplemented = new TreeSet<>(registry);
+        registeredButNotImplemented.removeAll(markerSet);
+
+        assertEquals(
+                markerSet,
+                registry,
+                "The override registry " + REGISTRY_RESOURCE + " is out of sync with the set of classes "
+                        + "implementing " + FlinkAuronExecNode.class.getSimpleName()
+                        + ". Classes implementing the marker but not registered: " + implementedButUnregistered
+                        + "; registered but not found / not implementing the marker: " + registeredButNotImplemented
+                        + ". Update META-INF/auron/shadowed-flink-execnodes.txt to list exactly the override classes.");
+    }
+
+    /**
+     * Returns the concrete, top-level classes compiled under {@link #EXEC_PACKAGE}. Interfaces,
+     * abstract classes, and inner classes (whose binary name contains {@code $}) are skipped, since
+     * the override contract applies only to the concrete {@code ExecNode} classes Flink instantiates
+     * by fully-qualified name.
+     */
+    private static Set<Class<?>> concreteTopLevelExecClasses() {
+        Path classesDir = Paths.get(System.getProperty("user.dir"), "target", "classes");
+        Path execDir = classesDir.resolve(EXEC_PACKAGE.replace('.', '/'));
+        if (!Files.isDirectory(execDir)) {
+            fail("Compiled exec-node package not found at " + execDir
+                    + " — the module must be compiled before this test runs.");
+        }
+        ClassLoader loader = Thread.currentThread().getContextClassLoader();
+        Set<Class<?>> result = new TreeSet<>((a, b) -> a.getName().compareTo(b.getName()));
+        try (Stream<Path> paths = Files.walk(execDir)) {
+            for (Path classFile :
+                    paths.filter(p -> p.toString().endsWith(".class")).collect(Collectors.toList())) {
+                String fqcn = toFqcn(classesDir, classFile);
+                if (fqcn.contains("$")) {
+                    continue;
+                }
+                Class<?> c;
+                try {
+                    c = Class.forName(fqcn, false, loader);
+                } catch (ClassNotFoundException | NoClassDefFoundError e) {
+                    throw new IllegalStateException("Failed to load compiled class " + fqcn, e);
+                }
+                if (c.isInterface() || Modifier.isAbstract(c.getModifiers())) {
+                    continue;
+                }
+                result.add(c);
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to walk compiled exec-node package at " + execDir, e);
+        }
+        return result;
+    }
+
+    private static String toFqcn(Path classesDir, Path classFile) {
+        String relative = classesDir.relativize(classFile).toString();
+        return relative.substring(0, relative.length() - ".class".length())
+                .replace(classFile.getFileSystem().getSeparator(), ".");
+    }
+
+    private static Set<String> readRegistry() {
+        Set<String> entries = new TreeSet<>();
+        try (InputStream in = ShadowedExecNodeRegistryTest.class.getResourceAsStream(REGISTRY_RESOURCE)) {
+            if (in == null) {
+                fail("Override registry resource not found on the classpath: " + REGISTRY_RESOURCE);
+            }
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8))) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    String trimmed = line.trim();
+                    if (trimmed.isEmpty() || trimmed.startsWith("#")) {
+                        continue;
+                    }
+                    entries.add(trimmed);
+                }
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to read override registry " + REGISTRY_RESOURCE, e);
+        }
+        return entries;
+    }
+}


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2291

# Rationale for this change

`auron-flink-assembly` is the single Flink deployment jar. It already bundles both Auron's `StreamExecCalc` override and Flink's stock `StreamExecCalc` (transitive from `flink-table-planner_2.12`), but with no class-level filter the surviving copy was decided by maven-shade's class-overlap ordering — not a guarantee. This makes Auron's override win structurally, so activation no longer depends on incidental shade/classpath ordering.

# What changes are included in this PR?

- Exclude Flink's stock `StreamExecCalc` from the shaded jar so only Auron's override remains.
- Add ASF NOTICE/LICENSE for the embedded modified Flink content, plus a full audit of bundled non-ALv2 dependencies (icu4j, protobuf, kryo, minlog, janino, commons-compiler, zstd-jni, jts-core, checker-qual).
- Add `AssemblyJarStructureIT`, a build-time test asserting the jar contains exactly one `StreamExecCalc` and it is Auron's.
- Run the structural test in the Flink CI workflow.

# Are there any user-facing changes?

The recommended deployment becomes a single structural jar swap (remove `flink-table-planner-loader-*.jar` from `$FLINK_HOME/lib/`, add `auron-flink-assembly.jar`). The user-facing deployment documentation is tracked separately in #1892.

# How was this patch tested?

`AssemblyJarStructureIT` (build-time, runs in CI). Manually verified the loader to non-loader jar swap on a Flink 1.18 home running a Calc SQL with native conversion active.
