### PR TITLE
[AURON #1860] Convert logical operators to Native operators

### DIFF
--- a/auron-flink-extension/auron-flink-planner/src/main/java/org/apache/auron/flink/table/planner/converter/RexCallConverter.java
+++ b/auron-flink-extension/auron-flink-planner/src/main/java/org/apache/auron/flink/table/planner/converter/RexCallConverter.java
@@ -17,14 +17,17 @@
 package org.apache.auron.flink.table.planner.converter;
 
 import java.util.EnumSet;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import org.apache.auron.protobuf.PhysicalBinaryExprNode;
+import org.apache.auron.protobuf.PhysicalCaseNode;
 import org.apache.auron.protobuf.PhysicalExprNode;
 import org.apache.auron.protobuf.PhysicalIsNotNull;
 import org.apache.auron.protobuf.PhysicalIsNull;
 import org.apache.auron.protobuf.PhysicalNegativeNode;
 import org.apache.auron.protobuf.PhysicalNot;
+import org.apache.auron.protobuf.PhysicalWhenThen;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexNode;
@@ -44,6 +47,10 @@ import org.apache.calcite.sql.type.SqlTypeUtil;
  * left-deep over Calcite's n-ary operands into binary nodes), {@code NOT},
  * {@code IS NULL}, and {@code IS NOT NULL}. Logical operands are already
  * boolean and are not cast.
+ *
+ * <p>{@code CASE WHEN} (searched form) becomes a {@link PhysicalCaseNode} with
+ * one {@link PhysicalWhenThen} per branch and a trailing else; each then/else
+ * result is cast to the call's result type so all branches share one type.
  */
 public class RexCallConverter implements FlinkRexNodeConverter {
 
@@ -65,7 +72,8 @@ public class RexCallConverter implements FlinkRexNodeConverter {
             SqlKind.OR,
             SqlKind.NOT,
             SqlKind.IS_NULL,
-            SqlKind.IS_NOT_NULL);
+            SqlKind.IS_NOT_NULL,
+            SqlKind.CASE);
 
     private final FlinkNodeConverterFactory factory;
 
@@ -119,6 +127,7 @@ public class RexCallConverter implements FlinkRexNodeConverter {
      *   <li>{@code NOT} → {@link PhysicalNot}
      *   <li>{@code IS NULL} → {@link PhysicalIsNull}
      *   <li>{@code IS NOT NULL} → {@link PhysicalIsNotNull}
+     *   <li>{@code CASE} → {@link PhysicalCaseNode}
      * </ul>
      *
      * @throws IllegalArgumentException if the SqlKind is not supported
@@ -154,6 +163,8 @@ public class RexCallConverter implements FlinkRexNodeConverter {
                 return buildIsNull(call, context);
             case IS_NOT_NULL:
                 return buildIsNotNull(call, context);
+            case CASE:
+                return buildCase(call, context);
             default:
                 throw new IllegalArgumentException("Unsupported SqlKind: " + kind);
         }
@@ -261,5 +272,32 @@ public class RexCallConverter implements FlinkRexNodeConverter {
         return PhysicalExprNode.newBuilder()
                 .setIsNotNullExpr(PhysicalIsNotNull.newBuilder().setExpr(operand))
                 .build();
+    }
+
+    /**
+     * Builds a searched {@code CASE} from Calcite's interleaved operands
+     * {@code [when1, then1, ..., whenN, thenN, else]} (odd count, trailing
+     * else). Each then and the else are cast to the call's result type so the
+     * native {@code CaseExpr} receives uniformly-typed branches. The
+     * simple-CASE {@code expr} field is left unset.
+     */
+    private PhysicalExprNode buildCase(RexCall call, ConverterContext context) {
+        RelDataType resultType = call.getType();
+        List<RexNode> operands = call.getOperands();
+        PhysicalCaseNode.Builder caseNode = PhysicalCaseNode.newBuilder();
+        int i = 0;
+        for (; i + 1 < operands.size(); i += 2) {
+            RexNode when = operands.get(i);
+            RexNode then = operands.get(i + 1);
+            PhysicalExprNode whenExpr = convertOperand(when, context);
+            PhysicalExprNode thenExpr =
+                    FlinkNodeConverterUtils.castIfNecessary(convertOperand(then, context), then.getType(), resultType);
+            caseNode.addWhenThenExpr(
+                    PhysicalWhenThen.newBuilder().setWhenExpr(whenExpr).setThenExpr(thenExpr));
+        }
+        RexNode elseOperand = operands.get(i);
+        caseNode.setElseExpr(FlinkNodeConverterUtils.castIfNecessary(
+                convertOperand(elseOperand, context), elseOperand.getType(), resultType));
+        return PhysicalExprNode.newBuilder().setCase(caseNode).build();
     }
 }

--- a/auron-flink-extension/auron-flink-planner/src/main/java/org/apache/auron/flink/table/planner/converter/RexCallConverter.java
+++ b/auron-flink-extension/auron-flink-planner/src/main/java/org/apache/auron/flink/table/planner/converter/RexCallConverter.java
@@ -21,7 +21,10 @@ import java.util.Optional;
 import java.util.Set;
 import org.apache.auron.protobuf.PhysicalBinaryExprNode;
 import org.apache.auron.protobuf.PhysicalExprNode;
+import org.apache.auron.protobuf.PhysicalIsNotNull;
+import org.apache.auron.protobuf.PhysicalIsNull;
 import org.apache.auron.protobuf.PhysicalNegativeNode;
+import org.apache.auron.protobuf.PhysicalNot;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexNode;
@@ -36,6 +39,11 @@ import org.apache.calcite.sql.type.SqlTypeUtil;
  * {@code %}), unary minus/plus, and {@code CAST}. Binary arithmetic operands
  * are promoted to a common type before conversion, and the result is cast to
  * the output type if it differs from the common type.
