### PR TITLE
[AURON #2352] Lock spills before new spiller

### DIFF
--- a/native-engine/datafusion-ext-plans/src/shuffle/sort_repartitioner.rs
+++ b/native-engine/datafusion-ext-plans/src/shuffle/sort_repartitioner.rs
@@ -98,6 +98,7 @@ impl MemConsumer for SortShuffleRepartitioner {
     async fn spill(&self) -> Result<()> {
         let data = self.data.lock().await.drain();
         let spill_metrics = self.exec_ctx.spill_metrics().clone();
+        let mut spills = self.spills.lock().await;
         let spill = tokio::task::spawn_blocking(move || {
             let mut spill = try_new_spill(&spill_metrics)?;
             let offsets = data.write(spill.get_buf_writer())?;
@@ -105,8 +106,7 @@ impl MemConsumer for SortShuffleRepartitioner {
         })
         .await
         .expect("tokio spawn_blocking error")?;
-
-        self.spills.lock().await.push(spill);
+        spills.push(spill);
         self.update_mem_used(0).await?;
         Ok(())
     }

--- a/native-engine/datafusion-ext-plans/src/shuffle/sort_repartitioner.rs
+++ b/native-engine/datafusion-ext-plans/src/shuffle/sort_repartitioner.rs
@@ -107,6 +107,7 @@ impl MemConsumer for SortShuffleRepartitioner {
         .await
         .expect("tokio spawn_blocking error")?;
         spills.push(spill);
+        drop(spills);
         self.update_mem_used(0).await?;
         Ok(())
     }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2352

# Rationale for this change

`try_new_spill` always uses `spills.len` as the `spill_id`, so we should always lock `spills` before `trying_new_spill`.

# What changes are included in this PR?

# Are there any user-facing changes?

# How was this patch tested?
