### PR TITLE
[AURON #2337] Support array input for native reverse

### DIFF
--- a/auron-spark-tests/spark31/src/test/scala/org/apache/auron/utils/AuronSparkTestSettings.scala
+++ b/auron-spark-tests/spark31/src/test/scala/org/apache/auron/utils/AuronSparkTestSettings.scala
@@ -31,10 +31,6 @@ class AuronSparkTestSettings extends SparkTestSettings {
     // Native execution wraps SparkRuntimeException from map_concat input validation in
     // SparkException.
     .exclude("map_concat function")
-    // Native reverse only supports string inputs; array inputs fail with unsupported List type.
-    .exclude("reverse function - array for primitive type not containing null")
-    .exclude("reverse function - array for primitive type containing null")
-    .exclude("reverse function - array for non-primitive type")
     // Native flatten can fail when child arrays have different containsNull metadata.
     .exclude("flatten function")
     // Native execution wraps SparkRuntimeException from null map keys in SparkException.

--- a/auron-spark-tests/spark32/src/test/scala/org/apache/auron/utils/AuronSparkTestSettings.scala
+++ b/auron-spark-tests/spark32/src/test/scala/org/apache/auron/utils/AuronSparkTestSettings.scala
@@ -31,10 +31,6 @@ class AuronSparkTestSettings extends SparkTestSettings {
     .exclude("map with arrays")
     .exclude("map_concat function")
     .exclude("SPARK-24734: Fix containsNull of Concat for array type")
-    // Native reverse only supports string inputs; array inputs fail with unsupported List type.
-    .exclude("reverse function - array for primitive type not containing null")
-    .exclude("reverse function - array for primitive type containing null")
-    .exclude("reverse function - array for non-primitive type")
     // Native flatten can fail when child arrays have different containsNull metadata.
     .exclude("flatten function")
 

--- a/auron-spark-tests/spark34/src/test/scala/org/apache/auron/utils/AuronSparkTestSettings.scala
+++ b/auron-spark-tests/spark34/src/test/scala/org/apache/auron/utils/AuronSparkTestSettings.scala
@@ -32,10 +32,6 @@ class AuronSparkTestSettings extends SparkTestSettings {
     .exclude("SPARK-24734: Fix containsNull of Concat for array type")
     .exclude("array_insert functions")
     .exclude("transform keys function - Invalid lambda functions and exceptions")
-    // Native reverse only supports string inputs; array inputs fail with unsupported List type.
-    .exclude("reverse function - array for primitive type not containing null")
-    .exclude("reverse function - array for primitive type containing null")
-    .exclude("reverse function - array for non-primitive type")
     // Native flatten can fail when child arrays have different containsNull metadata.
     .exclude("flatten function")
 

--- a/auron-spark-tests/spark35/src/test/scala/org/apache/auron/utils/AuronSparkTestSettings.scala
+++ b/auron-spark-tests/spark35/src/test/scala/org/apache/auron/utils/AuronSparkTestSettings.scala
@@ -32,10 +32,6 @@ class AuronSparkTestSettings extends SparkTestSettings {
     .exclude("SPARK-24734: Fix containsNull of Concat for array type")
     .exclude("array_insert functions")
     .exclude("transform keys function - Invalid lambda functions and exceptions")
-    // Native reverse only supports string inputs; array inputs fail with unsupported List type.
-    .exclude("reverse function - array for primitive type not containing null")
-    .exclude("reverse function - array for primitive type containing null")
-    .exclude("reverse function - array for non-primitive type")
     // Native flatten can fail when child arrays have different containsNull metadata.
     .exclude("flatten function")
 

--- a/native-engine/datafusion-ext-functions/src/lib.rs
+++ b/native-engine/datafusion-ext-functions/src/lib.rs
@@ -19,6 +19,7 @@ use datafusion::{common::Result, logical_expr::ScalarFunctionImplementation};
 use datafusion_ext_commons::df_unimplemented_err;
 
 mod brickhouse;
+mod spark_array;
 mod spark_bround;
 mod spark_check_overflow;
 mod spark_crypto;
@@ -63,6 +64,7 @@ pub fn create_auron_ext_function(
             Arc::new(spark_get_json_object::spark_get_parsed_json_object)
         }
         "Spark_ParseJson" => Arc::new(spark_get_json_object::spark_parse_json),
+        "Spark_ArrayReverse" => Arc::new(spark_array::array_reverse),
         "Spark_MakeArray" => Arc::new(spark_make_array::array),
         "Spark_MapConcat" => Arc::new(spark_map::map_concat),
         "Spark_MapFromArrays" => Arc::new(spark_map::map_from_arrays),

--- a/native-engine/datafusion-ext-functions/src/spark_array.rs
+++ b/native-engine/datafusion-ext-functions/src/spark_array.rs
@@ -32,6 +32,7 @@ pub fn array_reverse(args: &[ColumnarValue]) -> Result<ColumnarValue> {
         ColumnarValue::Array(array) => Ok(ColumnarValue::Array(reverse_list_array(
             downcast_any!(array, ListArray)?,
         )?)),
+        ColumnarValue::Scalar(scalar) if scalar.is_null() => Ok(ColumnarValue::Scalar(scalar.clone())),
         ColumnarValue::Scalar(scalar) => match scalar.data_type() {
             DataType::List(_) => {
                 let array = scalar.to_array()?;
@@ -41,7 +42,7 @@ pub fn array_reverse(args: &[ColumnarValue]) -> Result<ColumnarValue> {
                 )?))
             }
             data_type => df_execution_err!("array_reverse only supports list, got {data_type:?}"),
-        },
+        }
     }
 }
 

--- a/native-engine/datafusion-ext-functions/src/spark_array.rs
+++ b/native-engine/datafusion-ext-functions/src/spark_array.rs
@@ -89,7 +89,7 @@ mod test {
     #[test]
     fn test_array_reverse_int() -> Result<()> {
         let input: ArrayRef = Arc::new(ListArray::from_iter_primitive::<Int32Type, _, _>(vec![
-            Some(vec![Some(1), Some(2), Some(3)]),
+            Some(vec![Some(1), None, Some(3)]),
             Some(vec![Some(4), Some(5)]),
             Some(vec![]),
             None,
@@ -97,7 +97,7 @@ mod test {
 
         let result = array_reverse(&[ColumnarValue::Array(input)])?.into_array(4)?;
         let expected: ArrayRef = Arc::new(ListArray::from_iter_primitive::<Int32Type, _, _>(vec![
-            Some(vec![Some(3), Some(2), Some(1)]),
+            Some(vec![Some(1), None, Some(3)]),
             Some(vec![Some(5), Some(4)]),
             Some(vec![]),
             None,

--- a/native-engine/datafusion-ext-functions/src/spark_array.rs
+++ b/native-engine/datafusion-ext-functions/src/spark_array.rs
@@ -1,0 +1,134 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use arrow::{array::*, datatypes::DataType};
+use datafusion::{
+    common::{Result, ScalarValue},
+    logical_expr::ColumnarValue,
+};
+use datafusion_ext_commons::{
+    df_execution_err, downcast_any, scalar_value::compacted_scalar_value_from_array,
+};
+
+pub fn array_reverse(args: &[ColumnarValue]) -> Result<ColumnarValue> {
+    match &args[0] {
+        ColumnarValue::Array(array) => Ok(ColumnarValue::Array(reverse_list_array(
+            downcast_any!(array, ListArray)?,
+        )?)),
+        ColumnarValue::Scalar(scalar) => match scalar.data_type() {
+            DataType::List(_) => {
+                let array = scalar.to_array()?;
+                let reversed = reverse_list_array(downcast_any!(&array, ListArray)?)?;
+                Ok(ColumnarValue::Scalar(ScalarValue::try_from_array(
+                    &reversed, 0,
+                )?))
+            }
+            data_type => df_execution_err!("array_reverse only supports list, got {data_type:?}"),
+        },
+    }
+}
+
+fn reverse_list_array(array: &ListArray) -> Result<ArrayRef> {
+    let DataType::List(field) = array.data_type() else {
+        return df_execution_err!(
+            "array_reverse only supports list, got {:?}",
+            array.data_type()
+        );
+    };
+
+    let mut values = Vec::with_capacity(array.len());
+    for row_idx in 0..array.len() {
+        if array.is_null(row_idx) {
+            values.push(ScalarValue::List(Arc::new(ListArray::new_null(
+                field.clone(),
+                1,
+            ))));
+        } else {
+            let row = array.value(row_idx);
+            let mut reversed = Vec::with_capacity(row.len());
+            for value_idx in (0..row.len()).rev() {
+                reversed.push(compacted_scalar_value_from_array(&row, value_idx)?);
+            }
+            values.push(ScalarValue::List(ScalarValue::new_list(
+                &reversed,
+                field.data_type(),
+                field.is_nullable(),
+            )));
+        }
+    }
+
+    ScalarValue::iter_to_array(values)
+}
+
+#[cfg(test)]
+mod test {
+    use std::sync::Arc;
+
+    use arrow::datatypes::Int32Type;
+    use datafusion::common::ScalarValue;
+
+    use super::*;
+
+    #[test]
+    fn test_array_reverse_int() -> Result<()> {
+        let input: ArrayRef = Arc::new(ListArray::from_iter_primitive::<Int32Type, _, _>(vec![
+            Some(vec![Some(1), Some(2), Some(3)]),
+            Some(vec![Some(4), Some(5)]),
+            Some(vec![]),
+            None,
+        ]));
+
+        let result = array_reverse(&[ColumnarValue::Array(input)])?.into_array(4)?;
+        let expected: ArrayRef = Arc::new(ListArray::from_iter_primitive::<Int32Type, _, _>(vec![
+            Some(vec![Some(3), Some(2), Some(1)]),
+            Some(vec![Some(5), Some(4)]),
+            Some(vec![]),
+            None,
+        ]));
+
+        assert_eq!(&result, &expected);
+        Ok(())
+    }
+
+    #[test]
+    fn test_array_reverse_scalar() -> Result<()> {
+        let input = ScalarValue::List(ScalarValue::new_list(
+            &[
+                ScalarValue::from(1),
+                ScalarValue::from(2),
+                ScalarValue::from(3),
+            ],
+            &DataType::Int32,
+            true,
+        ));
+
+        let result = array_reverse(&[ColumnarValue::Scalar(input)])?.into_array(1)?;
+        let expected = ScalarValue::List(ScalarValue::new_list(
+            &[
+                ScalarValue::from(3),
+                ScalarValue::from(2),
+                ScalarValue::from(1),
+            ],
+            &DataType::Int32,
+            true,
+        ))
+        .to_array()?;
+
+        assert_eq!(&result, &expected);
+        Ok(())
+    }
+}

--- a/native-engine/datafusion-ext-functions/src/spark_array.rs
+++ b/native-engine/datafusion-ext-functions/src/spark_array.rs
@@ -97,7 +97,7 @@ mod test {
 
         let result = array_reverse(&[ColumnarValue::Array(input)])?.into_array(4)?;
         let expected: ArrayRef = Arc::new(ListArray::from_iter_primitive::<Int32Type, _, _>(vec![
-            Some(vec![Some(1), None, Some(3)]),
+            Some(vec![Some(3), None, Some(1)]),
             Some(vec![Some(5), Some(4)]),
             Some(vec![]),
             None,

--- a/native-engine/datafusion-ext-functions/src/spark_array.rs
+++ b/native-engine/datafusion-ext-functions/src/spark_array.rs
@@ -25,6 +25,9 @@ use datafusion_ext_commons::{
 };
 
 pub fn array_reverse(args: &[ColumnarValue]) -> Result<ColumnarValue> {
+    if args.len() != 1 {
+        return df_execution_err!("array_reverse requires exactly 1 argument");
+    }
     match &args[0] {
         ColumnarValue::Array(array) => Ok(ColumnarValue::Array(reverse_list_array(
             downcast_any!(array, ListArray)?,

--- a/native-engine/datafusion-ext-functions/src/spark_array.rs
+++ b/native-engine/datafusion-ext-functions/src/spark_array.rs
@@ -32,7 +32,9 @@ pub fn array_reverse(args: &[ColumnarValue]) -> Result<ColumnarValue> {
         ColumnarValue::Array(array) => Ok(ColumnarValue::Array(reverse_list_array(
             downcast_any!(array, ListArray)?,
         )?)),
-        ColumnarValue::Scalar(scalar) if scalar.is_null() => Ok(ColumnarValue::Scalar(scalar.clone())),
+        ColumnarValue::Scalar(scalar) if scalar.is_null() => {
+            Ok(ColumnarValue::Scalar(scalar.clone()))
+        }
         ColumnarValue::Scalar(scalar) => match scalar.data_type() {
             DataType::List(_) => {
                 let array = scalar.to_array()?;
@@ -42,7 +44,7 @@ pub fn array_reverse(args: &[ColumnarValue]) -> Result<ColumnarValue> {
                 )?))
             }
             data_type => df_execution_err!("array_reverse only supports list, got {data_type:?}"),
-        }
+        },
     }
 }
 

--- a/spark-extension/src/main/scala/org/apache/spark/sql/auron/NativeConverters.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/auron/NativeConverters.scala
@@ -926,6 +926,8 @@ object NativeConverters extends Logging {
         buildExtScalarFunction("Spark_NullIf", left :: right :: Nil, e.dataType)
       case Md5(_1) =>
         buildExtScalarFunction("Spark_MD5", Seq(unpackBinaryTypeCast(_1)), StringType)
+      case e @ Reverse(child) if child.dataType.isInstanceOf[ArrayType] =>
+        buildExtScalarFunction("Spark_ArrayReverse", e.children, e.dataType)
       case Reverse(_1) =>
         buildScalarFunction(pb.ScalarFunction.Reverse, Seq(unpackBinaryTypeCast(_1)), StringType)
       case e: InitCap =>


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2337 

# Rationale for this change

Spark's `reverse` expression supports both string and array inputs. Auron previously converted native `Reverse` as a string function only, so `reverse(array<T>)` could not execute natively and the Spark reverse array tests were excluded.

Supporting array input closes this Spark compatibility gap and improves native expression coverage for a common built-in function.

# What changes are included in this PR?

- Add a native `Spark_ArrayReverse` ext scalar function.
- Route `Reverse` with `ArrayType` input to `Spark_ArrayReverse`.
- Keep the existing string reverse conversion unchanged.
- Preserve null arrays and null elements when reversing array values.
- Remove the reverse array excludes from Spark 3.1, 3.2, 3.4, and 3.5 test settings.

# Are there any user-facing changes?

Yes. Queries using `reverse(array<T>)` can now be executed by Auron native execution instead of falling back or being unsupported.

# How was this patch tested?
UT.