### PR TITLE
[AURON #1861] Convert comparison operators and LIKE to native operators

### DIFF
--- a/auron-flink-extension/auron-flink-planner/src/main/java/org/apache/auron/flink/table/planner/converter/RexCallConverter.java
+++ b/auron-flink-extension/auron-flink-planner/src/main/java/org/apache/auron/flink/table/planner/converter/RexCallConverter.java
@@ -39,9 +39,11 @@ import org.apache.calcite.sql.type.SqlTypeUtil;
  * {@link PhysicalExprNode}.
  *
  * <p>Handles arithmetic operators ({@code +}, {@code -}, {@code *}, {@code /},
- * {@code %}), unary minus/plus, and {@code CAST}. Binary arithmetic operands
- * are promoted to a common type before conversion, and the result is cast to
- * the output type if it differs from the common type.
+ * {@code %}), comparison operators ({@code =}, {@code <>}, {@code >}, {@code <},
+ * {@code >=}, {@code <=}), unary minus/plus, and {@code CAST}. Binary arithmetic
+ * and comparison operands are promoted to a common type before conversion;
+ * arithmetic additionally casts the result to the output type if it differs from
+ * the common type, while a comparison result is already BOOLEAN and needs no cast.
  *
  * <p>Also handles logical operators: {@code AND} and {@code OR} (folded
  * left-deep over Calcite's n-ary operands into binary nodes), {@code NOT},
@@ -73,7 +75,13 @@ public class RexCallConverter implements FlinkRexNodeConverter {
             SqlKind.NOT,
             SqlKind.IS_NULL,
             SqlKind.IS_NOT_NULL,
-            SqlKind.CASE);
+            SqlKind.CASE,
+            SqlKind.EQUALS,
+            SqlKind.NOT_EQUALS,
+            SqlKind.GREATER_THAN,
+            SqlKind.LESS_THAN,
+            SqlKind.GREATER_THAN_OR_EQUAL,
+            SqlKind.LESS_THAN_OR_EQUAL);
 
     private final FlinkNodeConverterFactory factory;
 
