### PR TITLE
[AURON #2444] Add build branch and build reversion info

### DIFF
--- a/.github/workflows/build-amd64-releases.yml
+++ b/.github/workflows/build-amd64-releases.yml
@@ -143,6 +143,8 @@ jobs:
       - name: Build auron-${{ matrix.sparkver }}_${{ matrix.scalaver }}
         env:
           AURON_JAVA_VERSION: ${{ matrix.javaver }}
+          AURON_BUILD_BRANCH: ${{ github.head_ref || github.ref_name }}
+          AURON_BUILD_REVISION: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
           sed -i 's/docker-compose -f/docker compose -f/g' ./auron-build.sh
           ./auron-build.sh \

--- a/.github/workflows/build-arm-releases.yml
+++ b/.github/workflows/build-arm-releases.yml
@@ -118,8 +118,12 @@ jobs:
           AURON_BUILD_REVISION: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
           rm -f .build-checksum_*.cache
-          build/mvn package -Prelease -P${{ matrix.sparkver }} -Pscala-${{ matrix.scalaver }} -DskipTests
-
+          SPARK_VERSION="${{ matrix.sparkver }}"
+          SPARK_VERSION="${SPARK_VERSION#spark-}"
+          ./auron-build.sh \
+            --release \
+            --sparkver "$SPARK_VERSION" \
+            --scalaver ${{ matrix.scalaver }}
       - name: Upload auron-${{ matrix.sparkver }}_${{ matrix.scalaver }}
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/build-arm-releases.yml
+++ b/.github/workflows/build-arm-releases.yml
@@ -113,6 +113,9 @@ jobs:
         run: echo "short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
       - name: Build auron-${{ matrix.sparkver }}_${{ matrix.scalaver }}
+        env:
+          AURON_BUILD_BRANCH: ${{ github.head_ref || github.ref_name }}
+          AURON_BUILD_REVISION: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
           rm -f .build-checksum_*.cache
           build/mvn package -Prelease -P${{ matrix.sparkver }} -Pscala-${{ matrix.scalaver }} -DskipTests

--- a/.github/workflows/build-macos-releases.yml
+++ b/.github/workflows/build-macos-releases.yml
@@ -121,6 +121,9 @@ jobs:
         run: echo "short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
       - name: Build auron-${{ matrix.sparkver }}_${{ matrix.scalaver }}
+        env:
+          AURON_BUILD_BRANCH: ${{ github.head_ref || github.ref_name }}
+          AURON_BUILD_REVISION: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
           ./auron-build.sh \
           --release \

--- a/.github/workflows/tpcds-reusable.yml
+++ b/.github/workflows/tpcds-reusable.yml
@@ -118,6 +118,9 @@ jobs:
             cargo
 
       - name: Build auron (Spark ${{ inputs.sparkver }}, Scala ${{ inputs.scalaver }}, JDK ${{ inputs.javaver }})
+        env:
+          AURON_BUILD_BRANCH: ${{ github.head_ref || github.ref_name }}
+          AURON_BUILD_REVISION: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
           rm -f .build-checksum_*.cache
           

--- a/auron-build.sh
+++ b/auron-build.sh
@@ -69,6 +69,10 @@ print_help() {
 
     echo "  -h, --help               Show this help message"
     echo
+    echo "Environment variables:"
+    echo "  AURON_BUILD_BRANCH       Override detected Git branch in generated build info"
+    echo "  AURON_BUILD_REVISION     Override detected Git revision in generated build info"
+    echo
     echo "Examples:"
     echo "  $0 --pre --sparkver ${SUPPORTED_SPARK_VERSIONS[*]: -1}" \
          "--scalaver ${SUPPORTED_SCALA_VERSIONS[*]: -1} -DskipBuildNative"
@@ -529,8 +533,8 @@ mkdir -p "$(dirname "$BUILD_INFO_FILE")"
 JAVA_VERSION=$(java -version 2>&1 | head -n 1 | awk '{print $3}' | tr -d '"')
 PROJECT_VERSION=$(./build/mvn help:evaluate -N -Dexpression=project.version -Pspark-${SPARK_VER} -q -DforceStdout 2>/dev/null)
 RUST_VERSION=$(rustc --version | awk '{print $2}')
-BUILD_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
-BUILD_REVISION=$(git rev-parse HEAD 2>/dev/null)
+BUILD_BRANCH="${AURON_BUILD_BRANCH:-$(git rev-parse --abbrev-ref HEAD 2>/dev/null)}"
+BUILD_REVISION="${AURON_BUILD_REVISION:-$(git rev-parse HEAD 2>/dev/null)}"
 
 get_build_info() {
   case "$1" in
@@ -606,6 +610,8 @@ if [[ "$USE_DOCKER" == true ]]; then
 
     echo "[INFO] Compiling inside Docker container..."
     export AURON_BUILD_ARGS="${BUILD_ARGS[*]}"
+    export AURON_BUILD_BRANCH="${BUILD_BRANCH}"
+    export AURON_BUILD_REVISION="${BUILD_REVISION}"
     export BUILD_CONTEXT="./${IMAGE_NAME}"
     # Spark 4.x requires JDK 17+, auto-set if not specified
     if [[ -z "$AURON_JAVA_VERSION" && "$SPARK_VER" == 4.* ]]; then

--- a/auron-build.sh
+++ b/auron-build.sh
@@ -529,6 +529,8 @@ mkdir -p "$(dirname "$BUILD_INFO_FILE")"
 JAVA_VERSION=$(java -version 2>&1 | head -n 1 | awk '{print $3}' | tr -d '"')
 PROJECT_VERSION=$(./build/mvn help:evaluate -N -Dexpression=project.version -Pspark-${SPARK_VER} -q -DforceStdout 2>/dev/null)
 RUST_VERSION=$(rustc --version | awk '{print $2}')
+BUILD_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+BUILD_REVISION=$(git rev-parse HEAD 2>/dev/null)
 
 get_build_info() {
   case "$1" in
@@ -543,6 +545,8 @@ get_build_info() {
     "flink.version") echo "${FLINK_VER}" ;;
     "iceberg.version") echo "${ICEBERG_VER}" ;;
     "hudi.version") echo "${HUDI_VER}" ;;
+    "build.branch") echo "${BUILD_BRANCH}" ;;
+    "build.revision") echo "${BUILD_REVISION}" ;;
     "build.timestamp") echo "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" ;;
     *) echo "" ;;
   esac
