### PR TITLE
[AURON #2449] Add fallback coverage for unsupported Paimon scan data type

### DIFF
--- a/thirdparty/auron-paimon/src/test/scala/org/apache/auron/paimon/AuronPaimonV2IntegrationSuite.scala
+++ b/thirdparty/auron-paimon/src/test/scala/org/apache/auron/paimon/AuronPaimonV2IntegrationSuite.scala
@@ -406,7 +406,8 @@ class AuronPaimonV2IntegrationSuite
 
   test("paimon v2 native scan falls back for unsupported data types") {
     withTable("paimon.db.t_unsupported_type") {
-      sql("create table paimon.db.t_unsupported_type (id int, amount decimal(38, 10)) using paimon")
+      sql(
+        "create table paimon.db.t_unsupported_type (id int, amount decimal(38, 10)) using paimon")
       sql(
         "insert into paimon.db.t_unsupported_type values " +
           "(1, cast(123.45 as decimal(38, 10)))")

--- a/thirdparty/auron-paimon/src/test/scala/org/apache/auron/paimon/AuronPaimonV2IntegrationSuite.scala
+++ b/thirdparty/auron-paimon/src/test/scala/org/apache/auron/paimon/AuronPaimonV2IntegrationSuite.scala
@@ -404,6 +404,20 @@ class AuronPaimonV2IntegrationSuite
     }
   }
 
+  test("paimon v2 native scan falls back for unsupported data types") {
+    withTable("paimon.db.t_unsupported_type") {
+      sql("create table paimon.db.t_unsupported_type (id int, amount decimal(38, 10)) using paimon")
+      sql(
+        "insert into paimon.db.t_unsupported_type values " +
+          "(1, cast(123.45 as decimal(38, 10)))")
+
+      val df = sql("select * from paimon.db.t_unsupported_type")
+      checkAnswer(df, Seq(Row(1, new java.math.BigDecimal("123.4500000000"))))
+      val plan = df.queryExecution.executedPlan.toString()
+      assert(!plan.contains("NativePaimonV2TableScan"))
+    }
+  }
+
   private def assertNativePaimonScanApplied(df: DataFrame): Unit = {
     val plan = df.queryExecution.executedPlan.toString()
     assert(


### PR DESCRIPTION
**Which issue does this PR close?**

Closes #2449 

**Rationale for this change**

Paimon native scan currently falls back when the read schema contains unsupported
data types, but this behavior was not covered by the integration tests.

Adding this regression test ensures unsupported decimal types continue to use the
Spark fallback path and do not enter native Paimon execution accidentally.

**What changes are included in this PR?**

Adds a Paimon integration test for an unsupported `decimal(38,10)` column.

The test:

- Writes a row using the unsupported decimal type.
- Verifies that Spark returns the expected result.
- Verifies that the executed plan does not contain `NativePaimonV2TableScan`.

No execution logic or user-facing behavior is changed.

**Are there any user-facing changes?**

No user-facing changes.

**How was this patch tested?**

UT.