### PR TITLE
[AURON #1864] Convert Cast operators to native operators

### DIFF
--- a/auron-flink-extension/auron-flink-planner/src/main/java/org/apache/auron/flink/table/planner/converter/FlinkNodeConverterUtils.java
+++ b/auron-flink-extension/auron-flink-planner/src/main/java/org/apache/auron/flink/table/planner/converter/FlinkNodeConverterUtils.java
@@ -17,6 +17,7 @@
 package org.apache.auron.flink.table.planner.converter;
 
 import org.apache.auron.flink.utils.SchemaConverters;
+import org.apache.auron.protobuf.PhysicalCastNode;
 import org.apache.auron.protobuf.PhysicalExprNode;
 import org.apache.auron.protobuf.PhysicalTryCastNode;
 import org.apache.calcite.rel.type.RelDataType;
@@ -117,6 +118,25 @@ public final class FlinkNodeConverterUtils {
         org.apache.auron.protobuf.ArrowType arrowType = SchemaConverters.convertToAuronArrowType(logicalType);
         return PhysicalExprNode.newBuilder()
                 .setTryCast(PhysicalTryCastNode.newBuilder().setExpr(expr).setArrowType(arrowType))
+                .build();
+    }
+
+    /**
+     * Wraps the given native expression in a strict {@link PhysicalCastNode}
+     * targeting the specified Calcite type. Unlike {@link #wrapInTryCast}, the
+     * strict cast errors on a bad conversion rather than producing {@code NULL}.
+     * The node shape and Arrow type stamping are identical to the try-cast
+     * variant.
+     *
+     * @param expr the native expression to wrap
+     * @param targetType the desired output type
+     * @return a new {@link PhysicalExprNode} containing a {@code Cast}
+     */
+    public static PhysicalExprNode wrapInCast(PhysicalExprNode expr, RelDataType targetType) {
+        LogicalType logicalType = FlinkTypeFactory.toLogicalType(targetType);
+        org.apache.auron.protobuf.ArrowType arrowType = SchemaConverters.convertToAuronArrowType(logicalType);
+        return PhysicalExprNode.newBuilder()
+                .setCast(PhysicalCastNode.newBuilder().setExpr(expr).setArrowType(arrowType))
                 .build();
     }
 

--- a/auron-flink-extension/auron-flink-planner/src/main/java/org/apache/auron/flink/table/planner/converter/RexCallConverter.java
+++ b/auron-flink-extension/auron-flink-planner/src/main/java/org/apache/auron/flink/table/planner/converter/RexCallConverter.java
@@ -35,6 +35,7 @@ import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.fun.SqlLikeOperator;
 import org.apache.calcite.sql.type.SqlTypeUtil;
+import org.apache.flink.table.planner.functions.sql.FlinkSqlOperatorTable;
 
 /**
  * Converts a Calcite {@link RexCall} (operator expression) to an Auron native
@@ -119,6 +120,11 @@ public class RexCallConverter implements FlinkRexNodeConverter {
     @Override
     public boolean isSupported(RexNode node, ConverterContext context) {
         RexCall call = (RexCall) node;
+        // TRY_CAST has SqlKind OTHER_FUNCTION (not in SUPPORTED_KINDS), so it is
+        // matched by operator identity before the kind checks.
+        if (call.getOperator() == FlinkSqlOperatorTable.TRY_CAST) {
+            return isCastTypeSupported(call.getOperands().get(0).getType(), call.getType());
+        }
         SqlKind kind = call.getKind();
         if (!SUPPORTED_KINDS.contains(kind)) {
             return false;
@@ -130,7 +136,43 @@ public class RexCallConverter implements FlinkRexNodeConverter {
         if (BINARY_ARITHMETIC_KINDS.contains(kind)) {
             return SqlTypeUtil.isNumeric(call.getType());
         }
+        if (kind == SqlKind.CAST) {
+            return isCastTypeSupported(call.getOperands().get(0).getType(), call.getType());
+        }
         return true;
+    }
+
+    /**
+     * Returns {@code true} if a cast from {@code source} to {@code target} is in
+     * the conservatively supported set that the native cast kernel performs
+     * faithfully: numeric&harr;numeric (including decimal), numeric&rarr;string,
+     * string&rarr;numeric (including string&rarr;decimal), boolean&rarr;string, and
+     * string&rarr;boolean. Every other pair (temporal, binary, complex, etc.)
+     * returns {@code false} so the whole Calc falls back to Flink's engine.
+     */
+    private static boolean isCastTypeSupported(RelDataType source, RelDataType target) {
+        boolean srcNum = SqlTypeUtil.isNumeric(source);
+        boolean tgtNum = SqlTypeUtil.isNumeric(target);
+        boolean srcStr = SqlTypeUtil.isString(source);
+        boolean tgtStr = SqlTypeUtil.isString(target);
+        boolean srcBool = SqlTypeUtil.isBoolean(source);
+        boolean tgtBool = SqlTypeUtil.isBoolean(target);
+        if (srcNum && tgtNum) {
+            return true;
+        }
+        if (srcNum && tgtStr) {
+            return true;
+        }
+        if (srcStr && tgtNum) {
+            return true;
+        }
+        if (srcBool && tgtStr) {
+            return true;
+        }
+        if (srcStr && tgtBool) {
+            return true;
+        }
+        return false;
     }
 
     /**
@@ -162,6 +204,11 @@ public class RexCallConverter implements FlinkRexNodeConverter {
     @Override
     public PhysicalExprNode convert(RexNode node, ConverterContext context) {
         RexCall call = (RexCall) node;
+        // TRY_CAST has SqlKind OTHER_FUNCTION, which the switch below would route
+        // to the throwing default; match it by operator identity beforehand.
+        if (call.getOperator() == FlinkSqlOperatorTable.TRY_CAST) {
+            return buildTryCast(call, context);
+        }
         SqlKind kind = call.getKind();
         switch (kind) {
             case PLUS:

--- a/auron-flink-extension/auron-flink-planner/src/main/java/org/apache/auron/flink/table/planner/converter/RexCallConverter.java
+++ b/auron-flink-extension/auron-flink-planner/src/main/java/org/apache/auron/flink/table/planner/converter/RexCallConverter.java
@@ -43,12 +43,19 @@ import org.apache.flink.table.planner.functions.sql.FlinkSqlOperatorTable;
  *
  * <p>Handles arithmetic operators ({@code +}, {@code -}, {@code *}, {@code /},
  * {@code %}), comparison operators ({@code =}, {@code <>}, {@code >}, {@code <},
- * {@code >=}, {@code <=}), {@code LIKE} / {@code NOT LIKE}, unary minus/plus, and
- * {@code CAST}. Binary arithmetic and comparison operands are promoted to a common
- * type before conversion; arithmetic additionally casts the result to the output
- * type if it differs from the common type, while a comparison result is already
- * BOOLEAN and needs no cast. {@code LIKE} maps to a dedicated like node; an
- * explicit {@code ESCAPE} clause is unsupported and falls back.
+ * {@code >=}, {@code <=}), {@code LIKE} / {@code NOT LIKE}, unary minus/plus,
+ * {@code CAST}, and {@code TRY_CAST}. Binary arithmetic and comparison operands
+ * are promoted to a common type before conversion; arithmetic additionally casts
+ * the result to the output type if it differs from the common type, while a
+ * comparison result is already BOOLEAN and needs no cast. {@code LIKE} maps to a
+ * dedicated like node; an explicit {@code ESCAPE} clause is unsupported and falls
+ * back.
+ *
+ * <p>An explicit {@code CAST} maps to a strict cast node that errors on a bad
+ * conversion, whereas {@code TRY_CAST} maps to a try-cast node that yields
+ * {@code NULL} on failure; the internal operand/result promotions above use the
+ * try-cast node. Only the source&rarr;target pairs in {@link #isCastTypeSupported}
+ * convert; every other pair falls back to Flink's engine.
  *
  * <p>Also handles logical operators: {@code AND} and {@code OR} (folded
  * left-deep over Calcite's n-ary operands into binary nodes), {@code NOT},
@@ -190,7 +197,11 @@ public class RexCallConverter implements FlinkRexNodeConverter {
      *       the {@code NOT} case
      *   <li>{@code MINUS_PREFIX} → {@link PhysicalNegativeNode}
      *   <li>{@code PLUS_PREFIX} → identity (passthrough to operand)
-     *   <li>{@code CAST} → {@link org.apache.auron.protobuf.PhysicalTryCastNode}
+     *   <li>{@code CAST} → {@link org.apache.auron.protobuf.PhysicalCastNode}
+     *       (strict; errors on a bad conversion)
+     *   <li>{@code TRY_CAST} → {@link org.apache.auron.protobuf.PhysicalTryCastNode}
+     *       (yields {@code NULL} on a bad conversion); matched by operator
+     *       identity before the {@link SqlKind} switch
      *   <li>{@code AND}/{@code OR} → {@link PhysicalBinaryExprNode} folded
      *       left-deep over the n-ary operands
      *   <li>{@code NOT} → {@link PhysicalNot}
@@ -240,7 +251,7 @@ public class RexCallConverter implements FlinkRexNodeConverter {
             case PLUS_PREFIX:
                 return convertOperand(call.getOperands().get(0), context);
             case CAST:
-                return buildTryCast(call, context);
+                return buildCast(call, context);
             case AND:
                 return buildBinaryFold(call, "And", context);
             case OR:
@@ -367,6 +378,11 @@ public class RexCallConverter implements FlinkRexNodeConverter {
         return PhysicalExprNode.newBuilder()
                 .setNegative(PhysicalNegativeNode.newBuilder().setExpr(operand))
                 .build();
+    }
+
+    private PhysicalExprNode buildCast(RexCall call, ConverterContext context) {
+        PhysicalExprNode operand = convertOperand(call.getOperands().get(0), context);
+        return FlinkNodeConverterUtils.wrapInCast(operand, call.getType());
     }
 
     private PhysicalExprNode buildTryCast(RexCall call, ConverterContext context) {

--- a/auron-flink-extension/auron-flink-planner/src/test/java/org/apache/auron/flink/table/planner/converter/RexCallConverterTest.java
+++ b/auron-flink-extension/auron-flink-planner/src/test/java/org/apache/auron/flink/table/planner/converter/RexCallConverterTest.java
@@ -33,6 +33,7 @@ import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.planner.functions.sql.FlinkSqlOperatorTable;
 import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.BooleanType;
 import org.apache.flink.table.types.logical.IntType;
@@ -159,6 +160,77 @@ class RexCallConverterTest {
         assertTrue(result.hasTryCast());
         assertTrue(result.getTryCast().getExpr().hasColumn());
         assertTrue(result.getTryCast().hasArrowType());
+    }
+
+    @Test
+    void testConvertTryCast() {
+        // TRY_CAST has SqlKind OTHER_FUNCTION; it is matched by operator identity
+        // and converts to a try-cast node (null-on-failure semantics).
+        RexNode tryCast = makeCall(bigintType(), FlinkSqlOperatorTable.TRY_CAST, makeIntRef(0));
+
+        PhysicalExprNode result = converter.convert(tryCast, context);
+
+        assertTrue(result.hasTryCast());
+        assertTrue(result.getTryCast().getExpr().hasColumn());
+        assertTrue(result.getTryCast().hasArrowType());
+    }
+
+    @Test
+    void testTryCastIsSupported() {
+        RexNode tryCast = makeCall(bigintType(), FlinkSqlOperatorTable.TRY_CAST, makeIntRef(0));
+
+        assertTrue(converter.isSupported(tryCast, context));
+    }
+
+    @Test
+    void testCastToUnsupportedTypeFallsBack() {
+        // INT -> DATE is outside the conservative supported set → not supported.
+        RexNode cast = makeCall(dateType(), SqlStdOperatorTable.CAST, makeIntRef(0));
+
+        assertFalse(converter.isSupported(cast, context));
+    }
+
+    @Test
+    void testTryCastToUnsupportedTypeFallsBack() {
+        // INT -> DATE is outside the conservative supported set → not supported.
+        RexNode tryCast = makeCall(dateType(), FlinkSqlOperatorTable.TRY_CAST, makeIntRef(0));
+
+        assertFalse(converter.isSupported(tryCast, context));
+    }
+
+    @Test
+    void testCastNumericToNumeric() {
+        RexNode cast = makeCall(bigintType(), SqlStdOperatorTable.CAST, makeIntRef(0));
+
+        assertTrue(converter.isSupported(cast, context));
+    }
+
+    @Test
+    void testCastNumericToString() {
+        RexNode cast = makeCall(varcharType(), SqlStdOperatorTable.CAST, makeIntRef(0));
+
+        assertTrue(converter.isSupported(cast, context));
+    }
+
+    @Test
+    void testCastStringToNumeric() {
+        RexNode cast = makeCall(intType(), SqlStdOperatorTable.CAST, strRef(5));
+
+        assertTrue(converter.isSupported(cast, context));
+    }
+
+    @Test
+    void testCastBooleanToString() {
+        RexNode cast = makeCall(varcharType(), SqlStdOperatorTable.CAST, makeBoolRef(2));
+
+        assertTrue(converter.isSupported(cast, context));
+    }
+
+    @Test
+    void testCastStringToDecimal() {
+        RexNode cast = makeCall(decimalType(), SqlStdOperatorTable.CAST, strRef(5));
+
+        assertTrue(converter.isSupported(cast, context));
     }
 
     @Test
@@ -475,6 +547,14 @@ class RexCallConverterTest {
 
     private static RelDataType varcharType() {
         return TYPE_FACTORY.createSqlType(SqlTypeName.VARCHAR);
+    }
+
+    private static RelDataType decimalType() {
+        return TYPE_FACTORY.createSqlType(SqlTypeName.DECIMAL, 10, 2);
+    }
+
+    private static RelDataType dateType() {
+        return TYPE_FACTORY.createSqlType(SqlTypeName.DATE);
     }
 
     /**

--- a/auron-flink-extension/auron-flink-planner/src/test/java/org/apache/auron/flink/table/planner/converter/RexCallConverterTest.java
+++ b/auron-flink-extension/auron-flink-planner/src/test/java/org/apache/auron/flink/table/planner/converter/RexCallConverterTest.java
@@ -153,13 +153,14 @@ class RexCallConverterTest {
 
     @Test
     void testConvertCast() {
+        // Explicit CAST routes to the strict cast node (throws on bad conversion).
         RexNode cast = makeCall(bigintType(), SqlStdOperatorTable.CAST, makeIntRef(0));
 
         PhysicalExprNode result = converter.convert(cast, context);
 
-        assertTrue(result.hasTryCast());
-        assertTrue(result.getTryCast().getExpr().hasColumn());
-        assertTrue(result.getTryCast().hasArrowType());
+        assertTrue(result.hasCast());
+        assertTrue(result.getCast().getExpr().hasColumn());
+        assertTrue(result.getCast().hasArrowType());
     }
 
     @Test

--- a/auron-flink-extension/auron-flink-planner/src/test/java/org/apache/auron/flink/table/runtime/AuronFlinkCalcITCase.java
+++ b/auron-flink-extension/auron-flink-planner/src/test/java/org/apache/auron/flink/table/runtime/AuronFlinkCalcITCase.java
@@ -144,6 +144,28 @@ public class AuronFlinkCalcITCase extends AuronFlinkTableTestBase {
         assertThat(rows).isEqualTo(Arrays.asList(Row.of((Object) null), Row.of((Object) null), Row.of((Object) null)));
     }
 
+    /** A valid numeric-to-numeric CAST converts to the strict native cast node and yields the
+     * widened values. */
+    @Test
+    public void testCastIntToDouble() {
+        List<Row> rows = CollectionUtil.iteratorToList(tableEnvironment
+                .executeSql("select cast(`int` as DOUBLE) from T1")
+                .collect());
+        rows.sort(Comparator.comparingDouble(o -> (double) o.getField(0)));
+        assertThat(rows).isEqualTo(Arrays.asList(Row.of(1d), Row.of(2d), Row.of(2d)));
+    }
+
+    /** A string-to-numeric CAST over a parseable per-row string converts to the strict native cast
+     * node and yields the parsed values. */
+    @Test
+    public void testCastStringToInt() {
+        List<Row> rows = CollectionUtil.iteratorToList(tableEnvironment
+                .executeSql("select cast(cast(`int` as STRING) as INT) from T1")
+                .collect());
+        rows.sort(Comparator.comparingInt(o -> (int) o.getField(0)));
+        assertThat(rows).isEqualTo(Arrays.asList(Row.of(1), Row.of(2), Row.of(2)));
+    }
+
     /** A cast to an unsupported target type (TIMESTAMP) is gated to Flink fallback and
      * still produces the correct row set. */
     @Test

--- a/auron-flink-extension/auron-flink-planner/src/test/java/org/apache/auron/flink/table/runtime/AuronFlinkCalcITCase.java
+++ b/auron-flink-extension/auron-flink-planner/src/test/java/org/apache/auron/flink/table/runtime/AuronFlinkCalcITCase.java
@@ -166,6 +166,28 @@ public class AuronFlinkCalcITCase extends AuronFlinkTableTestBase {
         assertThat(rows).isEqualTo(Arrays.asList(Row.of(1), Row.of(2), Row.of(2)));
     }
 
+    /** A boolean-to-string CAST over a per-row comparison converts to the strict native cast node
+     * and renders each boolean as its lowercase textual form. */
+    @Test
+    public void testCastBooleanToString() {
+        List<Row> rows = CollectionUtil.iteratorToList(tableEnvironment
+                .executeSql("select cast((`int` > 1) as STRING) from T1")
+                .collect());
+        rows.sort(Comparator.comparing(o -> (String) o.getField(0)));
+        assertThat(rows).isEqualTo(Arrays.asList(Row.of("false"), Row.of("true"), Row.of("true")));
+    }
+
+    /** A string-to-boolean CAST over a per-row boolean rendered as text round-trips back to the
+     * original boolean values through the strict native cast node. */
+    @Test
+    public void testCastStringToBoolean() {
+        List<Row> rows = CollectionUtil.iteratorToList(tableEnvironment
+                .executeSql("select cast(cast((`int` > 1) as STRING) as BOOLEAN) from T1")
+                .collect());
+        rows.sort(Comparator.comparing(o -> (Boolean) o.getField(0)));
+        assertThat(rows).isEqualTo(Arrays.asList(Row.of(false), Row.of(true), Row.of(true)));
+    }
+
     /** A cast to an unsupported target type (TIMESTAMP) is gated to Flink fallback and
      * still produces the correct row set. */
     @Test

--- a/auron-flink-extension/auron-flink-planner/src/test/java/org/apache/auron/flink/table/runtime/AuronFlinkCalcITCase.java
+++ b/auron-flink-extension/auron-flink-planner/src/test/java/org/apache/auron/flink/table/runtime/AuronFlinkCalcITCase.java
@@ -129,4 +129,29 @@ public class AuronFlinkCalcITCase extends AuronFlinkTableTestBase {
         rows.sort(Comparator.comparing(o -> (String) o.getField(0)));
         assertThat(rows).isEqualTo(Arrays.asList(Row.of("Comment#1"), Row.of("Comment#1")));
     }
+
+    /**
+     * A string that cannot be parsed as INT under TRY_CAST resolves to NULL via the native
+     * try-cast path instead of failing the query, confirming the converter routes the
+     * TRY_CAST operator to the null-on-failure native node end to end.
+     */
+    @Test
+    public void testTryCastUnparseableStringToInt() {
+        List<Row> rows = CollectionUtil.iteratorToList(tableEnvironment
+                .executeSql("select try_cast(`string` as INT) from T1")
+                .collect());
+        // Every `string` value ("Hi", "Comment#1") is non-numeric → all NULL.
+        assertThat(rows).isEqualTo(Arrays.asList(Row.of((Object) null), Row.of((Object) null), Row.of((Object) null)));
+    }
+
+    /** A cast to an unsupported target type (TIMESTAMP) is gated to Flink fallback and
+     * still produces the correct row set. */
+    @Test
+    public void testCastToUnsupportedTypeFallsBack() {
+        List<Row> rows = CollectionUtil.iteratorToList(tableEnvironment
+                .executeSql("select `int` from T1 where cast(`ts` as TIMESTAMP) is not null")
+                .collect());
+        rows.sort(Comparator.comparingInt(o -> (int) o.getField(0)));
+        assertThat(rows).isEqualTo(Arrays.asList(Row.of(1), Row.of(2), Row.of(2)));
+    }
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1864

# Rationale for this change

Flink SQL `CAST(x AS T)` is strict — it must error on a bad conversion (overflow, unparseable string) — while `TRY_CAST(x AS T)` returns NULL. The Flink converter previously routed explicit `CAST` to the native try-cast node, so a failing `CAST` silently returned NULL instead of erroring, changing query semantics under native acceleration. It also accepted every cast unconditionally, with no source→target type validation, even though the native cast kernels do not faithfully cover every type pair.

This PR makes cast conversion faithful to Flink semantics and safe against kernel mismatches: strict `CAST` errors, `TRY_CAST` nulls, and conversions outside a conservative supported set fall back to Flink's engine.

# What changes are included in this PR?

Commit 1 — gate cast type support and convert `TRY_CAST`:
- Add a source→target type gate (`isCastTypeSupported`) so only numeric↔numeric, numeric→string, string→numeric, and boolean↔string conversions convert natively; everything else (temporal, complex, etc.) falls back to Flink.
- Support explicit `TRY_CAST`, matched by operator identity (`FlinkSqlOperatorTable.TRY_CAST`) since its `SqlKind` is `OTHER_FUNCTION`, routing it to the native try-cast node (NULL on failure).

Commit 2 — route explicit `CAST` to the strict native cast node:
- Add `wrapInCast` / `buildCast` and route explicit `CAST` to the strict `PhysicalCastNode` (errors on failure), where it previously used the try-cast node.
- Internal widening promotions (arithmetic, comparison, CASE) are unchanged and still use try-cast — widening never fails, so try-cast is correct there.

No protobuf, native-engine, or dependency changes — both cast nodes already exist.

# Are there any user-facing changes?

Yes. Flink SQL `CAST` now executes with strict (error-on-failure) semantics natively, matching Flink, and `TRY_CAST` executes with null-on-failure semantics. Casts to currently-unsupported types transparently fall back to Flink's engine and produce the same results as before.

# How was this patch tested?

Unit tests in `RexCallConverterTest` cover strict `CAST` (strict node), `TRY_CAST` (try node), the supported-type pairs, and unsupported pairs that fall back. End-to-end SQL tests in `AuronFlinkCalcITCase` run `CAST` and `TRY_CAST` queries (including a non-parseable string under `TRY_CAST` yielding NULL) and a cast-to-unsupported-type query that falls back, all asserting the native row-set. Full `auron-flink-planner` module suite passes (117 tests) with 0 Checkstyle violations.