@@ -118,7 +126,10 @@ public class RexCallConverter implements FlinkRexNodeConverter {
      * <p>Dispatches by {@link SqlKind}:
      * <ul>
      *   <li>Binary arithmetic → {@link PhysicalBinaryExprNode} with type
-     *       promotion
+     *       promotion and an output cast when the result type differs
+     *   <li>Comparison ({@code =}, {@code <>}, {@code >}, {@code <}, {@code >=},
+     *       {@code <=}) → {@link PhysicalBinaryExprNode} with type promotion and
+     *       no output cast (the result is already BOOLEAN)
      *   <li>{@code MINUS_PREFIX} → {@link PhysicalNegativeNode}
      *   <li>{@code PLUS_PREFIX} → identity (passthrough to operand)
      *   <li>{@code CAST} → {@link org.apache.auron.protobuf.PhysicalTryCastNode}
@@ -147,6 +158,18 @@ public class RexCallConverter implements FlinkRexNodeConverter {
                 return buildBinaryExpr(call, "Divide", context);
             case MOD:
                 return buildBinaryExpr(call, "Modulo", context);
+            case EQUALS:
+                return buildComparison(call, "Eq", context);
+            case NOT_EQUALS:
+                return buildComparison(call, "NotEq", context);
+            case GREATER_THAN:
+                return buildComparison(call, "Gt", context);
+            case LESS_THAN:
+                return buildComparison(call, "Lt", context);
+            case GREATER_THAN_OR_EQUAL:
+                return buildComparison(call, "GtEq", context);
+            case LESS_THAN_OR_EQUAL:
+                return buildComparison(call, "LtEq", context);
             case MINUS_PREFIX:
                 return buildNegative(call, context);
             case PLUS_PREFIX:
@@ -206,6 +229,39 @@ public class RexCallConverter implements FlinkRexNodeConverter {
             return FlinkNodeConverterUtils.wrapInTryCast(binaryExpr, outputType);
         }
         return binaryExpr;
+    }
+
+    /**
+     * Builds a comparison expression with type promotion between operands.
+     *
+     * <p>Operands are promoted to a common type so the native comparison kernel
+     * sees matching operand types. The result is already BOOLEAN, so it is
+     * returned without an output cast.
+     */
+    private PhysicalExprNode buildComparison(RexCall call, String op, ConverterContext context) {
+        RexNode left = call.getOperands().get(0);
+        RexNode right = call.getOperands().get(1);
+
+        RelDataType compatibleType = FlinkNodeConverterUtils.getCommonTypeForComparison(
+                left.getType(), right.getType(), FlinkNodeConverterUtils.TYPE_FACTORY);
+        if (compatibleType == null) {
+            throw new IllegalStateException("Incompatible types: "
+                    + left.getType().getSqlTypeName()
+                    + " and "
+                    + right.getType().getSqlTypeName());
+        }
+
+        PhysicalExprNode leftExpr =
+                FlinkNodeConverterUtils.castIfNecessary(convertOperand(left, context), left.getType(), compatibleType);
+        PhysicalExprNode rightExpr = FlinkNodeConverterUtils.castIfNecessary(
+                convertOperand(right, context), right.getType(), compatibleType);
+
+        return PhysicalExprNode.newBuilder()
+                .setBinaryExpr(PhysicalBinaryExprNode.newBuilder()
+                        .setL(leftExpr)
+                        .setR(rightExpr)
+                        .setOp(op))
+                .build();
     }
 
     /**

--- a/auron-flink-extension/auron-flink-planner/src/main/java/org/apache/auron/flink/table/planner/converter/RexCallConverter.java
+++ b/auron-flink-extension/auron-flink-planner/src/main/java/org/apache/auron/flink/table/planner/converter/RexCallConverter.java
@@ -25,6 +25,7 @@ import org.apache.auron.protobuf.PhysicalCaseNode;
 import org.apache.auron.protobuf.PhysicalExprNode;
 import org.apache.auron.protobuf.PhysicalIsNotNull;
 import org.apache.auron.protobuf.PhysicalIsNull;
+import org.apache.auron.protobuf.PhysicalLikeExprNode;
 import org.apache.auron.protobuf.PhysicalNegativeNode;
 import org.apache.auron.protobuf.PhysicalNot;
 import org.apache.auron.protobuf.PhysicalWhenThen;
@@ -32,6 +33,7 @@ import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.fun.SqlLikeOperator;
 import org.apache.calcite.sql.type.SqlTypeUtil;
 
 /**
@@ -40,10 +42,12 @@ import org.apache.calcite.sql.type.SqlTypeUtil;
  *
  * <p>Handles arithmetic operators ({@code +}, {@code -}, {@code *}, {@code /},
  * {@code %}), comparison operators ({@code =}, {@code <>}, {@code >}, {@code <},
- * {@code >=}, {@code <=}), unary minus/plus, and {@code CAST}. Binary arithmetic
- * and comparison operands are promoted to a common type before conversion;
- * arithmetic additionally casts the result to the output type if it differs from
- * the common type, while a comparison result is already BOOLEAN and needs no cast.
+ * {@code >=}, {@code <=}), {@code LIKE} / {@code NOT LIKE}, unary minus/plus, and
+ * {@code CAST}. Binary arithmetic and comparison operands are promoted to a common
+ * type before conversion; arithmetic additionally casts the result to the output
+ * type if it differs from the common type, while a comparison result is already
+ * BOOLEAN and needs no cast. {@code LIKE} maps to a dedicated like node; an
+ * explicit {@code ESCAPE} clause is unsupported and falls back.
  *
  * <p>Also handles logical operators: {@code AND} and {@code OR} (folded
  * left-deep over Calcite's n-ary operands into binary nodes), {@code NOT},
@@ -81,7 +85,8 @@ public class RexCallConverter implements FlinkRexNodeConverter {
             SqlKind.GREATER_THAN,
             SqlKind.LESS_THAN,
             SqlKind.GREATER_THAN_OR_EQUAL,
-            SqlKind.LESS_THAN_OR_EQUAL);
+            SqlKind.LESS_THAN_OR_EQUAL,
+            SqlKind.LIKE);
 
     private final FlinkNodeConverterFactory factory;
 
@@ -106,6 +111,10 @@ public class RexCallConverter implements FlinkRexNodeConverter {
      *
      * <p>For binary arithmetic kinds, the call's result type must also be
      * numeric to reject non-arithmetic uses (e.g., TIMESTAMP + INTERVAL).
+     *
+     * <p>{@code LIKE} is supported only in its two-operand form ({@code expr
+     * LIKE pattern}). A three-operand {@code LIKE} with an explicit
+     * {@code ESCAPE} clause has no native equivalent and falls back.
      */
     @Override
     public boolean isSupported(RexNode node, ConverterContext context) {
@@ -113,6 +122,10 @@ public class RexCallConverter implements FlinkRexNodeConverter {
         SqlKind kind = call.getKind();
         if (!SUPPORTED_KINDS.contains(kind)) {
             return false;
+        }
+        if (kind == SqlKind.LIKE) {
+            return call.getOperator() instanceof SqlLikeOperator
+                    && call.getOperands().size() == 2;
         }
         if (BINARY_ARITHMETIC_KINDS.contains(kind)) {
             return SqlTypeUtil.isNumeric(call.getType());
@@ -130,6 +143,9 @@ public class RexCallConverter implements FlinkRexNodeConverter {
      *   <li>Comparison ({@code =}, {@code <>}, {@code >}, {@code <}, {@code >=},
      *       {@code <=}) → {@link PhysicalBinaryExprNode} with type promotion and
      *       no output cast (the result is already BOOLEAN)
+     *   <li>{@code LIKE} → {@link PhysicalLikeExprNode} (case-sensitive, never
+     *       negated); {@code NOT LIKE} is {@code NOT(LIKE(...))} and converts via
+     *       the {@code NOT} case
      *   <li>{@code MINUS_PREFIX} → {@link PhysicalNegativeNode}
      *   <li>{@code PLUS_PREFIX} → identity (passthrough to operand)
      *   <li>{@code CAST} → {@link org.apache.auron.protobuf.PhysicalTryCastNode}
@@ -170,6 +186,8 @@ public class RexCallConverter implements FlinkRexNodeConverter {
                 return buildComparison(call, "GtEq", context);
             case LESS_THAN_OR_EQUAL:
                 return buildComparison(call, "LtEq", context);
+            case LIKE:
+                return buildLike(call, context);
             case MINUS_PREFIX:
                 return buildNegative(call, context);
             case PLUS_PREFIX:
@@ -261,6 +279,25 @@ public class RexCallConverter implements FlinkRexNodeConverter {
                         .setL(leftExpr)
                         .setR(rightExpr)
                         .setOp(op))
+                .build();
+    }
+
+    /**
+     * Builds a {@code LIKE} expression as a {@link PhysicalLikeExprNode}. Matching
+     * is case-sensitive (Flink SQL {@code LIKE} semantics). The node is never
+     * negated here: Calcite represents {@code NOT LIKE} as {@code NOT(LIKE(...))}
+     * (a negated like operator cannot form a {@link RexCall}), so a {@code LIKE}
+     * call always reaches this method un-negated.
+     */
+    private PhysicalExprNode buildLike(RexCall call, ConverterContext context) {
+        PhysicalExprNode expr = convertOperand(call.getOperands().get(0), context);
+        PhysicalExprNode pattern = convertOperand(call.getOperands().get(1), context);
+        return PhysicalExprNode.newBuilder()
+                .setLikeExpr(PhysicalLikeExprNode.newBuilder()
+                        .setNegated(false)
+                        .setCaseInsensitive(false)
+                        .setExpr(expr)
+                        .setPattern(pattern))
                 .build();
     }
 

--- a/auron-flink-extension/auron-flink-planner/src/test/java/org/apache/auron/flink/table/planner/converter/RexCallConverterTest.java
+++ b/auron-flink-extension/auron-flink-planner/src/test/java/org/apache/auron/flink/table/planner/converter/RexCallConverterTest.java
@@ -38,6 +38,7 @@ import org.apache.flink.table.types.logical.BooleanType;
 import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.VarCharType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -61,9 +62,15 @@ class RexCallConverterTest {
 
         RowType inputType = RowType.of(
                 new LogicalType[] {
-                    new IntType(), new BigIntType(), new BooleanType(), new BooleanType(), new BooleanType()
+                    new IntType(),
+                    new BigIntType(),
+                    new BooleanType(),
+                    new BooleanType(),
+                    new BooleanType(),
+                    new VarCharType(),
+                    new VarCharType()
                 },
-                new String[] {"f0", "f1", "f2", "f3", "f4"});
+                new String[] {"f0", "f1", "f2", "f3", "f4", "f5", "f6"});
         context = new ConverterContext(new Configuration(), null, getClass().getClassLoader(), inputType);
     }
 
@@ -389,6 +396,42 @@ class RexCallConverterTest {
         assertTrue(result.getCase().hasElseExpr());
     }
 
+    @Test
+    void testConvertLike() {
+        RexNode like = makeCall(boolType(), SqlStdOperatorTable.LIKE, strRef(5), strRef(6));
+
+        PhysicalExprNode result = converter.convert(like, context);
+
+        assertTrue(result.hasLikeExpr());
+        assertFalse(result.getLikeExpr().getNegated(), "Plain LIKE must not be negated");
+        assertFalse(result.getLikeExpr().getCaseInsensitive(), "LIKE is case-sensitive");
+        assertTrue(result.getLikeExpr().hasExpr(), "Expr operand must be present");
+        assertTrue(result.getLikeExpr().hasPattern(), "Pattern operand must be present");
+    }
+
+    @Test
+    void testNotLikeConvertsAsNotOfLike() {
+        // Calcite never builds a negated LIKE RexCall (RexCall.<init> rejects a negated
+        // SqlLikeOperator via validRexOperands). At the Rex layer x NOT LIKE y is
+        // NOT(x LIKE y), which converts to a NOT wrapping the un-negated like node.
+        RexNode like = makeCall(boolType(), SqlStdOperatorTable.LIKE, strRef(5), strRef(6));
+        RexNode notLike = REX_BUILDER.makeCall(SqlStdOperatorTable.NOT, like);
+
+        assertTrue(converter.isSupported(notLike, context));
+        PhysicalExprNode result = converter.convert(notLike, context);
+        assertTrue(result.hasNotExpr());
+        assertTrue(result.getNotExpr().getExpr().hasLikeExpr(), "NOT wraps the like node");
+        assertFalse(result.getNotExpr().getExpr().getLikeExpr().getNegated(), "Inner like node stays un-negated");
+    }
+
+    @Test
+    void testLikeWithExplicitEscapeIsUnsupported() {
+        // 3-operand LIKE (expr, pattern, ESCAPE) has no native escape field → falls back.
+        RexNode escapeLike = makeCall(boolType(), SqlStdOperatorTable.LIKE, strRef(5), strRef(6), strRef(5));
+
+        assertFalse(converter.isSupported(escapeLike, context));
+    }
+
     // ---- Helpers ----
 
     private void assertComparison(org.apache.calcite.sql.SqlOperator op, String expectedOp) {
@@ -424,6 +467,14 @@ class RexCallConverterTest {
 
     private static RelDataType booleanType() {
         return TYPE_FACTORY.createSqlType(SqlTypeName.BOOLEAN);
+    }
+
+    private static RexNode strRef(int index) {
+        return REX_BUILDER.makeInputRef(varcharType(), index);
+    }
+
+    private static RelDataType varcharType() {
+        return TYPE_FACTORY.createSqlType(SqlTypeName.VARCHAR);
     }
 
     /**

--- a/auron-flink-extension/auron-flink-planner/src/test/java/org/apache/auron/flink/table/planner/converter/RexCallConverterTest.java
+++ b/auron-flink-extension/auron-flink-planner/src/test/java/org/apache/auron/flink/table/planner/converter/RexCallConverterTest.java
@@ -213,10 +213,58 @@ class RexCallConverterTest {
 
     @Test
     void testIsNotSupportedNonNumericKind() {
-        // EQUALS is not in the supported set
-        RexNode eq = REX_BUILDER.makeCall(SqlStdOperatorTable.EQUALS, makeIntRef(0), makeIntRef(0));
+        // SIMILAR_TO is not in the supported set
+        RexNode similar = REX_BUILDER.makeCall(SqlStdOperatorTable.SIMILAR_TO, makeIntRef(0), makeIntRef(0));
 
-        assertFalse(converter.isSupported(eq, context));
+        assertFalse(converter.isSupported(similar, context));
+    }
+
+    @Test
+    void testConvertEquals() {
+        assertComparison(SqlStdOperatorTable.EQUALS, "Eq");
+    }
+
+    @Test
+    void testConvertNotEquals() {
+        assertComparison(SqlStdOperatorTable.NOT_EQUALS, "NotEq");
+    }
+
+    @Test
+    void testConvertGreaterThan() {
+        assertComparison(SqlStdOperatorTable.GREATER_THAN, "Gt");
+    }
+
+    @Test
+    void testConvertLessThan() {
+        assertComparison(SqlStdOperatorTable.LESS_THAN, "Lt");
+    }
+
+    @Test
+    void testConvertGreaterThanOrEqual() {
+        assertComparison(SqlStdOperatorTable.GREATER_THAN_OR_EQUAL, "GtEq");
+    }
+
+    @Test
+    void testConvertLessThanOrEqual() {
+        assertComparison(SqlStdOperatorTable.LESS_THAN_OR_EQUAL, "LtEq");
+    }
+
+    @Test
+    void testConvertComparisonPromotesOperands() {
+        // INT (f0) = BIGINT (f1): the INT operand is promoted to BIGINT,
+        // and the comparison result is a plain BINARY expr (no outer result cast).
+        RexNode intRef = makeIntRef(0);
+        RexNode bigintRef = REX_BUILDER.makeInputRef(bigintType(), 1);
+        RexNode eq = makeCall(boolType(), SqlStdOperatorTable.EQUALS, intRef, bigintRef);
+
+        PhysicalExprNode result = converter.convert(eq, context);
+
+        assertTrue(result.hasBinaryExpr(), "Top-level node must be a plain binary expr (no outer TryCast)");
+        assertEquals("Eq", result.getBinaryExpr().getOp());
+        PhysicalExprNode left = result.getBinaryExpr().getL();
+        assertTrue(left.hasTryCast(), "Left operand (INT) should be cast to BIGINT");
+        PhysicalExprNode right = result.getBinaryExpr().getR();
+        assertTrue(right.hasColumn(), "Right operand (BIGINT) should be a plain column");
     }
 
     @Test
@@ -342,6 +390,21 @@ class RexCallConverterTest {
     }
 
     // ---- Helpers ----
+
+    private void assertComparison(org.apache.calcite.sql.SqlOperator op, String expectedOp) {
+        RexNode call = makeCall(boolType(), op, makeIntRef(0), makeIntRef(0));
+
+        PhysicalExprNode result = converter.convert(call, context);
+
+        assertTrue(result.hasBinaryExpr());
+        assertEquals(expectedOp, result.getBinaryExpr().getOp());
+        assertTrue(result.getBinaryExpr().hasL(), "Left operand must be present");
+        assertTrue(result.getBinaryExpr().hasR(), "Right operand must be present");
+    }
+
+    private static RelDataType boolType() {
+        return TYPE_FACTORY.createSqlType(SqlTypeName.BOOLEAN);
+    }
 
     private static RexNode makeIntRef(int index) {
         return REX_BUILDER.makeInputRef(intType(), index);

--- a/auron-flink-extension/auron-flink-planner/src/test/java/org/apache/auron/flink/table/runtime/AuronCalcRewriteITCase.java
+++ b/auron-flink-extension/auron-flink-planner/src/test/java/org/apache/auron/flink/table/runtime/AuronCalcRewriteITCase.java
@@ -45,10 +45,9 @@ public class AuronCalcRewriteITCase extends AuronFlinkTableTestBase {
         assertThat(rows).isEqualTo(Arrays.asList(Row.of(2, 2), Row.of(3, 4), Row.of(3, 4)));
     }
 
-    /** A filter-plus-projection Calc whose condition uses a not-yet-supported comparison operator
-     * falls back to Flink's codegen path. Asserts the job still produces correct results; the
-     * Auron-side {@code Filter[FFIReader]} plan-shape coverage will be added when a
-     * predicate-returning converter lands. */
+    /** A filter-plus-projection Calc whose WHERE condition and projection are both
+     * converter-supported, exercising the combined Filter+Project path. Asserts the final
+     * row set is correct; the harness does not distinguish native execution from fallback. */
     @Test
     public void testFilterAndProjectEndToEnd() {
         List<Row> rows = CollectionUtil.iteratorToList(tableEnvironment

--- a/auron-flink-extension/auron-flink-planner/src/test/java/org/apache/auron/flink/table/runtime/AuronFlinkCalcITCase.java
+++ b/auron-flink-extension/auron-flink-planner/src/test/java/org/apache/auron/flink/table/runtime/AuronFlinkCalcITCase.java
@@ -19,6 +19,7 @@ package org.apache.auron.flink.table.runtime;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import org.apache.auron.flink.table.AuronFlinkTableTestBase;
@@ -37,5 +38,95 @@ public class AuronFlinkCalcITCase extends AuronFlinkTableTestBase {
                 tableEnvironment.executeSql("select `int` + 1 from T1").collect());
         rows.sort(Comparator.comparingInt(o -> (int) o.getField(0)));
         assertThat(rows).isEqualTo(Arrays.asList(Row.of(2), Row.of(3), Row.of(3)));
+    }
+
+    /** An equality filter keeps only rows whose value matches. */
+    @Test
+    public void testFilterEquals() {
+        List<Row> rows = CollectionUtil.iteratorToList(tableEnvironment
+                .executeSql("select `int` from T1 where `int` = 1")
+                .collect());
+        rows.sort(Comparator.comparingInt(o -> (int) o.getField(0)));
+        assertThat(rows).isEqualTo(Arrays.asList(Row.of(1)));
+    }
+
+    /** A not-equals filter drops rows whose value matches. */
+    @Test
+    public void testFilterNotEquals() {
+        List<Row> rows = CollectionUtil.iteratorToList(tableEnvironment
+                .executeSql("select `int` from T1 where `int` <> 1")
+                .collect());
+        rows.sort(Comparator.comparingInt(o -> (int) o.getField(0)));
+        assertThat(rows).isEqualTo(Arrays.asList(Row.of(2), Row.of(2)));
+    }
+
+    /** A greater-than filter keeps only rows strictly above the bound. */
+    @Test
+    public void testFilterGreaterThan() {
+        List<Row> rows = CollectionUtil.iteratorToList(tableEnvironment
+                .executeSql("select `int` from T1 where `int` > 1")
+                .collect());
+        rows.sort(Comparator.comparingInt(o -> (int) o.getField(0)));
+        assertThat(rows).isEqualTo(Arrays.asList(Row.of(2), Row.of(2)));
+    }
+
+    /** A less-than filter keeps only rows strictly below the bound. */
+    @Test
+    public void testFilterLessThan() {
+        List<Row> rows = CollectionUtil.iteratorToList(tableEnvironment
+                .executeSql("select `int` from T1 where `int` < 2")
+                .collect());
+        rows.sort(Comparator.comparingInt(o -> (int) o.getField(0)));
+        assertThat(rows).isEqualTo(Arrays.asList(Row.of(1)));
+    }
+
+    /** A greater-or-equal filter keeps rows at or above the bound. */
+    @Test
+    public void testFilterGreaterEqual() {
+        List<Row> rows = CollectionUtil.iteratorToList(tableEnvironment
+                .executeSql("select `int` from T1 where `int` >= 1")
+                .collect());
+        rows.sort(Comparator.comparingInt(o -> (int) o.getField(0)));
+        assertThat(rows).isEqualTo(Arrays.asList(Row.of(1), Row.of(2), Row.of(2)));
+    }
+
+    /** A less-or-equal filter keeps rows at or below the bound. */
+    @Test
+    public void testFilterLessEqual() {
+        List<Row> rows = CollectionUtil.iteratorToList(tableEnvironment
+                .executeSql("select `int` from T1 where `int` <= 2")
+                .collect());
+        rows.sort(Comparator.comparingInt(o -> (int) o.getField(0)));
+        assertThat(rows).isEqualTo(Arrays.asList(Row.of(1), Row.of(2), Row.of(2)));
+    }
+
+    /** A comparison used directly in the projection yields a Boolean column per row. */
+    @Test
+    public void testComparisonInBooleanProjection() {
+        List<Row> rows = CollectionUtil.iteratorToList(
+                tableEnvironment.executeSql("select `int` > 1 from T1").collect());
+        rows.sort(Comparator.comparing(o -> (Boolean) o.getField(0)));
+        assertThat(rows).isEqualTo(Arrays.asList(Row.of(false), Row.of(true), Row.of(true)));
+    }
+
+    /** A filter comparing an INT column against a DOUBLE column exercises INT-to-DOUBLE operand
+     * promotion; no row has int greater than double, so the result is empty. */
+    @Test
+    public void testMixedTypePromotionFilter() {
+        List<Row> rows = CollectionUtil.iteratorToList(tableEnvironment
+                .executeSql("select `int` from T1 where `int` > `double`")
+                .collect());
+        rows.sort(Comparator.comparingInt(o -> (int) o.getField(0)));
+        assertThat(rows).isEqualTo(Collections.emptyList());
+    }
+
+    /** A LIKE filter keeps rows whose string matches the pattern. */
+    @Test
+    public void testFilterLike() {
+        List<Row> rows = CollectionUtil.iteratorToList(tableEnvironment
+                .executeSql("select `string` from T1 where `string` LIKE 'Comment%'")
+                .collect());
+        rows.sort(Comparator.comparing(o -> (String) o.getField(0)));
+        assertThat(rows).isEqualTo(Arrays.asList(Row.of("Comment#1"), Row.of("Comment#1")));
     }
 }

--- a/auron-flink-extension/auron-flink-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecCalcTest.java
+++ b/auron-flink-extension/auron-flink-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecCalcTest.java
@@ -214,7 +214,7 @@ class StreamExecCalcTest {
         CapturingTranslator node = new CapturingTranslator(
                 tableConfig,
                 Arrays.asList(intRef(0)),
-                makeBinary(intType(), SqlStdOperatorTable.EQUALS, intRef(0), intRef(1)),
+                makeBinary(intType(), SqlStdOperatorTable.SIMILAR_TO, intRef(0), intRef(1)),
                 inputProperty,
                 RowType.of(new IntType()),
                 "calc",
@@ -231,10 +231,10 @@ class StreamExecCalcTest {
     @Test
     void testFallsBackWhenUnsupportedRexNodeInProjection() throws Exception {
         Transformation<RowData> stub = new FakeSourceTransformation();
-        // EQUALS produces a RexCall whose isSupported() returns false in RexCallConverter.
+        // SIMILAR_TO produces a RexCall whose isSupported() returns false in RexCallConverter.
         CapturingTranslator node = new CapturingTranslator(
                 tableConfig,
-                Arrays.asList(makeBinary(intType(), SqlStdOperatorTable.EQUALS, intRef(0), intRef(1))),
+                Arrays.asList(makeBinary(intType(), SqlStdOperatorTable.SIMILAR_TO, intRef(0), intRef(1))),
                 null,
                 inputProperty,
                 RowType.of(new IntType()),
@@ -284,7 +284,7 @@ class StreamExecCalcTest {
             CapturingTranslator node = new CapturingTranslator(
                     tableConfig,
                     Arrays.asList(intRef(0)),
-                    makeBinary(intType(), SqlStdOperatorTable.EQUALS, intRef(0), intRef(1)),
+                    makeBinary(intType(), SqlStdOperatorTable.SIMILAR_TO, intRef(0), intRef(1)),
                     inputProperty,
                     RowType.of(new IntType()),
                     "calc",
@@ -313,7 +313,7 @@ class StreamExecCalcTest {
         CapturingTranslator a = new CapturingTranslator(
                 tableConfig,
                 Arrays.asList(intRef(0)),
-                makeBinary(intType(), SqlStdOperatorTable.EQUALS, intRef(0), intRef(1)),
+                makeBinary(intType(), SqlStdOperatorTable.SIMILAR_TO, intRef(0), intRef(1)),
                 inputProperty,
                 RowType.of(new IntType()),
                 "calc-a",
@@ -324,7 +324,7 @@ class StreamExecCalcTest {
         CapturingTranslator b = new CapturingTranslator(
                 tableConfig,
                 Arrays.asList(intRef(0)),
-                makeBinary(intType(), SqlStdOperatorTable.EQUALS, intRef(0), intRef(1)),
+                makeBinary(intType(), SqlStdOperatorTable.SIMILAR_TO, intRef(0), intRef(1)),
                 inputProperty,
                 RowType.of(new IntType()),
                 "calc-b",
@@ -339,11 +339,11 @@ class StreamExecCalcTest {
      * distinct WARN log lines. */
     @Test
     void testFallbackEmitsDistinctWarnLogsForDistinctRexClasses() throws Exception {
-        // First fallback: RexCall (EQUALS) is unsupported by RexCallConverter.isSupported.
+        // First fallback: RexCall (SIMILAR_TO) is unsupported by RexCallConverter.isSupported.
         CapturingTranslator a = new CapturingTranslator(
                 tableConfig,
                 Arrays.asList(intRef(0)),
-                makeBinary(intType(), SqlStdOperatorTable.EQUALS, intRef(0), intRef(1)),
+                makeBinary(intType(), SqlStdOperatorTable.SIMILAR_TO, intRef(0), intRef(1)),
                 inputProperty,
                 RowType.of(new IntType()),
                 "calc-a",


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1861

# Rationale for this change

Flink Calc expressions that use comparison operators (`=`, `<>`, `>`, `<`, `>=`, `<=`) or `LIKE` could not run on the Auron native engine — the Flink `RexCallConverter` recognized only arithmetic and `CAST`, so any Calc containing a comparison fell back to the Flink engine. Comparisons are the backbone of `WHERE`/`JOIN`/`CASE` predicates, so without them most real queries cannot be accelerated.

# What changes are included in this PR?

Extends the existing `RexCallConverter` (no proto, Rust, or dependency changes — the native plumbing already exists for all of these operators):

- **Comparison operators** → `PhysicalBinaryExprNode` with op strings `Eq` / `NotEq` / `Gt` / `Lt` / `GtEq` / `LtEq`. Operands are promoted to a common type before conversion (the native comparison kernel requires matching operand types and performs no implicit coercion); the boolean result needs no output cast.
- **`LIKE`** → the dedicated `PhysicalLikeExprNode`. `LIKE ... ESCAPE c` (explicit, non-default escape) is reported unsupported so the Calc falls back, since the native like node has no escape field. `NOT LIKE` is represented by Calcite as `NOT(LIKE(...))`; it converts end-to-end once the logical `NOT` converter is in place, and falls back to Flink until then.

Two commits: one for the six comparison operators, one for `LIKE`.

A few existing tests used `EQUALS` as a known-unsupported operator to exercise the fallback path; now that comparisons are supported, they use `SIMILAR TO` (still unsupported) to keep testing fallback.

# Are there any user-facing changes?

Flink queries whose Calc predicates use these comparison operators or `LIKE` now execute on the native engine instead of falling back to Flink. No API or configuration change.

# How was this patch tested?

New unit tests in `RexCallConverterTest` cover each comparison operator's native op string, operand type promotion, `LIKE`, the `NOT(LIKE)` fallback, and the explicit-`ESCAPE` fallback. The full `auron-flink-planner` module test suite passes (82 tests), with 0 Checkstyle violations.
