### PR TITLE
[AURON #2396] [RELEASE] Bump the development version to 9.0.0-SNAPSHOT

### DIFF
--- a/.github/workflows/build-amd64-releases.yml
+++ b/.github/workflows/build-amd64-releases.yml
@@ -40,7 +40,7 @@ jobs:
         sparkver: [spark-3.0, spark-3.1, spark-3.2, spark-3.3, spark-3.4, spark-3.5, spark-4.0, spark-4.1]
         scalaver: [ 2.12, 2.13 ]
         javaver: [ 8, 21 ]
-        auronver: [8.0.0-incubating]
+        auronver: [9.0.0-SNAPSHOT]
         runner: [ ubuntu-24.04 ]
         exclude:
           # Only build on scala-2.13 for spark-3.5+
@@ -85,13 +85,13 @@ jobs:
           - sparkver: spark-4.0
             scalaver: '2.13'
             javaver: '21'
-            auronver: 8.0.0-incubating
+            auronver: 9.0.0-SNAPSHOT
             runner: ubuntu-24.04
             image: rockylinux8
           - sparkver: spark-4.1
             scalaver: '2.13'
             javaver: '21'
-            auronver: 8.0.0-incubating
+            auronver: 9.0.0-SNAPSHOT
             runner: ubuntu-24.04
             image: rockylinux8
 

--- a/.github/workflows/build-arm-releases.yml
+++ b/.github/workflows/build-arm-releases.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       matrix:
         sparkver: [spark-3.0, spark-3.1, spark-3.2, spark-3.3, spark-3.4, spark-3.5, spark-4.0, spark-4.1]
-        auronver: [8.0.0-incubating]
+        auronver: [9.0.0-SNAPSHOT]
         scalaver: [2.12, 2.13]
         javaver: [ 8, 21 ]
         runner: [ ubuntu-24.04-arm ]

--- a/.github/workflows/build-macos-releases.yml
+++ b/.github/workflows/build-macos-releases.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       matrix:
         sparkver: [spark-3.0, spark-3.1, spark-3.2, spark-3.3, spark-3.4, spark-3.5, spark-4.0, spark-4.1]
-        auronver: [8.0.0-incubating]
+        auronver: [9.0.0-SNAPSHOT]
         scalaver: [2.12, 2.13]
         javaver: [8, 21]
         runner: [macos-15]
@@ -129,4 +129,3 @@ jobs:
           name: auron-${{matrix.sparkver}}_${{ matrix.scalaver }}-${{ matrix.javaver }}-release-${{ env.osclassfier }}-${{ matrix.auronver }}-${{ matrix.runner }}-${{ steps.commit.outputs.short }}.jar
           path: target/auron-${{matrix.sparkver}}_${{ matrix.scalaver }}-release-${{ env.osclassfier }}-${{ matrix.auronver }}.jar
           overwrite: true
-

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
   </modules>
 
   <properties>
-    <project.version>8.0.0-incubating</project.version>
+    <project.version>9.0.0-SNAPSHOT</project.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <arrowVersion>16.0.0</arrowVersion>
     <bytebuddyVersion>1.14.11</bytebuddyVersion>


### PR DESCRIPTION
### Which issue does this PR close?

Closes #2396

### Rationale for this change

Apache Auron 8.0.0-incubating has been released. Continued development on the `master` branch should use the next snapshot version instead of retaining the released version.

The release build workflows also contain hard-coded Auron version values. These values must remain consistent with the Maven project version so that generated JAR names match the artifact paths expected by GitHub Actions.

### What changes are included in this PR?

- Update `project.version` in the root `pom.xml` from
  `8.0.0-incubating` to `9.0.0-SNAPSHOT`.
- Update `auronver` to `9.0.0-SNAPSHOT` in the AMD64 release workflow.
- Update the explicit Spark 4.0 and Spark 4.1 AMD64 matrix entries.
- Update `auronver` to `9.0.0-SNAPSHOT` in the ARM64 release workflow.
- Update `auronver` to `9.0.0-SNAPSHOT` in the macOS release workflow.

### Are there any user-facing changes?

No.

This change only updates the development version and CI artifact naming.
It does not introduce changes to runtime behavior or public APIs.

### How was this patch tested?

### Was this patch authored or co-authored using generative AI tooling?
- [ ] Yes
- [x] No

If yes, include: `Generated-by: <tool name and version>`

ASF guidance: https://www.apache.org/legal/generative-tooling.html
