### PR TITLE
[AURON #2398] Fix Maven -D argument handling in auron-build.sh

### DIFF
--- a/auron-build.sh
+++ b/auron-build.sh
@@ -156,7 +156,7 @@ UNIFFLE_VER=""
 PAIMON_VER=""
 ICEBERG_VER=""
 HUDI_VER=""
-MVN_D_ARGS=""
+MVN_D_ARGS=()
 
 # -----------------------------------------------------------------------------
 # Section: Argument Parsing
@@ -368,7 +368,7 @@ while [[ $# -gt 0 ]]; do
             ;;
         -*)
             if [[ "$1" == -D* ]]; then
-                MVN_D_ARGS="$MVN_D_ARGS $1"
+                MVN_D_ARGS+=("$1")
                 shift
             else
                 break
@@ -590,11 +590,6 @@ if [[ "$USE_DOCKER" == true ]]; then
     fi
     run_docker_compose_up
 else
-    echo "[INFO] Compiling locally with maven args: $MVN_CMD ${MVN_ARGS[@]} ${MVN_D_ARGS} $@"
-    if [[ -n "$MVN_D_ARGS" ]]; then
-        "$MVN_CMD" "${MVN_ARGS[@]}" "${MVN_D_ARGS}" "$@"
-    else
-        "$MVN_CMD" "${MVN_ARGS[@]}" "$@"
-    fi
+    echo "[INFO] Compiling locally with maven args: $MVN_CMD ${MVN_ARGS[@]} ${MVN_D_ARGS[*]} $@"
+    "$MVN_CMD" "${MVN_ARGS[@]}" "${MVN_D_ARGS[@]}" "$@"
 fi
-


### PR DESCRIPTION
### Which issue does this PR close?

Closes #2398

### Rationale for this change

The `auron-build.sh` script incorrectly handles Maven `-D` arguments.

The script previously stored these arguments in a single string and added a leading space before the first argument. It then passed the complete string to Maven as one quoted argument.

For example, Maven received:

```text
" -DskipBuildNative"
```

instead of:

```
"-DskipBuildNative"
```

This caused Maven to report:

```
Unknown lifecycle phase " -DskipBuildNative"
```

### What changes are included in this PR?

- Replace the string-based `MVN_D_ARGS` variable with a Bash array.
- Store every Maven `-D` option as an independent array element.
- Pass Maven properties using quoted array expansion.
- Preserve multiple Maven properties and values containing spaces.
- Simplify the local Maven command execution path.

### Are there any user-facing changes?

Yes.

Users can now pass Maven `-D` properties through `auron-build.sh` as documented. 

For example:

```
./auron-build.sh --pre --sparkver 4.1 --scalaver 2.13 -DskipBuildNative
```

Multiple Maven properties are also preserved as separate arguments.

### How was this patch tested?

- Reproduced the original behavior and confirmed that the script produced:

```
< -DskipBuildNative>
```

- Verified that the fixed script produces:

```
<-DskipBuildNative>
```

### Was this patch authored or co-authored using generative AI tooling?
- [ ] Yes
- [x] No

If yes, include: `Generated-by: <tool name and version>`

ASF guidance: https://www.apache.org/legal/generative-tooling.html