@@ -560,6 +564,8 @@ for key in \
   "paimon.version" \
   "flink.version" \
   "iceberg.version" \
+  "build.branch" \
+  "build.revision" \
   "build.timestamp"; do
   value="$(get_build_info "$key")"
   if [[ -n "$value" ]]; then

--- a/common/src/main/scala/org/apache/auron/common/AuronBuildInfo.scala
+++ b/common/src/main/scala/org/apache/auron/common/AuronBuildInfo.scala
@@ -50,6 +50,8 @@ object AuronBuildInfo {
   val UNIFFLE_VERSION_STRING: String = "Uniffle Version"
   val PAIMON_VERSION_STRING: String = "Paimon Version"
   val ICEBERG_VERSION_STRING: String = "Iceberg Version"
+  val BUILD_BRANCH_STRING: String = "Build Branch"
+  val BUILD_REVISION_STRING: String = "Build Revision"
   val BUILD_DATE_STRING: String = "Build Timestamp"
 
   val VERSION: String = props.getProperty("project.version", unknown)
@@ -62,5 +64,7 @@ object AuronBuildInfo {
   val PAIMON_VERSION: String = props.getProperty("paimon.version", unknown)
   val ICEBERG_VERSION: String = props.getProperty("iceberg.version", unknown)
   val FLINK_VERSION: String = props.getProperty("flink.version", unknown)
+  val BUILD_BRANCH: String = props.getProperty("build.branch", unknown)
+  val BUILD_REVISION: String = props.getProperty("build.revision", unknown)
   val BUILD_DATE: String = props.getProperty("build.timestamp", unknown)
 }

--- a/dev/docker-build/docker-compose.yml
+++ b/dev/docker-build/docker-compose.yml
@@ -33,6 +33,8 @@ services:
     environment:
       RUSTFLAGS: "-C target-cpu=skylake"
       AURON_BUILD_ARGS: "${AURON_BUILD_ARGS}"
+      AURON_BUILD_BRANCH: "${AURON_BUILD_BRANCH}"
+      AURON_BUILD_REVISION: "${AURON_BUILD_REVISION}"
       AURON_JAVA_VERSION: "${AURON_JAVA_VERSION:-8}"
     command: >
       bash -c '

--- a/spark-extension-shims-spark/src/main/scala/org/apache/spark/sql/auron/ShimsImpl.scala
+++ b/spark-extension-shims-spark/src/main/scala/org/apache/spark/sql/auron/ShimsImpl.scala
@@ -201,6 +201,8 @@ class ShimsImpl extends Shims with Logging {
     auronBuildInfo.put(AuronBuildInfo.PAIMON_VERSION_STRING, AuronBuildInfo.PAIMON_VERSION)
     auronBuildInfo.put(AuronBuildInfo.ICEBERG_VERSION_STRING, AuronBuildInfo.ICEBERG_VERSION)
     auronBuildInfo.put(AuronBuildInfo.FLINK_VERSION_STRING, AuronBuildInfo.FLINK_VERSION)
+    auronBuildInfo.put(AuronBuildInfo.BUILD_BRANCH_STRING, AuronBuildInfo.BUILD_BRANCH)
+    auronBuildInfo.put(AuronBuildInfo.BUILD_REVISION_STRING, AuronBuildInfo.BUILD_REVISION)
     auronBuildInfo.put(AuronBuildInfo.BUILD_DATE_STRING, AuronBuildInfo.BUILD_DATE)
     auronBuildInfo.retain { case (_, v) => v != null && v.nonEmpty }
     val event = AuronBuildInfoEvent(auronBuildInfo)


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2444

# Rationale for this change
Auron build information currently includes component versions and build timestamp, but it does not identify the Git branch or commit used to produce the artifact. This makes it harder to trace a running application or built package back to the exact source revision.

# What changes are included in this PR?

This PR adds Git branch and revision information to the Auron build info file.

# Are there any user-facing changes?
No.
# How was this patch tested?
Rebuild
# Was this patch authored or co-authored using generative AI tooling?
- [ ] Yes
- [x] No
