### PR TITLE
[AURON #2364] fix: Native Paimon V2 scan returns wrong results with native filter

### DIFF
--- a/spark-extension/src/main/scala/org/apache/spark/sql/auron/AuronConverters.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/auron/AuronConverters.scala
@@ -1220,6 +1220,8 @@ object AuronConverters extends Logging {
         true
       case exec if exec.nodeName == "NativeIcebergTableScan" =>
         true
+      case exec if exec.nodeName == "NativePaimonV2TableScan" =>
+        true
       case _: ConvertToNativeBase => needRenameColumns(plan.children.head)
       case exec if NativeHelper.isNative(exec) =>
         NativeHelper.getUnderlyingNativePlan(exec).output != plan.output

--- a/thirdparty/auron-paimon/src/test/scala/org/apache/auron/paimon/AuronPaimonV2IntegrationSuite.scala
+++ b/thirdparty/auron-paimon/src/test/scala/org/apache/auron/paimon/AuronPaimonV2IntegrationSuite.scala
@@ -102,6 +102,25 @@ class AuronPaimonV2IntegrationSuite
     }
   }
 
+  test("paimon v2 native scan supports native filter on renamed output columns") {
+    withTable("paimon.db.t_rename_columns") {
+      sql("create table paimon.db.t_rename_columns (id int, v string) using paimon")
+      sql("insert into paimon.db.t_rename_columns values (1, 'a'), (2, 'b')")
+
+      withSQLConf("spark.sql.adaptive.enabled" -> "false") {
+        val df = sql("select id from paimon.db.t_rename_columns where id = 1")
+        assertNativePaimonScanApplied(df)
+
+        val plan = df.queryExecution.executedPlan
+        assert(
+          plan.exists(_.nodeName == "NativeFilter"),
+          s"expected a native filter consuming the Paimon scan:\n$plan")
+
+        checkAnswer(df, Seq(Row(1)))
+      }
+    }
+  }
+
   test("paimon v2 native scan supports COW primary-key table") {
     withTable("paimon.db.t_cow") {
       sql("""


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2364

# Rationale for this change

Auron recently added native scan support for Paimon DSv2 tables. When a Paimon V2 native scan is followed by a native filter, the query can return wrong results.

For example:

```sql
create table paimon.db.t_rename_columns (id int, v string) using paimon;
insert into paimon.db.t_rename_columns values (1, 'a'), (2, 'b');
select id from paimon.db.t_rename_columns where id = 1;
```

The buggy plan returns an empty result instead of `[1]`.

# What changes are included in this PR?

updates `AuronConverters.needRenameColumns` to mark `NativePaimonV2TableScan` as requiring rename-columns handling.

# Are there any user-facing changes?

No API changes. Only a bug fix.

# How was this patch tested?
Adds a Paimon V2 integration test covering a native filter on top of a native Paimon V2 scan.