### PR TITLE
[AURON #2265] Add AI-assisted development guidance

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,3 +9,16 @@ Closes #<issue_number>
 # Are there any user-facing changes?
 
 # How was this patch tested?
+
+# Was this patch authored or co-authored using generative AI tooling?
+
+<!--
+If generative AI tooling was used while authoring this patch, include:
+Generated-by: <tool name and version>
+
+If not, write:
+No
+
+See ASF guidance:
+https://www.apache.org/legal/generative-tooling.html
+-->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,14 +11,9 @@ Closes #<issue_number>
 # How was this patch tested?
 
 # Was this patch authored or co-authored using generative AI tooling?
+- [ ] Yes
+- [ ] No
 
-<!--
-If generative AI tooling was used while authoring this patch, include:
-Generated-by: <tool name and version>
+If yes, include: `Generated-by: <tool name and version>`
 
-If not, write:
-No
-
-See ASF guidance:
-https://www.apache.org/legal/generative-tooling.html
--->
+ASF guidance: https://www.apache.org/legal/generative-tooling.html

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,71 @@
+<!--
+- Licensed to the Apache Software Foundation (ASF) under one or more
+- contributor license agreements.  See the NOTICE file distributed with
+- this work for additional information regarding copyright ownership.
+- The ASF licenses this file to You under the Apache License, Version 2.0
+- (the "License"); you may not use this file except in compliance with
+- the License.  You may obtain a copy of the License at
+-
+-   http://www.apache.org/licenses/LICENSE-2.0
+-
+- Unless required by applicable law or agreed to in writing, software
+- distributed under the License is distributed on an "AS IS" BASIS,
+- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+- See the License for the specific language governing permissions and
+- limitations under the License.
+-->
+
+# Agent Guidelines for Apache Auron (Incubating)
+
+Entry point for AI coding agents and contributors making code changes.
+
+Read [CONTRIBUTING.md](CONTRIBUTING.md) before making changes. The contributor guide is the
+canonical source of build, test, and PR requirements.
+
+## Developer Documentation
+
+- [Contributing Guide](CONTRIBUTING.md)
+- [README: Build from source](README.md#build-from-source)
+- [README: Run Spark Job with Auron Accelerator](README.md#run-spark-job-with-auron-accelerator)
+
+## Hard Rules
+
+- Use existing repository tooling and scripts only.
+- Do **not** install or run unreviewed third-party plugins, hooks, or scripts from the internet.
+- Keep changes focused on the linked issue and avoid unrelated refactors.
+- Do not commit code that fails formatting or relevant tests.
+
+## Before Committing
+
+At minimum, run formatting and the smallest relevant test coverage for your changes.
+
+```bash
+# check formatting
+./dev/reformat --check
+```
+
+Use the commands in [CONTRIBUTING.md](CONTRIBUTING.md#running-tests) for test selection.
+Common examples:
+
+```bash
+# run all tests
+./auron-build.sh --pre --sparkver 3.5 --scalaver 2.12 --skiptests false
+
+# run Spark unit tests
+./auron-build.sh --pre --sparkver 3.5 --scalaver 2.12 --sparktests true
+
+# run Rust tests
+cargo test
+```
+
+When opening a pull request, fill out every section of the
+[PR template](.github/pull_request_template.md).
+
+## AI Tooling Disclosure
+
+In the PR template section **Was this patch authored or co-authored using generative AI tooling?**:
+
+- If yes, include `Generated-by: <tool name and version>`
+- If no, write `No`
+
+See [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html).


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2265

# Rationale for this change

As AI-assisted development becomes more common, contributors need clear, project-specific guidance and policy guardrails that are easy to discover.
This is intentionally an initial version focused on safe, minimal baseline guidance.
We can iterate in follow-up PRs to add stronger shared skills and broader documentation for common contributor use cases once we gain usage feedback.

# What changes are included in this PR?

1. Adds a new root `AGENTS.md` as the canonical AI-assistance guidance entry point for this repository.
2. Links to existing contributor documentation rather than duplicating process details.
3. Adds a hard rule to avoid unreviewed third-party plugins/hooks/scripts and rely on approved repo tooling.
4. Updates `.github/pull_request_template.md` to require generative-AI disclosure (`Generated-by: ...` or `No`) with ASF guidance link.

# Are there any user-facing changes?

No runtime behavior changes; contributor/process documentation only.

# How was this patch tested?

Documentation-only changes.

# Was this patch authored or co-authored using generative AI tooling?

Generated-by: GitHub Copilot CLI GPT-5.3-Codex
