### PR TITLE
[AURON #2380] [RELEASE] Bump version to 8.0.0-incubating

### DIFF
--- a/.github/workflows/build-amd64-releases.yml
+++ b/.github/workflows/build-amd64-releases.yml
@@ -40,7 +40,7 @@ jobs:
         sparkver: [spark-3.0, spark-3.1, spark-3.2, spark-3.3, spark-3.4, spark-3.5, spark-4.0, spark-4.1]
         scalaver: [ 2.12, 2.13 ]
         javaver: [ 8, 21 ]
-        auronver: [8.0.0-SNAPSHOT]
+        auronver: [8.0.0-incubating]
         runner: [ ubuntu-24.04 ]
         exclude:
           # Only build on scala-2.13 for spark-3.5+
@@ -85,13 +85,13 @@ jobs:
           - sparkver: spark-4.0
             scalaver: '2.13'
             javaver: '21'
-            auronver: 8.0.0-SNAPSHOT
+            auronver: 8.0.0-incubating
             runner: ubuntu-24.04
             image: rockylinux8
           - sparkver: spark-4.1
             scalaver: '2.13'
             javaver: '21'
-            auronver: 8.0.0-SNAPSHOT
+            auronver: 8.0.0-incubating
             runner: ubuntu-24.04
             image: rockylinux8
 

--- a/.github/workflows/build-arm-releases.yml
+++ b/.github/workflows/build-arm-releases.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       matrix:
         sparkver: [spark-3.0, spark-3.1, spark-3.2, spark-3.3, spark-3.4, spark-3.5, spark-4.0, spark-4.1]
-        auronver: [8.0.0-SNAPSHOT]
+        auronver: [8.0.0-incubating]
         scalaver: [2.12, 2.13]
         javaver: [ 8, 21 ]
         runner: [ ubuntu-24.04-arm ]

--- a/.github/workflows/build-macos-releases.yml
+++ b/.github/workflows/build-macos-releases.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       matrix:
         sparkver: [spark-3.0, spark-3.1, spark-3.2, spark-3.3, spark-3.4, spark-3.5, spark-4.0, spark-4.1]
-        auronver: [8.0.0-SNAPSHOT]
+        auronver: [8.0.0-incubating]
         scalaver: [2.12, 2.13]
         javaver: [8, 21]
         runner: [macos-15]

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
   </modules>
 
   <properties>
-    <project.version>8.0.0-SNAPSHOT</project.version>
+    <project.version>8.0.0-incubating</project.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <arrowVersion>16.0.0</arrowVersion>
     <bytebuddyVersion>1.14.11</bytebuddyVersion>


### PR DESCRIPTION
# Rationale for this change

This PR prepares the Apache Auron 8.0.0-incubating release by bumping the project version from `8.0.0-SNAPSHOT` to `8.0.0-incubating`.

This is required before creating the release candidate tag and publishing the release artifacts.

# What changes are included in this PR?

- Updated the project version in `pom.xml`
  - From `8.0.0-SNAPSHOT`
  - To `8.0.0-incubating`

# Are there any user-facing changes?

No.

This is a release preparation change only. It does not introduce any behavior changes, API changes, or user-facing functionality changes.

# How was this patch tested?

No Need Test.