### PR TITLE
[AURON #2090] Convert CoalesceExec to native implementation

### DIFF
--- a/native-engine/auron-planner/proto/auron.proto
+++ b/native-engine/auron-planner/proto/auron.proto
@@ -53,6 +53,7 @@ message PhysicalPlanNode {
     OrcScanExecNode orc_scan = 25;
     KafkaScanExecNode kafka_scan = 26;
     OrcSinkExecNode orc_sink = 27;
+    CoalesceExecNode coalesce = 29;
   }
 }
 
@@ -777,6 +778,12 @@ message KafkaScanExecNode {
   KafkaFormat data_format = 7;
   string format_config_json = 8;
   string mock_data_json_array = 9;
+}
+
+message CoalesceExecNode {
+  PhysicalPlanNode input = 1;
+  int32  numPartitions = 2
+  ;
 }
 
 enum KafkaFormat {

--- a/native-engine/auron-planner/proto/auron.proto
+++ b/native-engine/auron-planner/proto/auron.proto
@@ -782,8 +782,7 @@ message KafkaScanExecNode {
 
 message CoalesceExecNode {
   PhysicalPlanNode input = 1;
-  int32  numPartitions = 2
-  ;
+  int32  numPartitions = 2;
 }
 
 enum KafkaFormat {

--- a/native-engine/auron-planner/src/planner.rs
+++ b/native-engine/auron-planner/src/planner.rs
@@ -578,8 +578,7 @@ impl PhysicalPlanner {
                 )))
             }
             PhysicalPlanType::Coalesce(coalesce) => {
-                let input: Arc<dyn ExecutionPlan> =
-                    convert_box_required!(self, coalesce.input)?;
+                let input: Arc<dyn ExecutionPlan> = convert_box_required!(self, coalesce.input)?;
                 Ok(Arc::new(CoalesceExec::new(
                     input,
                     coalesce.num_partitions as usize,

--- a/native-engine/auron-planner/src/planner.rs
+++ b/native-engine/auron-planner/src/planner.rs
@@ -67,6 +67,7 @@ use datafusion_ext_plans::{
     agg_exec::AggExec,
     broadcast_join_build_hash_map_exec::BroadcastJoinBuildHashMapExec,
     broadcast_join_exec::BroadcastJoinExec,
+    coalesce_exec::CoalesceExec,
     debug_exec::DebugExec,
     empty_partitions_exec::EmptyPartitionsExec,
     expand_exec::ExpandExec,
@@ -574,6 +575,14 @@ impl PhysicalPlanner {
                     ffi_reader.num_partitions as usize,
                     ffi_reader.export_iter_provider_resource_id.clone(),
                     schema,
+                )))
+            }
+            PhysicalPlanType::Coalesce(coalesce) => {
+                let input: Arc<dyn ExecutionPlan> =
+                    convert_box_required!(self, coalesce.input)?;
+                Ok(Arc::new(CoalesceExec::new(
+                    input,
+                    coalesce.num_partitions as usize,
                 )))
             }
             PhysicalPlanType::CoalesceBatches(coalesce_batches) => {

--- a/native-engine/datafusion-ext-plans/src/coalesce_exec.rs
+++ b/native-engine/datafusion-ext-plans/src/coalesce_exec.rs
@@ -1,0 +1,120 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{any::Any, fmt::Formatter, sync::Arc};
+
+use arrow::datatypes::SchemaRef;
+use datafusion::{
+    common::Result,
+    execution::context::TaskContext,
+    physical_expr::EquivalenceProperties,
+    physical_plan::{
+        DisplayAs, DisplayFormatType, ExecutionPlan, ExecutionPlanProperties, PlanProperties,
+        SendableRecordBatchStream, Statistics,
+        execution_plan::{Boundedness, EmissionType},
+        metrics::{ExecutionPlanMetricsSet, MetricsSet},
+    },
+};
+use futures::StreamExt;
+use once_cell::sync::OnceCell;
+
+use crate::common::execution_context::ExecutionContext;
+
+#[derive(Debug)]
+pub struct CoalesceExec {
+    input: Arc<dyn ExecutionPlan>,
+    num_partitions: usize,
+    metrics: ExecutionPlanMetricsSet,
+    props: OnceCell<PlanProperties>,
+}
+
+impl CoalesceExec {
+    pub fn new(input: Arc<dyn ExecutionPlan>, num_partitions: usize) -> Self {
+        Self {
+            input,
+            num_partitions,
+            metrics: ExecutionPlanMetricsSet::new(),
+            props: OnceCell::new(),
+        }
+    }
+}
+
+impl DisplayAs for CoalesceExec {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut Formatter) -> std::fmt::Result {
+        write!(f, "CoalesceExec[num_partitions={}]", self.num_partitions)
+    }
+}
+
+impl ExecutionPlan for CoalesceExec {
+    fn name(&self) -> &str {
+        "CoalesceExec"
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        self.input.schema()
+    }
+
+    fn properties(&self) -> &PlanProperties {
+        self.props.get_or_init(|| {
+            PlanProperties::new(
+                EquivalenceProperties::new(self.schema()),
+                self.input.output_partitioning().clone(),
+                EmissionType::Both,
+                Boundedness::Bounded,
+            )
+        })
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![&self.input]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        Ok(Arc::new(CoalesceExec::new(
+            children[0].clone(),
+            self.num_partitions,
+        )))
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<TaskContext>,
+    ) -> Result<SendableRecordBatchStream> {
+        let exec_ctx = ExecutionContext::new(context, partition, self.schema(), &self.metrics);
+        let mut input = exec_ctx.execute(&self.input)?;
+        Ok(exec_ctx.output_with_sender("Coalesce", move |sender| async move {
+            while let Some(batch) = input.next().await.transpose()? {
+                sender.send(batch).await;
+            }
+            Ok(())
+        }))
+    }
+
+    fn metrics(&self) -> Option<MetricsSet> {
+        Some(self.metrics.clone_inner())
+    }
+
+    fn statistics(&self) -> Result<Statistics> {
+        todo!()
+    }
+}

--- a/native-engine/datafusion-ext-plans/src/coalesce_exec.rs
+++ b/native-engine/datafusion-ext-plans/src/coalesce_exec.rs
@@ -102,12 +102,14 @@ impl ExecutionPlan for CoalesceExec {
     ) -> Result<SendableRecordBatchStream> {
         let exec_ctx = ExecutionContext::new(context, partition, self.schema(), &self.metrics);
         let mut input = exec_ctx.execute(&self.input)?;
-        Ok(exec_ctx.output_with_sender("Coalesce", move |sender| async move {
-            while let Some(batch) = input.next().await.transpose()? {
-                sender.send(batch).await;
-            }
-            Ok(())
-        }))
+        Ok(
+            exec_ctx.output_with_sender("Coalesce", move |sender| async move {
+                while let Some(batch) = input.next().await.transpose()? {
+                    sender.send(batch).await;
+                }
+                Ok(())
+            }),
+        )
     }
 
     fn metrics(&self) -> Option<MetricsSet> {

--- a/native-engine/datafusion-ext-plans/src/lib.rs
+++ b/native-engine/datafusion-ext-plans/src/lib.rs
@@ -36,6 +36,7 @@ pub mod agg;
 pub mod agg_exec;
 pub mod broadcast_join_build_hash_map_exec;
 pub mod broadcast_join_exec;
+pub mod coalesce_exec;
 pub mod debug_exec;
 pub mod empty_partitions_exec;
 pub mod expand_exec;

--- a/spark-extension-shims-spark/src/main/scala/org/apache/spark/sql/auron/ShimsImpl.scala
+++ b/spark-extension-shims-spark/src/main/scala/org/apache/spark/sql/auron/ShimsImpl.scala
@@ -288,6 +288,9 @@ class ShimsImpl extends Shims with Logging {
   override def createNativeFilterExec(condition: Expression, child: SparkPlan): NativeFilterBase =
     NativeFilterExec(condition, child)
 
+  def createNativeCoalesceExec(numPartitions: Int, child: SparkPlan): NativeCoalesceBase =
+    NativeCoalesceExec(numPartitions, child)
+
   override def createNativeGenerateExec(
       generator: Generator,
       requiredChildOutput: Seq[Attribute],

--- a/spark-extension-shims-spark/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeCoalesceExec.scala
+++ b/spark-extension-shims-spark/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeCoalesceExec.scala
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.auron.plan
+
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.execution.SparkPlan
+
+import org.apache.auron.sparkver
+
+case class NativeCoalesceExec(numPartitions: Int, override val child: SparkPlan)
+    extends NativeCoalesceBase(numPartitions, child) {
+  @sparkver("3.2 / 3.3 / 3.4 / 3.5 / 4.0 / 4.1")
+  override protected def withNewChildInternal(newChild: SparkPlan): SparkPlan =
+    copy(child = newChild)
+
+  @sparkver("3.0 / 3.1")
+  override def withNewChildren(newChildren: Seq[SparkPlan]): SparkPlan =
+    copy(child = newChildren.head)
+
+  override def output: Seq[Attribute] =
+    child.output
+}

--- a/spark-extension-shims-spark/src/test/scala/org/apache/auron/AuronNativeCoalesceExecSuite.scala
+++ b/spark-extension-shims-spark/src/test/scala/org/apache/auron/AuronNativeCoalesceExecSuite.scala
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.auron
+
+import org.apache.spark.sql.{AuronQueryTest, Row}
+import org.apache.spark.sql.execution.auron.plan.NativeCoalesceExec
+
+class AuronNativeCoalesceExecSuite extends AuronQueryTest with BaseAuronSQLSuite {
+  import testImplicits._
+
+  test("test CoalesceExec to native") {
+    withSQLConf("spark.auron.enable.coalesce" -> "true") {
+      Seq((1, 2, "test test"))
+        .toDF("c1", "c2", "part")
+//        .coalesce(2)
+        .createOrReplaceTempView("coalesce_table1")
+      val df = {
+//        spark.sql("select count(a.c1), count(a.c2) from coalesce_table1 a ")
+        spark.sql("select /*+ coalesce(2)*/ a.c1, a.c2 from coalesce_table1 a ")
+      }
+      df.show()
+
+      checkAnswer(df, Seq(Row(1, 2)))
+      assert(collectFirst(df.queryExecution.executedPlan) {
+        case coalesceExec: NativeCoalesceExec =>
+          coalesceExec
+      }.isDefined)
+
+    }
+  }
+
+  test("123") {
+    val random = new java.util.Random()
+    val data = (0 until 1000).map { _ =>
+      (random.nextInt(10), random.nextInt(100))
+    }
+    data.toDF("key", "value").coalesce(2).createOrReplaceTempView("coalesce_table1")
+
+    val df =
+      spark.sql("select count(key), count(value) from coalesce_table1 a ")
+
+    checkAnswer(df, Seq(Row(1, 2)))
+
+  }
+}

--- a/spark-extension-shims-spark/src/test/scala/org/apache/auron/AuronNativeCoalesceExecSuite.scala
+++ b/spark-extension-shims-spark/src/test/scala/org/apache/auron/AuronNativeCoalesceExecSuite.scala
@@ -37,7 +37,6 @@ class AuronNativeCoalesceExecSuite extends AuronQueryTest with BaseAuronSQLSuite
         case coalesceExec: NativeCoalesceExec =>
           coalesceExec
       }.isDefined)
-
     }
   }
 }

