### PR TITLE
[AURON #2308] Capture nativeSortExecNode before RDD creation to prevent NPE in NativeShuffleExchangeBase

### DIFF
--- a/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeShuffleExchangeBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeShuffleExchangeBase.scala
@@ -244,6 +244,8 @@ abstract class NativeShuffleExchangeBase(
       case _ => null
     }
 
+    val nativeSortExecNode = this.nativeSortExecNode
+
     val nativeShuffleRDD = new NativeRDD(
       nativeInputRDD.sparkContext,
       nativeMetrics,


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2308

# Rationale for this change

Capture nativeSortExecNode (and nativeHashExprs) as local vals before creating the NativeRDD closure. Without this, the closure references `this` which can be null at task execution time when the SparkPlan tree has been cleared, causing a NullPointerException during RangePartitioning shuffle writes.

# What changes are included in this PR?
capture `this.nativeSortExecNode`

# Are there any user-facing changes?
No.

# How was this patch tested?
UTs.