### PR TITLE
[AURON #2439] Add git to yum install

### DIFF
--- a/.github/workflows/build-amd64-releases.yml
+++ b/.github/workflows/build-amd64-releases.yml
@@ -30,6 +30,7 @@ on:
     paths:
       - '.github/workflows/build-amd64-releases.yml'
       - 'auron-build.sh'
+      - 'dev/docker-build/centos7/Dockerfile'
 
 jobs:
   build-snapshot:

--- a/dev/docker-build/centos7/Dockerfile
+++ b/dev/docker-build/centos7/Dockerfile
@@ -30,7 +30,7 @@ RUN sed -i "s/^mirrorlist/#mirrorlist/g" /etc/yum.repos.d/*.repo
 RUN sed -i "s|^metalink=|#metalink=|g" /etc/yum.repos.d/epel.repo
 RUN sed -i "s|https://download.fedoraproject.org/pub/epel|https://archives.fedoraproject.org/pub/archive/epel|g" /etc/yum.repos.d/epel.repo
 RUN yum clean all && yum makecache
-RUN yum install -y libzip unzip openssl-devel
+RUN yum install -y libzip unzip openssl-devel git
 
 # install gcc-11
 RUN yum install -y devtoolset-11-gcc devtoolset-11-gcc-c++

--- a/dev/vendors/setup-vendors.sh
+++ b/dev/vendors/setup-vendors.sh
@@ -95,7 +95,7 @@ apply_patches() {
   for patch in "${patches[@]}"; do
     i=$((i + 1))
     echo "  [${i}/${#patches[@]}] $(basename "${patch}")"
-    git -C "${target_dir}" apply --3way "${patch}"
+    (cd "${target_dir}" && git apply --3way "${patch}")
   done
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2439

# Rationale for this change


https://github.com/apache/auron/actions/runs/30325123247/job/90213501717
```
build-release-1  | [ERROR] [mvn-builder-auron-core] ./dev/vendors/setup-vendors.sh: line 135: git: command not found
```

# What changes are included in this PR?

  1. `dev/docker-build/centos7/Dockerfile`: install `git` alongside the other build tools
     (it was previously missing entirely, causing `setup-vendors.sh` to fail with
     `git: command not found`).
  2. `dev/vendors/setup-vendors.sh`: replace `git -C "${target_dir}" apply --3way "${patch}"`
     with `(cd "${target_dir}" && git apply --3way "${patch}")`, so patch application no longer
     depends on a git version >= 1.8.5.
  3. `.github/workflows/build-amd64-releases.yml`: add `dev/docker-build/centos7/Dockerfile` to
     the `paths` trigger list so changes to the build image are validated by this workflow on PRs.

# Are there any user-facing changes?
No

# How was this patch tested?
GHA

# Was this patch authored or co-authored using generative AI tooling?
- [ ] Yes
- [ ] No

