### PR TITLE
[AURON #2451] Add Paimon COW multi-commit correctness coverage

### DIFF
--- a/thirdparty/auron-paimon/src/test/scala/org/apache/auron/paimon/AuronPaimonV2IntegrationSuite.scala
+++ b/thirdparty/auron-paimon/src/test/scala/org/apache/auron/paimon/AuronPaimonV2IntegrationSuite.scala
@@ -143,7 +143,7 @@ class AuronPaimonV2IntegrationSuite
     }
   }
 
-  test("paimon v2 COW primary-key table preserves latest value across commits") {
+  test("paimon v2 native scan preserves latest COW value after compaction") {
     withTable("paimon.db.t_cow_multi_commit") {
       sql("""
             |create table paimon.db.t_cow_multi_commit (id int, v string)
@@ -156,6 +156,7 @@ class AuronPaimonV2IntegrationSuite
             |""".stripMargin)
       sql("insert into paimon.db.t_cow_multi_commit values (1, 'a'), (2, 'b')")
       sql("insert into paimon.db.t_cow_multi_commit values (1, 'updated')")
+      sql("CALL paimon.sys.compact(table => 'db.t_cow_multi_commit')")
       val df = sql("select * from paimon.db.t_cow_multi_commit")
       checkAnswer(df, Seq(Row(1, "updated"), Row(2, "b")))
       assertNativePaimonScanApplied(df)

--- a/thirdparty/auron-paimon/src/test/scala/org/apache/auron/paimon/AuronPaimonV2IntegrationSuite.scala
+++ b/thirdparty/auron-paimon/src/test/scala/org/apache/auron/paimon/AuronPaimonV2IntegrationSuite.scala
@@ -143,6 +143,24 @@ class AuronPaimonV2IntegrationSuite
     }
   }
 
+  test("paimon v2 COW primary-key table preserves latest value across commits") {
+    withTable("paimon.db.t_cow_multi_commit") {
+      sql("""
+            |create table paimon.db.t_cow_multi_commit (id int, v string)
+            |using paimon
+            |tblproperties (
+            |  'primary-key' = 'id',
+            |  'bucket' = '2',
+            |  'full-compaction.delta-commits' = '1'
+            |)
+            |""".stripMargin)
+      sql("insert into paimon.db.t_cow_multi_commit values (1, 'a'), (2, 'b')")
+      sql("insert into paimon.db.t_cow_multi_commit values (1, 'updated')")
+      val df = sql("select * from paimon.db.t_cow_multi_commit")
+      checkAnswer(df, Seq(Row(1, "updated"), Row(2, "b")))
+    }
+  }
+
   test("paimon v2 native scan handles empty table") {
     withTable("paimon.db.t_empty") {
       sql("create table paimon.db.t_empty (id int, v string) using paimon")

--- a/thirdparty/auron-paimon/src/test/scala/org/apache/auron/paimon/AuronPaimonV2IntegrationSuite.scala
+++ b/thirdparty/auron-paimon/src/test/scala/org/apache/auron/paimon/AuronPaimonV2IntegrationSuite.scala
@@ -158,6 +158,7 @@ class AuronPaimonV2IntegrationSuite
       sql("insert into paimon.db.t_cow_multi_commit values (1, 'updated')")
       val df = sql("select * from paimon.db.t_cow_multi_commit")
       checkAnswer(df, Seq(Row(1, "updated"), Row(2, "b")))
+      assertNativePaimonScanApplied(df)
     }
   }
 


### PR DESCRIPTION
**Which issue does this PR close?**

Closes #2451 

**Rationale for this change**

The existing Paimon COW test verifies only a single commit. It does not protect against stale rows being returned after a later commit updates an existing primary key.

This change adds multi-commit correctness coverage while keeping the native scan implementation unchanged.

**What changes are included in this PR?**

Updates the existing Paimon COW primary-key integration test to:

- Write the initial rows.
- Write a newer value for an existing primary key in a second commit.
- Verify that only the latest value is returned.
- Verify that the query still uses `NativePaimonV2TableScan`.

**Are there any user-facing changes?**

No user-facing changes.

**How was this patch tested?**

UT.