### PR TITLE
[AURON #2304] Add end-to-end IT coverage for composed native Calc predicates and expressions

### DIFF
--- a/auron-flink-extension/auron-flink-planner/src/test/java/org/apache/auron/flink/table/runtime/AuronCalcRewriteITCase.java
+++ b/auron-flink-extension/auron-flink-planner/src/test/java/org/apache/auron/flink/table/runtime/AuronCalcRewriteITCase.java
@@ -122,4 +122,27 @@ public class AuronCalcRewriteITCase extends AuronFlinkTableTestBase {
         rows.sort(Comparator.comparingInt(o -> (int) o.getField(0)));
         assertThat(rows).isEqualTo(Arrays.asList(Row.of(2), Row.of(3), Row.of(3)));
     }
+
+    /** A CASE whose guard is a comparison varies per row: the guard is false for the int=1 row
+     * (yielding the ELSE) and true for the int=2 rows. */
+    @Test
+    public void testCaseWhenComparisonGuard() {
+        List<Row> rows = CollectionUtil.iteratorToList(tableEnvironment
+                .executeSql("select CASE WHEN `int` > 1 THEN `int` * 2 ELSE 0 END from T1")
+                .collect());
+        rows.sort(Comparator.comparingInt(o -> (int) o.getField(0)));
+        assertThat(rows).isEqualTo(Arrays.asList(Row.of(0), Row.of(4), Row.of(4)));
+    }
+
+    /** A multi-branch searched CASE evaluates its WHEN guards in order; the int=1 row takes the
+     * first branch and the int=2 rows fall through to the ELSE. */
+    @Test
+    public void testCaseWhenMultipleBranches() {
+        List<Row> rows = CollectionUtil.iteratorToList(tableEnvironment
+                .executeSql(
+                        "select CASE WHEN `int` = 1 THEN 'one' WHEN `int` > 2 THEN 'big' " + "ELSE 'two' END from T1")
+                .collect());
+        rows.sort(Comparator.comparing(o -> (String) o.getField(0)));
+        assertThat(rows).isEqualTo(Arrays.asList(Row.of("one"), Row.of("two"), Row.of("two")));
+    }
 }

--- a/auron-flink-extension/auron-flink-planner/src/test/java/org/apache/auron/flink/table/runtime/AuronFlinkCalcITCase.java
+++ b/auron-flink-extension/auron-flink-planner/src/test/java/org/apache/auron/flink/table/runtime/AuronFlinkCalcITCase.java
@@ -198,4 +198,36 @@ public class AuronFlinkCalcITCase extends AuronFlinkTableTestBase {
         rows.sort(Comparator.comparingInt(o -> (int) o.getField(0)));
         assertThat(rows).isEqualTo(Arrays.asList(Row.of(1), Row.of(2), Row.of(2)));
     }
+
+    /** A compound filter ANDing two comparisons on different columns keeps only rows satisfying both;
+     * each comparison excludes a different row. */
+    @Test
+    public void testFilterAndComparison() {
+        List<Row> rows = CollectionUtil.iteratorToList(tableEnvironment
+                .executeSql("select `int` from T1 where `int` <> 1 AND `ts` = '2020-10-10 00:00:02'")
+                .collect());
+        rows.sort(Comparator.comparingInt(o -> (int) o.getField(0)));
+        assertThat(rows).isEqualTo(Arrays.asList(Row.of(2)));
+    }
+
+    /** A compound filter ORing two comparisons on different columns keeps rows satisfying either;
+     * both operands contribute a distinct row. */
+    @Test
+    public void testFilterOrComparison() {
+        List<Row> rows = CollectionUtil.iteratorToList(tableEnvironment
+                .executeSql("select `int` from T1 where `int` = 1 OR `ts` = '2020-10-10 00:00:03'")
+                .collect());
+        rows.sort(Comparator.comparingInt(o -> (int) o.getField(0)));
+        assertThat(rows).isEqualTo(Arrays.asList(Row.of(1), Row.of(2)));
+    }
+
+    /** A NOT LIKE filter keeps rows whose string does not match the pattern. */
+    @Test
+    public void testFilterNotLike() {
+        List<Row> rows = CollectionUtil.iteratorToList(tableEnvironment
+                .executeSql("select `string` from T1 where `string` NOT LIKE 'Comment%'")
+                .collect());
+        rows.sort(Comparator.comparing(o -> (String) o.getField(0)));
+        assertThat(rows).isEqualTo(Arrays.asList(Row.of("Hi")));
+    }
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2304

# Rationale for this change

Several operator *combinations* convert into a single native Flink Calc now that the expression converters merged (#1859 math, #1860 logical, #1861 comparison/LIKE), but they lacked end-to-end `ITCase` coverage — each composed case could not be tested while its partner operator still fell back, so only the per-operator converter unit tests existed. This adds the missing end-to-end coverage so a regression in the composed native path is caught. Test-only; no production change.

# What changes are included in this PR?

Five end-to-end `ITCase` methods over the existing `T1` table, asserting the final row set (native-on):

`AuronFlinkCalcITCase` (compound filters):
- `testFilterAndComparison` — `where int <> 1 AND ts = '2020-10-10 00:00:02'` → `[2]`
- `testFilterOrComparison` — `where int = 1 OR ts = '2020-10-10 00:00:03'` → `[1, 2]`
- `testFilterNotLike` — `where string NOT LIKE 'Comment%'` → `["Hi"]`

`AuronCalcRewriteITCase` (CASE projections):
- `testCaseWhenComparisonGuard` — `CASE WHEN int > 1 THEN int * 2 ELSE 0 END` → `[0, 4, 4]`
- `testCaseWhenMultipleBranches` — `CASE WHEN int = 1 THEN 'one' WHEN int > 2 THEN 'big' ELSE 'two' END` → `["one", "two", "two"]`

The compound predicates cross two columns deliberately: a same-column compound (e.g. `int > 1 AND int < 5`) is folded by Calcite's `RexSimplify` into a single `SEARCH` before reaching the converter, so it would not build a native `And`/`Or` node. String operands use equality (varchar inequalities currently fall back), and the comparisons avoid decimal-literal-vs-`DOUBLE` forms. Both operands of each compound are load-bearing, so an `AND`/`OR` swap changes the asserted row set.

# Are there any user-facing changes?

No.

# How was this patch tested?

These are the tests. The full `auron-flink-planner` module passes (109/109) with 0 Checkstyle violations. Each new test was confirmed to execute natively during development — the runtime plan dump shows the expected native node (`FilterExec [int != 1 AND ts = ...]`, `FilterExec [int = 1 OR ts = ...]`, `FilterExec [NOT string LIKE Comment%]`, and `ProjectExec [CASE WHEN ... END]`) over the FFI reader, rather than a Flink-codegen fallback.
