### PR TITLE
[AURON #2341] Fix NativeIcebergTableScan to respect SinglePartition outputPartitioning

### DIFF
--- a/thirdparty/auron-iceberg/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeIcebergTableScanExec.scala
+++ b/thirdparty/auron-iceberg/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeIcebergTableScanExec.scala
@@ -34,7 +34,6 @@ import org.apache.spark.sql.auron.{EmptyNativeRDD, NativeConverters, NativeHelpe
 import org.apache.spark.sql.auron.iceberg.IcebergScanPlan
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Literal
-import org.apache.spark.sql.catalyst.plans.physical.SinglePartition
 import org.apache.spark.sql.execution.{LeafExecNode, SparkPlan, SQLExecution}
 import org.apache.spark.sql.execution.datasources.{FilePartition, PartitionedFile}
 import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
@@ -276,6 +275,7 @@ case class NativeIcebergTableScanExec(basedScan: BatchScanExec, plan: IcebergSca
       .sortBy(_.length)(Ordering[Long].reverse)
       .toSeq
 
+    // Keep the physical scan partition count aligned with the declared single-partition output.
     if (basedScan.outputPartitioning == SinglePartition) {
       Array(FilePartition(0, partitionedFiles.toArray))
     } else {

--- a/thirdparty/auron-iceberg/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeIcebergTableScanExec.scala
+++ b/thirdparty/auron-iceberg/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeIcebergTableScanExec.scala
@@ -34,6 +34,7 @@ import org.apache.spark.sql.auron.{EmptyNativeRDD, NativeConverters, NativeHelpe
 import org.apache.spark.sql.auron.iceberg.IcebergScanPlan
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Literal
+import org.apache.spark.sql.catalyst.plans.physical.SinglePartition
 import org.apache.spark.sql.execution.{LeafExecNode, SparkPlan, SQLExecution}
 import org.apache.spark.sql.execution.datasources.{FilePartition, PartitionedFile}
 import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
@@ -263,13 +264,10 @@ case class NativeIcebergTableScanExec(basedScan: BatchScanExec, plan: IcebergSca
   }
 
   private def buildFilePartitions(): Array[FilePartition] = {
-    // Convert Iceberg file tasks into Spark FilePartition groups for execution.
     if (fileTasks.isEmpty) {
       return Array.empty
     }
 
-    val sparkSession = Shims.get.getSqlContext(basedScan).sparkSession
-    val maxSplitBytes = getMaxSplitBytes(sparkSession, fileTasks)
     val partitionedFiles = fileTasks
       .map { task =>
         val filePath = task.file().location()
@@ -278,7 +276,13 @@ case class NativeIcebergTableScanExec(basedScan: BatchScanExec, plan: IcebergSca
       .sortBy(_.length)(Ordering[Long].reverse)
       .toSeq
 
-    FilePartition.getFilePartitions(sparkSession, partitionedFiles, maxSplitBytes).toArray
+    if (basedScan.outputPartitioning == SinglePartition) {
+      Array(FilePartition(0, partitionedFiles.toArray))
+    } else {
+      val sparkSession = Shims.get.getSqlContext(basedScan).sparkSession
+      val maxSplitBytes = getMaxSplitBytes(sparkSession, fileTasks)
+      FilePartition.getFilePartitions(sparkSession, partitionedFiles, maxSplitBytes).toArray
+    }
   }
 
   private def getMaxSplitBytes(sparkSession: SparkSession, tasks: Seq[FileScanTask]): Long = {

--- a/thirdparty/auron-iceberg/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeIcebergTableScanExec.scala
+++ b/thirdparty/auron-iceberg/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeIcebergTableScanExec.scala
@@ -34,6 +34,7 @@ import org.apache.spark.sql.auron.{EmptyNativeRDD, NativeConverters, NativeHelpe
 import org.apache.spark.sql.auron.iceberg.IcebergScanPlan
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Literal
+import org.apache.spark.sql.catalyst.plans.physical.SinglePartition
 import org.apache.spark.sql.execution.{LeafExecNode, SparkPlan, SQLExecution}
 import org.apache.spark.sql.execution.datasources.{FilePartition, PartitionedFile}
 import org.apache.spark.sql.execution.datasources.v2.BatchScanExec

--- a/thirdparty/auron-iceberg/src/test/scala/org/apache/auron/iceberg/AuronIcebergIntegrationSuite.scala
+++ b/thirdparty/auron-iceberg/src/test/scala/org/apache/auron/iceberg/AuronIcebergIntegrationSuite.scala
@@ -450,4 +450,17 @@ class AuronIcebergIntegrationSuite
     assert(nativeScan.nonEmpty)
     nativeScan.get
   }
+
+  test("native iceberg scan respects SinglePartition for global sort correctness") {
+    withTable("local.db.t_global_sort") {
+      sql("create table local.db.t_global_sort (id int, value string) using iceberg")
+      sql("insert into local.db.t_global_sort values (4, 'd'), (1, 'a')")
+      sql("insert into local.db.t_global_sort values (3, 'c'), (2, 'b')")
+
+      val df = sql("select id, value from local.db.t_global_sort order by id")
+      val result = df.collect().map(_.getInt(0)).toSeq
+      assert(result === Seq(1, 2, 3, 4), s"Global ORDER BY must produce [1,2,3,4], got: $result")
+      assert(df.queryExecution.executedPlan.toString().contains("NativeIcebergTableScan"))
+    }
+  }
 }

--- a/thirdparty/auron-iceberg/src/test/scala/org/apache/auron/iceberg/AuronIcebergIntegrationSuite.scala
+++ b/thirdparty/auron-iceberg/src/test/scala/org/apache/auron/iceberg/AuronIcebergIntegrationSuite.scala
@@ -461,6 +461,7 @@ class AuronIcebergIntegrationSuite
       val result = df.collect().map(_.getInt(0)).toSeq
       assert(result === Seq(1, 2, 3, 4), s"Global ORDER BY must produce [1,2,3,4], got: $result")
       assert(df.queryExecution.executedPlan.toString().contains("NativeIcebergTableScan"))
+      assert(df.rdd.getNumPartitions === 1)
     }
   }
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2341

# Rationale for this change

`NativeIcebergTableScanExec` declares `outputPartitioning = basedScan.outputPartitioning`, which may be `SinglePartition` (decided by AQE). However, its `buildFilePartitions()` independently uses bin-packing to split files into multiple partitions, violating this contract.

When `NativeSort(global=true)` sits on top of the scan, Spark trusts the `SinglePartition` declaration and skips inserting a shuffle exchange. `NativeSort` then performs per-partition sort on each of the multiple partitions independently, and the results are concatenated by partition index — producing incorrect global ordering.

# What changes are included in this PR?

Fix `NativeIcebergTableScanExec.buildFilePartitions()` to honor `basedScan.outputPartitioning`: when Spark declares `SinglePartition`, merge all files into a single FilePartition instead of bin-packing into multiple partitions

# Are there any user-facing changes?

`ORDER BY` queries on multi-file Iceberg tables now return correct globally sorted results.

# How was this patch tested?
Add new integration test