### PR TITLE
[AURON #2333] Fix master build: pass keys to getDefaultNativeMetrics in NativeOrcInsertIntoHiveTableBase

### DIFF
--- a/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeOrcInsertIntoHiveTableBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeOrcInsertIntoHiveTableBase.scala
@@ -71,8 +71,7 @@ abstract class NativeOrcInsertIntoHiveTableBase(
     BasicWriteJobStatsTracker.metrics ++
     Map(
       NativeHelper
-        .getDefaultNativeMetrics(sparkContext)
-        .filterKeys(Set("stage_id", "output_rows", "elapsed_compute"))
+        .getDefaultNativeMetrics(sparkContext, Set("stage_id", "output_rows", "elapsed_compute"))
         .toSeq
         :+ ("io_time" -> SQLMetrics.createNanoTimingMetric(sparkContext, "Native.io_time"))
         :+ ("bytes_written" ->


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2333

# Rationale for this change

`master` currently fails to compile `spark-extension`, which fails the Style check and several build/test jobs:

```
spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeOrcInsertIntoHiveTableBase.scala:74:
  not enough arguments for method getDefaultNativeMetrics:
  (sc: SparkContext, keys: Set[String])Map[String,SQLMetric]. Unspecified value parameter keys.
```

#1982 ([AURON #1985]) changed `NativeHelper.getDefaultNativeMetrics` to take a `keys: Set[String]` argument and updated all call sites except this one, which still used the old single-arg form with a trailing `.filterKeys(...)`.

# What changes are included in this PR?

Update the `NativeOrcInsertIntoHiveTableBase` metrics call site to pass the keys directly and drop `.filterKeys(...)`, mirroring how #1982 converted the other call sites.

# Are there any user-facing changes?

No.

# How was this patch tested?

`./build/mvn test-compile -Pspark-3.5 -Pscala-2.12 -pl spark-extension -am` compiles with 0 errors, and `spotless:check` on the module passes.