--- a/spark-extension-shims-spark/src/test/scala/org/apache/auron/AuronNativeCoalesceExecSuite.scala
+++ b/spark-extension-shims-spark/src/test/scala/org/apache/auron/AuronNativeCoalesceExecSuite.scala
@@ -33,6 +33,12 @@ class AuronNativeCoalesceExecSuite extends AuronQueryTest with BaseAuronSQLSuite
       df.show()
 
       checkAnswer(df, Seq(Row(1, 2)))
+      val test = collectFirst(df.queryExecution.executedPlan) {
+        case coalesceExec: NativeCoalesceExec =>
+          coalesceExec
+      }
+      println(test.get)
+
       assert(collectFirst(df.queryExecution.executedPlan) {
         case coalesceExec: NativeCoalesceExec =>
           coalesceExec

--- a/spark-extension-shims-spark/src/test/scala/org/apache/auron/AuronNativeCoalesceExecSuite.scala
+++ b/spark-extension-shims-spark/src/test/scala/org/apache/auron/AuronNativeCoalesceExecSuite.scala
@@ -26,10 +26,8 @@ class AuronNativeCoalesceExecSuite extends AuronQueryTest with BaseAuronSQLSuite
     withSQLConf("spark.auron.enable.coalesce" -> "true") {
       Seq((1, 2, "test test"))
         .toDF("c1", "c2", "part")
-//        .coalesce(2)
         .createOrReplaceTempView("coalesce_table1")
       val df = {
-//        spark.sql("select count(a.c1), count(a.c2) from coalesce_table1 a ")
         spark.sql("select /*+ coalesce(2)*/ a.c1, a.c2 from coalesce_table1 a ")
       }
       df.show()
@@ -41,19 +39,5 @@ class AuronNativeCoalesceExecSuite extends AuronQueryTest with BaseAuronSQLSuite
       }.isDefined)
 
     }
