### PR TITLE
[AURON #2413] fix(ci): adapt labeler.yml to actions/labeler v7

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -17,119 +17,102 @@
 
 infra:
   - changed-files:
-    - any-glob-to-any-file: [
-        ".github/**",
-        ".asf.yaml",
-        ".rat-excludes",
-        ".gitattributes",
-        ".gitignore",
-        ".gitmodules"
-      ]
+    - any-glob-to-any-file:
+        - ".github/**"
+        - ".asf.yaml"
+        - ".rat-excludes"
+        - ".gitattributes"
+        - ".gitignore"
+        - ".gitmodules"
 
 build:
   - changed-files:
-    - any-glob-to-any-file: [
-        "build/**",
-        "**/*pom.xml",
-        "Cargo.toml",
-        "Cargo.lock",
-        "auron-build.sh",
-        "rust-toolchain.toml",
-        "rustfmt.toml",
-        "scalafix.conf",
-        "scalafmt.conf"
-      ]
+    - any-glob-to-any-file:
+        - "build/**"
+        - "**/*pom.xml"
+        - "Cargo.toml"
+        - "Cargo.lock"
+        - "auron-build.sh"
+        - "rust-toolchain.toml"
+        - "rustfmt.toml"
+        - "scalafix.conf"
+        - "scalafmt.conf"
 
 documentation:
   - changed-files:
-    - any-glob-to-any-file: [
-        "**/*.md",
-        "LICENSE"
-      ]
+    - any-glob-to-any-file:
+        - "**/*.md"
+        - "LICENSE"
 
 core:
   - changed-files:
-    - any-glob-to-any-file: [
-        "auron-core/**"
-      ]
+    - any-glob-to-any-file:
+        - "auron-core/**"
 
 common:
   - changed-files:
-    - any-glob-to-any-file: [
-        "common/**"
-      ]
+    - any-glob-to-any-file:
+        - "common/**"
 
 native:
   - changed-files:
-    - any-glob-to-any-file: [
-        "native-engine/**"
-      ]
+    - any-glob-to-any-file:
+        - "native-engine/**"
 
 hadoop:
   - changed-files:
-    - any-glob-to-any-file: [
-        "hadoop-shim/**"
-      ]
+    - any-glob-to-any-file:
+        - "hadoop-shim/**"
 
 spark:
   - changed-files:
-    - any-glob-to-any-file: [
-        "spark-extension/**",
-        "spark-extension-shims-spark/**",
-        "spark-version-annotation-macros/**"
-      ]
+    - any-glob-to-any-file:
+        - "spark-extension/**"
+        - "spark-extension-shims-spark/**"
+        - "spark-version-annotation-macros/**"
 
 spark-ui:
   - changed-files:
-    - any-glob-to-any-file: [
-        "auron-spark-ui/**"
-      ]
+    - any-glob-to-any-file:
+        - "auron-spark-ui/**"
 
 spark-tests:
   - changed-files:
-    - any-glob-to-any-file: [
-        "auron-spark-tests/**"
-      ]
+    - any-glob-to-any-file:
+        - "auron-spark-tests/**"
 
 flink:
   - changed-files:
-    - any-glob-to-any-file: [
-        "auron-flink-extension/**"
-      ]
+    - any-glob-to-any-file:
+        - "auron-flink-extension/**"
 
 thirdparty-celeborn:
   - changed-files:
-    - any-glob-to-any-file: [
-        "thirdparty/auron-celeborn-*/**"
-      ]
+    - any-glob-to-any-file:
+        - "thirdparty/auron-celeborn-*/**"
 
 thirdparty-uniffle:
   - changed-files:
-    - any-glob-to-any-file: [
-        "thirdparty/auron-uniffle/**"
-      ]
+    - any-glob-to-any-file:
+        - "thirdparty/auron-uniffle/**"
 
 thirdparty-paimon:
   - changed-files:
-    - any-glob-to-any-file: [
-        "thirdparty/auron-paimon/**"
-      ]
+    - any-glob-to-any-file:
+        - "thirdparty/auron-paimon/**"
 
 thirdparty-iceberg:
   - changed-files:
-    - any-glob-to-any-file: [
-        "thirdparty/auron-iceberg/**"
-      ]
+    - any-glob-to-any-file:
+        - "thirdparty/auron-iceberg/**"
 
 dev-tools:
   - changed-files:
-    - any-glob-to-any-file: [
-        "dev/**",
-        ".idea/**"
-      ]
+    - any-glob-to-any-file:
+        - "dev/**"
+        - ".idea/**"
 
 benchmark:
   - changed-files:
-    - any-glob-to-any-file: [
-        "benchmark-results/**"
-      ]
+    - any-glob-to-any-file:
+        - "benchmark-results/**"


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2413.

# Rationale for this change

#2410 bumped `actions/labeler` from v6 to v7, which brought `js-yaml` `^5.1.0`. js-yaml 5.x enforces stricter indentation on multi-line flow sequences and rejects the current `.github/labeler.yml` with `YAMLException: deficient indentation (27:7)`, so the `triage` check now fails on PRs that run after that bump.

# What changes are included in this PR?

Rewrite the glob lists in `.github/labeler.yml` from multi-line flow sequences (`[ ... ]`) to block sequences, for all 17 label entries. The label names and glob patterns are unchanged; only the YAML list style changes.

Verified with `js-yaml` 5.2.1 (the version labeler v7 resolves): the current file throws `deficient indentation (27:7)`, and the updated file parses cleanly into the same 17 labels and 36 glob patterns.

# Are there any user-facing changes?

No. This is a CI configuration fix.

# How was this patch tested?

Loaded both the old and new `.github/labeler.yml` with `js-yaml` 5.2.1. The old file reproduces the CI error; the new file parses without error and yields identical label-to-glob mappings.

# Note

The `triage` check on this PR is expected to fail until this is merged. The labeler workflow runs on `pull_request_target` and reads `.github/labeler.yml` from the base branch (master), not from the PR, so it still sees the current file until the fix lands on master.