+ *
+ * <p>Also handles logical operators: {@code AND} and {@code OR} (folded
+ * left-deep over Calcite's n-ary operands into binary nodes), {@code NOT},
+ * {@code IS NULL}, and {@code IS NOT NULL}. Logical operands are already
+ * boolean and are not cast.
  */
 public class RexCallConverter implements FlinkRexNodeConverter {
 
@@ -52,7 +60,12 @@ public class RexCallConverter implements FlinkRexNodeConverter {
             SqlKind.MOD,
             SqlKind.MINUS_PREFIX,
             SqlKind.PLUS_PREFIX,
-            SqlKind.CAST);
+            SqlKind.CAST,
+            SqlKind.AND,
+            SqlKind.OR,
+            SqlKind.NOT,
+            SqlKind.IS_NULL,
+            SqlKind.IS_NOT_NULL);
 
     private final FlinkNodeConverterFactory factory;
 
@@ -101,6 +114,11 @@ public class RexCallConverter implements FlinkRexNodeConverter {
      *   <li>{@code MINUS_PREFIX} → {@link PhysicalNegativeNode}
      *   <li>{@code PLUS_PREFIX} → identity (passthrough to operand)
      *   <li>{@code CAST} → {@link org.apache.auron.protobuf.PhysicalTryCastNode}
+     *   <li>{@code AND}/{@code OR} → {@link PhysicalBinaryExprNode} folded
+     *       left-deep over the n-ary operands
+     *   <li>{@code NOT} → {@link PhysicalNot}
+     *   <li>{@code IS NULL} → {@link PhysicalIsNull}
+     *   <li>{@code IS NOT NULL} → {@link PhysicalIsNotNull}
      * </ul>
      *
      * @throws IllegalArgumentException if the SqlKind is not supported
@@ -126,6 +144,16 @@ public class RexCallConverter implements FlinkRexNodeConverter {
                 return convertOperand(call.getOperands().get(0), context);
             case CAST:
                 return buildTryCast(call, context);
+            case AND:
+                return buildBinaryFold(call, "And", context);
+            case OR:
+                return buildBinaryFold(call, "Or", context);
+            case NOT:
+                return buildNot(call, context);
+            case IS_NULL:
+                return buildIsNull(call, context);
+            case IS_NOT_NULL:
+                return buildIsNotNull(call, context);
             default:
                 throw new IllegalArgumentException("Unsupported SqlKind: " + kind);
         }
@@ -193,5 +221,45 @@ public class RexCallConverter implements FlinkRexNodeConverter {
     private PhysicalExprNode buildTryCast(RexCall call, ConverterContext context) {
         PhysicalExprNode operand = convertOperand(call.getOperands().get(0), context);
         return FlinkNodeConverterUtils.wrapInTryCast(operand, call.getType());
+    }
+
+    /**
+     * Folds a Calcite n-ary {@code AND}/{@code OR} (operand count &ge; 2) into a
+     * left-deep chain of binary nodes: {@code ((o0 op o1) op o2) ...}. Operands
+     * are already boolean and are not cast.
+     */
+    private PhysicalExprNode buildBinaryFold(RexCall call, String op, ConverterContext context) {
+        PhysicalExprNode acc = convertOperand(call.getOperands().get(0), context);
+        for (int i = 1; i < call.getOperands().size(); i++) {
+            PhysicalExprNode right = convertOperand(call.getOperands().get(i), context);
+            acc = PhysicalExprNode.newBuilder()
+                    .setBinaryExpr(PhysicalBinaryExprNode.newBuilder()
+                            .setL(acc)
+                            .setR(right)
+                            .setOp(op))
+                    .build();
+        }
+        return acc;
+    }
+
+    private PhysicalExprNode buildNot(RexCall call, ConverterContext context) {
+        PhysicalExprNode operand = convertOperand(call.getOperands().get(0), context);
+        return PhysicalExprNode.newBuilder()
+                .setNotExpr(PhysicalNot.newBuilder().setExpr(operand))
+                .build();
+    }
+
+    private PhysicalExprNode buildIsNull(RexCall call, ConverterContext context) {
+        PhysicalExprNode operand = convertOperand(call.getOperands().get(0), context);
+        return PhysicalExprNode.newBuilder()
+                .setIsNullExpr(PhysicalIsNull.newBuilder().setExpr(operand))
+                .build();
+    }
+
+    private PhysicalExprNode buildIsNotNull(RexCall call, ConverterContext context) {
+        PhysicalExprNode operand = convertOperand(call.getOperands().get(0), context);
+        return PhysicalExprNode.newBuilder()
+                .setIsNotNullExpr(PhysicalIsNotNull.newBuilder().setExpr(operand))
+                .build();
     }
 }

--- a/auron-flink-extension/auron-flink-planner/src/test/java/org/apache/auron/flink/table/planner/converter/RexCallConverterTest.java
+++ b/auron-flink-extension/auron-flink-planner/src/test/java/org/apache/auron/flink/table/planner/converter/RexCallConverterTest.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.math.BigDecimal;
 import java.util.Arrays;
 import org.apache.auron.protobuf.PhysicalExprNode;
+import org.apache.auron.protobuf.PhysicalWhenThen;
 import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
@@ -284,6 +285,60 @@ class RexCallConverterTest {
 
         assertTrue(result.hasIsNotNullExpr());
         assertTrue(result.getIsNotNullExpr().getExpr().hasColumn());
+    }
+
+    @Test
+    void testConvertCaseNoCast() {
+        // CASE WHEN f2 THEN f0 ELSE f0 END — all branches INT, result INT → no cast
+        RexNode caseExpr = makeCall(intType(), SqlStdOperatorTable.CASE, makeBoolRef(2), makeIntRef(0), makeIntRef(0));
+
+        PhysicalExprNode result = converter.convert(caseExpr, context);
+
+        assertTrue(result.hasCase());
+        assertEquals(1, result.getCase().getWhenThenExprCount());
+        // Searched CASE leaves the simple-CASE expr unset.
+        assertFalse(result.getCase().hasExpr());
+        PhysicalWhenThen whenThen = result.getCase().getWhenThenExpr(0);
+        assertTrue(whenThen.getWhenExpr().hasColumn());
+        // then is plain column (INT == result INT), not cast-wrapped.
+        assertTrue(whenThen.getThenExpr().hasColumn());
+        assertFalse(whenThen.getThenExpr().hasTryCast());
+        assertTrue(result.getCase().hasElseExpr());
+        assertTrue(result.getCase().getElseExpr().hasColumn());
+        assertFalse(result.getCase().getElseExpr().hasTryCast());
+    }
+
+    @Test
+    void testConvertCaseWithBranchCast() {
+        // CASE WHEN f2 THEN f0(INT) ELSE f0(INT) END with result BIGINT → branches cast to BIGINT
+        RexNode caseExpr =
+                makeCall(bigintType(), SqlStdOperatorTable.CASE, makeBoolRef(2), makeIntRef(0), makeIntRef(0));
+
+        PhysicalExprNode result = converter.convert(caseExpr, context);
+
+        assertTrue(result.hasCase());
+        PhysicalWhenThen whenThen = result.getCase().getWhenThenExpr(0);
+        assertTrue(whenThen.getThenExpr().hasTryCast(), "then INT should be cast to result BIGINT");
+        assertTrue(result.getCase().getElseExpr().hasTryCast(), "else INT should be cast to result BIGINT");
+    }
+
+    @Test
+    void testConvertCaseMultipleBranches() {
+        // CASE WHEN f2 THEN f0 WHEN f3 THEN f0 ELSE f0 END → two when/then branches
+        RexNode caseExpr = makeCall(
+                intType(),
+                SqlStdOperatorTable.CASE,
+                makeBoolRef(2),
+                makeIntRef(0),
+                makeBoolRef(3),
+                makeIntRef(0),
+                makeIntRef(0));
+
+        PhysicalExprNode result = converter.convert(caseExpr, context);
+
+        assertTrue(result.hasCase());
+        assertEquals(2, result.getCase().getWhenThenExprCount());
+        assertTrue(result.getCase().hasElseExpr());
     }
 
     // ---- Helpers ----

--- a/auron-flink-extension/auron-flink-planner/src/test/java/org/apache/auron/flink/table/planner/converter/RexCallConverterTest.java
+++ b/auron-flink-extension/auron-flink-planner/src/test/java/org/apache/auron/flink/table/planner/converter/RexCallConverterTest.java
@@ -33,6 +33,7 @@ import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.BooleanType;
 import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
@@ -57,7 +58,11 @@ class RexCallConverterTest {
         factory.registerRexConverter(new RexLiteralConverter());
         factory.registerRexConverter(converter);
 
-        RowType inputType = RowType.of(new LogicalType[] {new IntType(), new BigIntType()}, new String[] {"f0", "f1"});
+        RowType inputType = RowType.of(
+                new LogicalType[] {
+                    new IntType(), new BigIntType(), new BooleanType(), new BooleanType(), new BooleanType()
+                },
+                new String[] {"f0", "f1", "f2", "f3", "f4"});
         context = new ConverterContext(new Configuration(), null, getClass().getClassLoader(), inputType);
     }
 
@@ -213,10 +218,82 @@ class RexCallConverterTest {
         assertFalse(converter.isSupported(eq, context));
     }
 
+    @Test
+    void testConvertAndTwoOperands() {
+        RexNode and = makeCall(booleanType(), SqlStdOperatorTable.AND, makeBoolRef(2), makeBoolRef(3));
+
+        PhysicalExprNode result = converter.convert(and, context);
+
+        assertTrue(result.hasBinaryExpr());
+        assertEquals("And", result.getBinaryExpr().getOp());
+        assertTrue(result.getBinaryExpr().getL().hasColumn());
+        assertTrue(result.getBinaryExpr().getR().hasColumn());
+    }
+
+    @Test
+    void testConvertAndThreeOperands() {
+        // AND(f2, f3, f4) folds left-deep to ((f2 AND f3) AND f4)
+        RexNode and = makeCall(booleanType(), SqlStdOperatorTable.AND, makeBoolRef(2), makeBoolRef(3), makeBoolRef(4));
+
+        PhysicalExprNode result = converter.convert(and, context);
+
+        assertTrue(result.hasBinaryExpr());
+        assertEquals("And", result.getBinaryExpr().getOp());
+        // Left child is the inner (f2 AND f3); right child is f4
+        PhysicalExprNode left = result.getBinaryExpr().getL();
+        assertTrue(left.hasBinaryExpr());
+        assertEquals("And", left.getBinaryExpr().getOp());
+        assertTrue(result.getBinaryExpr().getR().hasColumn());
+    }
+
+    @Test
+    void testConvertOr() {
+        RexNode or = makeCall(booleanType(), SqlStdOperatorTable.OR, makeBoolRef(2), makeBoolRef(3));
+
+        PhysicalExprNode result = converter.convert(or, context);
+
+        assertTrue(result.hasBinaryExpr());
+        assertEquals("Or", result.getBinaryExpr().getOp());
+    }
+
+    @Test
+    void testConvertNot() {
+        RexNode not = makeCall(booleanType(), SqlStdOperatorTable.NOT, makeBoolRef(2));
+
+        PhysicalExprNode result = converter.convert(not, context);
+
+        assertTrue(result.hasNotExpr());
+        assertTrue(result.getNotExpr().getExpr().hasColumn());
+    }
+
+    @Test
+    void testConvertIsNull() {
+        RexNode isNull = makeCall(booleanType(), SqlStdOperatorTable.IS_NULL, makeIntRef(0));
+
+        PhysicalExprNode result = converter.convert(isNull, context);
+
+        assertTrue(result.hasIsNullExpr());
+        assertTrue(result.getIsNullExpr().getExpr().hasColumn());
+    }
+
+    @Test
+    void testConvertIsNotNull() {
+        RexNode isNotNull = makeCall(booleanType(), SqlStdOperatorTable.IS_NOT_NULL, makeIntRef(0));
+
+        PhysicalExprNode result = converter.convert(isNotNull, context);
+
+        assertTrue(result.hasIsNotNullExpr());
+        assertTrue(result.getIsNotNullExpr().getExpr().hasColumn());
+    }
+
     // ---- Helpers ----
 
     private static RexNode makeIntRef(int index) {
         return REX_BUILDER.makeInputRef(intType(), index);
+    }
+
+    private static RexNode makeBoolRef(int index) {
+        return REX_BUILDER.makeInputRef(booleanType(), index);
     }
 
     private static RelDataType intType() {
@@ -225,6 +302,10 @@ class RexCallConverterTest {
 
     private static RelDataType bigintType() {
         return TYPE_FACTORY.createSqlType(SqlTypeName.BIGINT);
+    }
+
+    private static RelDataType booleanType() {
+        return TYPE_FACTORY.createSqlType(SqlTypeName.BOOLEAN);
     }
 
     /**

--- a/auron-flink-extension/auron-flink-planner/src/test/java/org/apache/auron/flink/table/runtime/AuronCalcRewriteITCase.java
+++ b/auron-flink-extension/auron-flink-planner/src/test/java/org/apache/auron/flink/table/runtime/AuronCalcRewriteITCase.java
@@ -80,4 +80,47 @@ public class AuronCalcRewriteITCase extends AuronFlinkTableTestBase {
         rows.sort(Comparator.comparingInt(o -> (int) o.getField(0)));
         assertThat(rows).isEqualTo(Arrays.asList(Row.of(2), Row.of(2), Row.of(3), Row.of(3), Row.of(9), Row.of(9)));
     }
+
+    /** Projects {@code IS NULL} and {@code IS NOT NULL} over a nullable column that contains no
+     * null values in the test data, so every row yields {@code (false, true)}. */
+    @Test
+    public void testIsNullAndIsNotNullProjection() {
+        List<Row> rows = CollectionUtil.iteratorToList(tableEnvironment
+                .executeSql("select `int` IS NULL, `int` IS NOT NULL from T1")
+                .collect());
+        assertThat(rows).isEqualTo(Arrays.asList(Row.of(false, true), Row.of(false, true), Row.of(false, true)));
+    }
+
+    /** Combines {@code IS NULL}/{@code IS NOT NULL} predicates through {@code AND} and {@code OR}.
+     * With no nulls present both combined conditions are constant, so every row yields
+     * {@code (true, true)}. */
+    @Test
+    public void testAndOrBooleanCombination() {
+        List<Row> rows = CollectionUtil.iteratorToList(tableEnvironment
+                .executeSql("select (`int` IS NOT NULL) AND (`name` IS NOT NULL), "
+                        + "(`int` IS NULL) OR (`name` IS NOT NULL) from T1")
+                .collect());
+        assertThat(rows).isEqualTo(Arrays.asList(Row.of(true, true), Row.of(true, true), Row.of(true, true)));
+    }
+
+    /** Negates an {@code IS NULL} predicate with {@code NOT}. With no nulls present the predicate
+     * is constant, so every row yields {@code true}. */
+    @Test
+    public void testNotProjection() {
+        List<Row> rows = CollectionUtil.iteratorToList(tableEnvironment
+                .executeSql("select NOT (`int` IS NULL) from T1")
+                .collect());
+        assertThat(rows).isEqualTo(Arrays.asList(Row.of(true), Row.of(true), Row.of(true)));
+    }
+
+    /** A {@code CASE WHEN} whose guard holds for every row (the column has no null values) while
+     * the arithmetic {@code THEN} branch varies the output: {@code int + 1} yields 2, 3, 3. */
+    @Test
+    public void testCaseWhenWithArithmeticBranch() {
+        List<Row> rows = CollectionUtil.iteratorToList(tableEnvironment
+                .executeSql("select CASE WHEN `int` IS NOT NULL THEN `int` + 1 ELSE 0 END from T1")
+                .collect());
+        rows.sort(Comparator.comparingInt(o -> (int) o.getField(0)));
+        assertThat(rows).isEqualTo(Arrays.asList(Row.of(2), Row.of(3), Row.of(3)));
+    }
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1860

# Rationale for this change

The Flink Calc pipeline rewrites Flink's `StreamExecCalc` into a native plan by converting each Calcite `RexNode` to an Auron `PhysicalExprNode` via the `FlinkNodeConverterFactory` framework. Until now only math operators converted; a `Calc` containing a logical or conditional expression (`AND`, `OR`, `NOT`, `IS NULL`, `IS NOT NULL`, `CASE WHEN`) failed conversion and fell back to Flink's CodeGen Calc. This PR adds those converters so such Calcs run natively. Flink `IF(c, a, b)` is planned as `CASE`, so it is covered as well.

This follows the established math-operator converter pattern and is a clean Wave-1 converter change: no native-engine change, no protobuf change, no new dependency.

# What changes are included in this PR?

Extends `RexCallConverter` (the framework's single `RexCall` converter) with the logical `SqlKind`s and one helper per operator:

- `AND` / `OR` → binary `PhysicalBinaryExprNode` with op `"And"` / `"Or"`. Calcite flattens `a AND b AND c` into one n-ary `RexCall`, so operands are folded left-deep into nested binaries.
- `NOT` → `PhysicalNot`; `IS NULL` → `PhysicalIsNull`; `IS NOT NULL` → `PhysicalIsNotNull` (single-child wrappers).
- `CASE WHEN` → `PhysicalCaseNode` with `PhysicalWhenThen` branches. Each `then` branch and the `else` are cast to the CASE result type, because the native `CaseExpr` does not cast its branches and DataFusion requires a consistent branch type.

Two commits: the boolean operators first, then `CASE WHEN` on its own.

# Are there any user-facing changes?

No API changes. More Flink SQL `Calc` expressions now execute natively instead of falling back to Flink's CodeGen path; behavior is unchanged, and any unsupported expression still falls back transparently.

# How was this patch tested?

New unit tests in `RexCallConverterTest` cover each operator: AND (2-operand and 3-operand left-deep fold), OR, NOT, IS NULL, IS NOT NULL, and CASE WHEN (branches matching the result type with no cast, branches needing a cast, and multiple branches). Full `auron-flink-planner` module suite passes (81 tests, including the `StreamExecCalc` and Kafka-source integration tests that exercise the Calc path) with 0 Checkstyle violations.