-  }
-
-  test("123") {
-    val random = new java.util.Random()
-    val data = (0 until 1000).map { _ =>
-      (random.nextInt(10), random.nextInt(100))
-    }
-    data.toDF("key", "value").coalesce(2).createOrReplaceTempView("coalesce_table1")
-
-    val df =
-      spark.sql("select count(key), count(value) from coalesce_table1 a ")
-
-    checkAnswer(df, Seq(Row(1, 2)))
-
   }
 }

--- a/spark-extension/src/main/java/org/apache/auron/spark/configuration/SparkAuronConfiguration.java
+++ b/spark-extension/src/main/java/org/apache/auron/spark/configuration/SparkAuronConfiguration.java
@@ -411,6 +411,11 @@ public class SparkAuronConfiguration extends AuronConfiguration {
             .withDescription("Enable AggregateExec operation conversion to native Auron implementations.")
             .withDefaultValue(true);
 
+    public static final ConfigOption<Boolean> ENABLE_COALESEC = new SQLConfOption<>(Boolean.class)
+            .withKey("auron.enable.coalesce")
+            .withCategory("Operator Supports")
+            .withDescription("Enable CoalesceExec operation conversion to native Auron implementations.")
+            .withDefaultValue(true);
     public static final ConfigOption<Boolean> ENABLE_EXPAND = new SQLConfOption<>(Boolean.class)
             .withKey("auron.enable.expand")
             .withCategory("Operator Supports")

--- a/spark-extension/src/main/scala/org/apache/spark/sql/auron/AuronConvertStrategy.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/auron/AuronConvertStrategy.scala
@@ -165,6 +165,8 @@ object AuronConvertStrategy extends Logging {
         e.setTagValue(convertStrategyTag, AlwaysConvert)
       case e: GenerateExec if isNative(e.child) =>
         e.setTagValue(convertStrategyTag, AlwaysConvert)
+      case e: CoalesceExec if isNative(e.child) =>
+        e.setTagValue(convertStrategyTag, AlwaysConvert)
       case e: ObjectHashAggregateExec if isNative(e.child) =>
         e.setTagValue(convertStrategyTag, AlwaysConvert)
       case e: LocalTableScanExec =>

--- a/spark-extension/src/main/scala/org/apache/spark/sql/auron/AuronConverters.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/auron/AuronConverters.scala
@@ -107,6 +107,7 @@ object AuronConverters extends Logging {
     SparkAuronConfiguration.ENABLE_TAKE_ORDERED_AND_PROJECT.get()
   def enableCollectLimit: Boolean = SparkAuronConfiguration.ENABLE_COLLECT_LIMIT.get()
   def enableAggr: Boolean = SparkAuronConfiguration.ENABLE_AGGR.get()
+  def enableCoalesec: Boolean = SparkAuronConfiguration.ENABLE_COALESEC.get()
   def enableExpand: Boolean = SparkAuronConfiguration.ENABLE_EXPAND.get()
   def enableWindow: Boolean = SparkAuronConfiguration.ENABLE_WINDOW.get()
   def enableWindowGroupLimit: Boolean = SparkAuronConfiguration.ENABLE_WINDOW_GROUP_LIMIT.get()
@@ -252,6 +253,10 @@ object AuronConverters extends Logging {
         }
         convertedAgg
 
+      case e: CoalesceExec if enableCoalesec => // coalesec
+        val convertedCoalesce = tryConvert(e, convertCoalesceExec)
+        convertedCoalesce
+
       case e: ObjectHashAggregateExec if enableAggr => // object hash aggregate
         val convertedAgg = tryConvert(e, convertObjectHashAggregateExec)
         if (!e.getTagValue(convertibleTag).contains(true)) {
@@ -370,6 +375,8 @@ object AuronConverters extends Logging {
           "Conversion disabled: spark.auron.enable.local.table.scan=false."
         case _: DataWritingCommandExec if !enableDataWriting =>
           "Conversion disabled: spark.auron.enable.data.writing=false."
+        case _: CoalesceExec if !enableCoalesec =>
+          "Conversion disabled: spark.auron.enable.coalesce=false."
         case _ =>
           s"${exec.getClass.getSimpleName} is not supported yet."
       }
@@ -805,6 +812,10 @@ object AuronConverters extends Logging {
     logDebugPlanConversion(exec)
     val (limit, offset) = Shims.get.getLimitAndOffset(exec)
     Shims.get.createNativeCollectLimitExec(limit, offset, exec.child)
+  }
+
+  def convertCoalesceExec(exec: CoalesceExec): SparkPlan = {
+    Shims.get.createNativeCoalesceExec(exec.numPartitions, exec.child)
   }
 
   def convertHashAggregateExec(exec: HashAggregateExec): SparkPlan = {

--- a/spark-extension/src/main/scala/org/apache/spark/sql/auron/NativeRDD.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/auron/NativeRDD.scala
@@ -26,7 +26,7 @@ import org.apache.spark.Partitioner
 import org.apache.spark.SparkContext
 import org.apache.spark.TaskContext
 import org.apache.spark.internal.Logging
-import org.apache.spark.rdd.RDD
+import org.apache.spark.rdd.{CoalescedRDDPartition, RDD}
 import org.apache.spark.sql.catalyst.InternalRow
 
 import org.apache.auron.metric.SparkMetricNode
@@ -76,6 +76,33 @@ class NativeRDD(
       Iterator.empty
     } else {
       NativeHelper.executeNativePlan(computingNativePlan, metrics, split, Some(context))
+    }
+  }
+}
+
+class CoalesceNativeRDD(
+    @transient private val rddSparkContext: SparkContext,
+    rddDependencies: Seq[Dependency[_]],
+    partitions: Array[Partition],
+    @transient private val nativePlan: (Partition, TaskContext) => PhysicalPlanNode,
+    friendlyName: String)
+    extends NativeRDD(
+      rddSparkContext,
+      metrics = SparkMetricNode(Map.empty, Seq(), None),
+      rddPartitions = partitions,
+      rddPartitioner = None,
+      rddDependencies,
+      rddShuffleReadFull = false,
+      nativePlan,
+      friendlyName)
+    with Logging
+    with Serializable {
+
+  override protected def getPartitions: Array[Partition] = partitions
+
+  override def compute(split: Partition, context: TaskContext): Iterator[InternalRow] = {
+    split.asInstanceOf[CoalescedRDDPartition].parents.iterator.flatMap { parentPartition =>
+      firstParent[InternalRow].iterator(parentPartition, context)
     }
   }
 }

--- a/spark-extension/src/main/scala/org/apache/spark/sql/auron/Shims.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/auron/Shims.scala
@@ -139,6 +139,8 @@ abstract class Shims {
       offset: Int,
       child: SparkPlan): NativeCollectLimitBase
 
+  def createNativeCoalesceExec(numPartitions: Int, child: SparkPlan): NativeCoalesceBase
+
   def createNativeParquetInsertIntoHiveTableExec(
       cmd: InsertIntoHiveTable,
       child: SparkPlan): NativeParquetInsertIntoHiveTableBase

--- a/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeCoalesceBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeCoalesceBase.scala
@@ -1,0 +1,321 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.auron.plan
+
+import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
+
+import org.apache.spark.Partition
+import org.apache.spark.rdd.{CoalescedRDDPartition, PartitionCoalescer, PartitionGroup, RDD}
+import org.apache.spark.sql.auron.{CoalesceNativeRDD, EmptyNativeRDD, NativeHelper, NativeRDD, NativeSupports}
+import org.apache.spark.sql.execution.{SparkPlan, UnaryExecNode}
+import org.apache.spark.sql.execution.auron.plan.NativeCoalesceBase.getNativeCoalesceBuilder
+
+import org.apache.auron.protobuf.{CoalesceExecNode, PhysicalPlanNode}
+
+abstract class NativeCoalesceBase(numPartitions: Int, override val child: SparkPlan)
+    extends UnaryExecNode
+    with NativeSupports {
+
+  override val nodeName: String = "NativeCoalesce"
+
+  private def nativeCoalesce = getNativeCoalesceBuilder(numPartitions).buildPartial()
+
+  nativeCoalesce
+
+  override def doExecuteNative(): NativeRDD = {
+    val inputRDD = NativeHelper.executeNative(child)
+    val partitions: Array[Partition] = {
+      val pc = new DefaultPartitionCoalescer()
+
+      pc.coalesce(numPartitions, inputRDD).zipWithIndex.map { case (pg, i) =>
+        val ids = pg.partitions.map(_.index).toArray
+        CoalescedRDDPartition(i, inputRDD, ids, pg.prefLoc)
+      }
+    }
+    if (numPartitions == 1 && inputRDD.getNumPartitions < 1) {
+      new EmptyNativeRDD(sparkContext)
+    } else {
+      new CoalesceNativeRDD(
+        sparkContext,
+        inputRDD.dependencies,
+        partitions,
+        (partition, taskContext) => {
+          val inputPartition = inputRDD.partitions(partition.index)
+          val nativeCoalesceExec = nativeCoalesce.toBuilder
+            .setInput(inputRDD.nativePlan(inputPartition, taskContext))
+            .build()
+          PhysicalPlanNode.newBuilder().setCoalesce(nativeCoalesceExec).build()
+        },
+        nodeName)
+    }
+  }
+
+}
+
+object NativeCoalesceBase {
+  def getNativeCoalesceBuilder(numPartitions: Int): CoalesceExecNode.Builder = {
+    CoalesceExecNode.newBuilder().setNumPartitions(numPartitions)
+  }
+}
+
+private class DefaultPartitionCoalescer(val balanceSlack: Double = 0.10)
+    extends PartitionCoalescer {
+
+  implicit object partitionGroupOrdering extends Ordering[PartitionGroup] {
+    override def compare(o1: PartitionGroup, o2: PartitionGroup): Int =
+      java.lang.Integer.compare(o1.numPartitions, o2.numPartitions)
+  }
+
+  private val rnd = new scala.util.Random(7919) // keep this class deterministic
+
+  // each element of groupArr represents one coalesced partition
+  private val groupArr = ArrayBuffer[PartitionGroup]()
+
+  // hash used to check whether some machine is already in groupArr
+  private val groupHash = mutable.Map[String, ArrayBuffer[PartitionGroup]]()
+
+  // hash used for the first maxPartitions (to avoid duplicates)
+  private val initialHash = mutable.Set[Partition]()
+
+  private var noLocality = true // if true if no preferredLocations exists for parent RDD
+
+  // gets the *current* preferred locations from the DAGScheduler (as opposed to the static ones)
+  private def currPrefLocs(part: Partition, prev: RDD[_]): Seq[String] = {
+    prev.context.getPreferredLocs(prev, part.index).map(tl => tl.host)
+  }
+
+  private class PartitionLocations(prev: RDD[_]) {
+
+    // contains all the partitions from the previous RDD that don't have preferred locations
+    val partsWithoutLocs = ArrayBuffer[Partition]()
+    // contains all the partitions from the previous RDD that have preferred locations
+    val partsWithLocs = ArrayBuffer[(String, Partition)]()
+
+    getAllPrefLocs(prev)
+
+    // gets all the preferred locations of the previous RDD and splits them into partitions
+    // with preferred locations and ones without
+    def getAllPrefLocs(prev: RDD[_]): Unit = {
+      val tmpPartsWithLocs = mutable.LinkedHashMap[Partition, Seq[String]]()
+      // first get the locations for each partition, only do this once since it can be expensive
+      prev.partitions.foreach(p => {
+        val locs = currPrefLocs(p, prev)
+        if (locs.nonEmpty) {
+          tmpPartsWithLocs.put(p, locs)
+        } else {
+          partsWithoutLocs += p
+        }
+      })
+      // convert it into an array of host to partition
+      for (x <- 0 to 2) {
+        tmpPartsWithLocs.foreach { parts =>
+          val p = parts._1
+          val locs = parts._2
+          if (locs.size > x) partsWithLocs += ((locs(x), p))
+        }
+      }
+    }
+  }
+
+  /**
+   * Gets the least element of the list associated with key in groupHash The returned
+   * PartitionGroup is the least loaded of all groups that represent the machine "key"
+   *
+   * @param key
+   *   string representing a partitioned group on preferred machine key
+   * @return
+   *   Option of [[PartitionGroup]] that has least elements for key
+   */
+  def getLeastGroupHash(key: String): Option[PartitionGroup] =
+    groupHash.get(key).filter(_.nonEmpty).map(_.min)
+
+  def addPartToPGroup(part: Partition, pgroup: PartitionGroup): Boolean = {
+    if (!initialHash.contains(part)) {
+      pgroup.partitions += part // already assign this element
+      initialHash += part // needed to avoid assigning partitions to multiple buckets
+      true
+    } else { false }
+  }
+
+  /**
+   * Initializes targetLen partition groups. If there are preferred locations, each group is
+   * assigned a preferredLocation. This uses coupon collector to estimate how many
+   * preferredLocations it must rotate through until it has seen most of the preferred locations
+   * (2 * n log(n))
+   * @param targetLen
+   *   The number of desired partition groups
+   */
+  def setupGroups(targetLen: Int, partitionLocs: PartitionLocations): Unit = {
+    // deal with empty case, just create targetLen partition groups with no preferred location
+    if (partitionLocs.partsWithLocs.isEmpty) {
+      (1 to targetLen).foreach(_ => groupArr += new PartitionGroup())
+      return
+    }
+
+    noLocality = false
+    // number of iterations needed to be certain that we've seen most preferred locations
+    val expectedCoupons2 = 2 * (math.log(targetLen) * targetLen + targetLen + 0.5).toInt
+    var numCreated = 0
+    var tries = 0
+
+    // rotate through until either targetLen unique/distinct preferred locations have been created
+    // OR (we have went through either all partitions OR we've rotated expectedCoupons2 - in
+    // which case we have likely seen all preferred locations)
+    val numPartsToLookAt = math.min(expectedCoupons2, partitionLocs.partsWithLocs.length)
+    while (numCreated < targetLen && tries < numPartsToLookAt) {
+      val (nxt_replica, nxt_part) = partitionLocs.partsWithLocs(tries)
+      tries += 1
+      if (!groupHash.contains(nxt_replica)) {
+        val pgroup = new PartitionGroup(Some(nxt_replica))
+        groupArr += pgroup
+        addPartToPGroup(nxt_part, pgroup)
+        groupHash.put(nxt_replica, ArrayBuffer(pgroup)) // list in case we have multiple
+        numCreated += 1
+      }
+    }
+    // if we don't have enough partition groups, create duplicates
+    while (numCreated < targetLen) {
+      // Copy the preferred location from a random input partition.
+      // This helps in avoiding skew when the input partitions are clustered by preferred location.
+      val (nxt_replica, nxt_part) =
+        partitionLocs.partsWithLocs(rnd.nextInt(partitionLocs.partsWithLocs.length))
+      val pgroup = new PartitionGroup(Some(nxt_replica))
+      groupArr += pgroup
+      groupHash.getOrElseUpdate(nxt_replica, ArrayBuffer()) += pgroup
+      addPartToPGroup(nxt_part, pgroup)
+      numCreated += 1
+    }
+  }
+
+  /**
+   * Takes a parent RDD partition and decides which of the partition groups to put it in Takes
+   * locality into account, but also uses power of 2 choices to load balance It strikes a balance
+   * between the two using the balanceSlack variable
+   * @param p
+   *   partition (ball to be thrown)
+   * @param balanceSlack
+   *   determines the trade-off between load-balancing the partitions sizes and their locality.
+   *   e.g., balanceSlack=0.10 means that it allows up to 10% imbalance in favor of locality
+   * @return
+   *   partition group (bin to be put in)
+   */
+  def pickBin(p: Partition, prev: RDD[_], balanceSlack: Double): PartitionGroup = {
+    val slack = (balanceSlack * prev.partitions.length).toInt
+    // least loaded pref locs
+    val pref = currPrefLocs(p, prev).flatMap(getLeastGroupHash)
+    val prefPart = if (pref.isEmpty) None else Some(pref.min)
+    val r1 = rnd.nextInt(groupArr.size)
+    val r2 = rnd.nextInt(groupArr.size)
+    val minPowerOfTwo = {
+      if (groupArr(r1).numPartitions < groupArr(r2).numPartitions) {
+        groupArr(r1)
+      } else {
+        groupArr(r2)
+      }
+    }
+    if (prefPart.isEmpty) {
+      // if no preferred locations, just use basic power of two
+      return minPowerOfTwo
+    }
+
+    val prefPartActual = prefPart.get
+
+    // more imbalance than the slack allows
+    if (minPowerOfTwo.numPartitions + slack <= prefPartActual.numPartitions) {
+      minPowerOfTwo // prefer balance over locality
+    } else {
+      prefPartActual // prefer locality over balance
+    }
+  }
+
+  def throwBalls(
+      maxPartitions: Int,
+      prev: RDD[_],
+      balanceSlack: Double,
+      partitionLocs: PartitionLocations): Unit = {
+    if (noLocality) { // no preferredLocations in parent RDD, no randomization needed
+      if (maxPartitions > groupArr.size) { // just return prev.partitions
+        for ((p, i) <- prev.partitions.zipWithIndex) {
+          groupArr(i).partitions += p
+        }
+      } else { // no locality available, then simply split partitions based on positions in array
+        for (i <- 0 until maxPartitions) {
+          val rangeStart = ((i.toLong * prev.partitions.length) / maxPartitions).toInt
+          val rangeEnd = (((i.toLong + 1) * prev.partitions.length) / maxPartitions).toInt
+          (rangeStart until rangeEnd).foreach { j =>
+            groupArr(i).partitions += prev.partitions(j)
+          }
+        }
+      }
+    } else {
+      // It is possible to have unionRDD where one rdd has preferred locations and another rdd
+      // that doesn't. To make sure we end up with the requested number of partitions,
+      // make sure to put a partition in every group.
+
+      // if we don't have a partition assigned to every group first try to fill them
+      // with the partitions with preferred locations
+      val partIter = partitionLocs.partsWithLocs.iterator
+      groupArr.filter(pg => pg.numPartitions == 0).foreach { pg =>
+        while (partIter.hasNext && pg.numPartitions == 0) {
+          var (_, nxt_part) = partIter.next()
+          if (!initialHash.contains(nxt_part)) {
+            pg.partitions += nxt_part
+            initialHash += nxt_part
+          }
+        }
+      }
+
+      // if we didn't get one partitions per group from partitions with preferred locations
+      // use partitions without preferred locations
+      val partNoLocIter = partitionLocs.partsWithoutLocs.iterator
+      groupArr.filter(pg => pg.numPartitions == 0).foreach { pg =>
+        while (partNoLocIter.hasNext && pg.numPartitions == 0) {
+          val nxt_part = partNoLocIter.next()
+          if (!initialHash.contains(nxt_part)) {
+            pg.partitions += nxt_part
+            initialHash += nxt_part
+          }
+        }
+      }
+
+      // finally pick bin for the rest
+      for (p <- prev.partitions
+        if (!initialHash.contains(p))) { // throw every partition into group
+        pickBin(p, prev, balanceSlack).partitions += p
+      }
+    }
+  }
+
+  def getPartitions: Array[PartitionGroup] = groupArr.filter(pg => pg.numPartitions > 0).toArray
+
+  /**
+   * Runs the packing algorithm and returns an array of PartitionGroups that if possible are load
+   * balanced and grouped by locality
+   *
+   * @return
+   *   array of partition groups
+   */
+  def coalesce(maxPartitions: Int, prev: RDD[_]): Array[PartitionGroup] = {
+    val partitionLocs = new PartitionLocations(prev)
+    // setup the groups (bins)
+    setupGroups(math.min(prev.partitions.length, maxPartitions), partitionLocs)
+    // assign partitions (balls) to each group (bins)
+    throwBalls(maxPartitions, prev, balanceSlack, partitionLocs)
+    getPartitions
+  }
+}

--- a/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeCoalesceBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeCoalesceBase.scala
@@ -21,7 +21,7 @@ import scala.collection.mutable.ArrayBuffer
 
 import org.apache.spark.Partition
 import org.apache.spark.rdd.{CoalescedRDDPartition, PartitionCoalescer, PartitionGroup, RDD}
-import org.apache.spark.sql.auron.{CoalesceNativeRDD, EmptyNativeRDD, NativeHelper, NativeRDD, NativeSupports}
+import org.apache.spark.sql.auron.{CoalesceNativeRDD, NativeHelper, NativeRDD, NativeSupports}
 import org.apache.spark.sql.execution.{SparkPlan, UnaryExecNode}
 import org.apache.spark.sql.execution.auron.plan.NativeCoalesceBase.getNativeCoalesceBuilder
 
@@ -47,8 +47,22 @@ abstract class NativeCoalesceBase(numPartitions: Int, override val child: SparkP
         CoalescedRDDPartition(i, inputRDD, ids, pg.prefLoc)
       }
     }
-    if (numPartitions == 1 && inputRDD.getNumPartitions < 1) {
-      new EmptyNativeRDD(sparkContext)
+    if (inputRDD.getNumPartitions < 1) {
+      // Spark's CoalesceExec always returns at least numPartitions partitions even
+      // when the input is empty, so that emptyDataFrame.coalesce(1) yields 1 partition.
+      val emptyPartitions: Array[Partition] = (0 until numPartitions).map { i =>
+        CoalescedRDDPartition(i, inputRDD, Array.empty, None)
+      }.toArray
+      new CoalesceNativeRDD(
+        sparkContext,
+        Seq(new org.apache.spark.OneToOneDependency(inputRDD)),
+        emptyPartitions,
+        (_, _) =>
+          PhysicalPlanNode
+            .newBuilder()
+            .setCoalesce(nativeCoalesce.toBuilder.build())
+            .build(),
+        nodeName)
     } else {
       new CoalesceNativeRDD(
         sparkContext,


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2090

# Rationale for this change
Convert CoalesceExec to native.

# What changes are included in this PR?
Identify the CoalesceExec scenario and convert it to native execution.

# Are there any user-facing changes?
Nothing.

# How was this patch tested?
UT