### PR TITLE
[AURON #2440] Consolidate Maven properties and format code

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,8 @@
     <javaVersion>8</javaVersion>
     <maven.compiler.source>${javaVersion}</maven.compiler.source>
     <maven.compiler.target>${javaVersion}</maven.compiler.target>
+    <semanticdb.version>4.14.5</semanticdb.version>
+    <scalafmtVersion>3.9.9</scalafmtVersion>
     <scalaVersion>2.12</scalaVersion>
     <scalaLongVersion>2.12.18</scalaLongVersion>
     <scala-xml.version>2.1.0</scala-xml.version>
@@ -1162,8 +1164,6 @@
       <properties>
         <javaVersion>8</javaVersion>
         <spotless.plugin.version>2.30.0</spotless.plugin.version>
-        <semanticdb.version>4.14.5</semanticdb.version>
-        <scalafmtVersion>3.0.0</scalafmtVersion>
       </properties>
     </profile>
 
@@ -1175,8 +1175,6 @@
       <properties>
         <javaVersion>11</javaVersion>
         <spotless.plugin.version>2.30.0</spotless.plugin.version>
-        <semanticdb.version>4.14.5</semanticdb.version>
-        <scalafmtVersion>3.0.0</scalafmtVersion>
       </properties>
     </profile>
 
@@ -1188,8 +1186,6 @@
       <properties>
         <javaVersion>17</javaVersion>
         <spotless.plugin.version>2.45.0</spotless.plugin.version>
-        <semanticdb.version>4.14.5</semanticdb.version>
-        <scalafmtVersion>3.9.9</scalafmtVersion>
       </properties>
     </profile>
 
@@ -1201,8 +1197,6 @@
       <properties>
         <javaVersion>21</javaVersion>
         <spotless.plugin.version>2.45.0</spotless.plugin.version>
-        <semanticdb.version>4.14.5</semanticdb.version>
-        <scalafmtVersion>3.9.9</scalafmtVersion>
       </properties>
     </profile>
 

--- a/spark-extension/src/main/scala/org/apache/spark/sql/auron/AuronConverters.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/auron/AuronConverters.scala
@@ -509,7 +509,7 @@ object AuronConverters extends Logging {
           assert(
             !exec.requiredSchema.exists(e => existTimestampType(e.dataType)),
             s"Parquet scan with timestamp type is not supported for table: ${tableIdentifier
-              .getOrElse("unknown")}. " +
+                .getOrElse("unknown")}. " +
               "Set spark.auron.enable.scan.parquet.timestamp=true to enable timestamp support " +
               "or remove timestamp columns from the query.")
         }
@@ -520,7 +520,7 @@ object AuronConverters extends Logging {
           assert(
             !exec.requiredSchema.exists(e => existTimestampType(e.dataType)),
             s"ORC scan with timestamp type is not supported for tableIdentifier: ${tableIdentifier
-              .getOrElse("unknown")}. " +
+                .getOrElse("unknown")}. " +
               "Set spark.auron.enable.scan.orc.timestamp=true to enable timestamp support " +
               "or remove timestamp columns from the query.")
         }
@@ -528,7 +528,7 @@ object AuronConverters extends Logging {
       case p =>
         throw new NotImplementedError(
           s"Cannot convert FileSourceScanExec tableIdentifier: ${tableIdentifier.getOrElse(
-            "unknown")}, class: ${p.getClass.getName}")
+              "unknown")}, class: ${p.getClass.getName}")
     }
   }
 

--- a/spark-extension/src/main/scala/org/apache/spark/sql/auron/AuronSparkSessionExtension.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/auron/AuronSparkSessionExtension.scala
@@ -91,7 +91,7 @@ case class AuronColumnarOverrides(sparkSession: SparkSession) extends ColumnarRu
         dumpSimpleSparkPlanTreeNode(sparkPlanTransformed)
 
         logInfo(s"Transformed spark plan after preColumnarTransitions:\n${sparkPlanTransformed
-          .treeString(verbose = true, addSuffix = true)}")
+            .treeString(verbose = true, addSuffix = true)}")
 
         // post-transform
         Shims.get.postTransform(sparkPlanTransformed, sparkSession.sparkContext)

--- a/spark-extension/src/main/scala/org/apache/spark/sql/auron/NativeHelper.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/auron/NativeHelper.scala
@@ -74,7 +74,7 @@ object NativeHelper extends Logging {
     val heapMemory = Runtime.getRuntime.maxMemory()
     val offheapMemory = totalMemory - heapMemory
     logWarning(s"memory total: ${Utils.bytesToString(totalMemory)}, onheap: ${Utils.bytesToString(
-      heapMemory)}, offheap: ${Utils.bytesToString(offheapMemory)}")
+        heapMemory)}, offheap: ${Utils.bytesToString(offheapMemory)}")
     offheapMemory
   }
 

--- a/spark-extension/src/main/scala/org/apache/spark/sql/auron/util/TaskContextHelper.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/auron/util/TaskContextHelper.scala
@@ -47,7 +47,7 @@ object TaskContextHelper extends Logging {
     val thread = Thread.currentThread()
     val threadPrefix = if (context != null) {
       s"auron native task ${context.partitionId()}.${context.attemptNumber()} in stage ${context
-        .stageId()}.${context.stageAttemptNumber()} (TID ${context.taskAttemptId()})"
+          .stageId()}.${context.stageAttemptNumber()} (TID ${context.taskAttemptId()})"
     } else {
       "auron native task"
     }

--- a/thirdparty/auron-uniffle/src/main/scala/org/apache/spark/sql/execution/auron/shuffle/uniffle/AuronUniffleShuffleReader.scala
+++ b/thirdparty/auron-uniffle/src/main/scala/org/apache/spark/sql/execution/auron/shuffle/uniffle/AuronUniffleShuffleReader.scala
@@ -172,7 +172,7 @@ class AuronUniffleShuffleReader[K, C](
       }
       if (!emptyPartitionIds.isEmpty) {
         logDebug(s"Found ${emptyPartitionIds
-          .size()} empty shuffle partitions: ${emptyPartitionIds.asScala.mkString(",")}")
+            .size()} empty shuffle partitions: ${emptyPartitionIds.asScala.mkString(",")}")
       }
       iterators = shuffleDataIterList.iterator()
       if (iterators.hasNext) {


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2440

# Rationale for this change

 `./dev/reformat` produced different formatting results depending on the JDK used to run it. `pom.xml` selected `scalafmtVersion` based on the active JDK profile: `3.0.0` for `jdk-8`/`jdk-11`, and `3.9.9` for `jdk-17`/`jdk-21`. However, `scalafmt.conf` declares `version = 3.9.9`, so only the JDK 17/21 profiles actually matched the intended
  formatting rules.
  
As a result, running the formatter under JDK 8/11 vs JDK 17/21 produced different indentation for multi-line string interpolations (e.g. `.getOrElse(...)` continuation lines), causing spurious diffs in `git status` depending on which JDK happened to be active locally.

# What changes are included in this PR?

Unify `scalafmtVersion` to `3.9.9` across all `jdk-8`/`jdk-11`/`jdk-17`/`jdk-21` profiles, matching the version declared in `scalafmt.conf`.

# Are there any user-facing changes?
No

# How was this patch tested?
GHA

# Was this patch authored or co-authored using generative AI tooling?
- [ ] Yes
- [ ] No