### PR TITLE
[AURON #2457] Fix per-partition job submission in NativeCollectLimit

### DIFF
--- a/spark-extension-shims-spark/src/test/scala/org/apache/auron/exec/AuronExecSuite.scala
+++ b/spark-extension-shims-spark/src/test/scala/org/apache/auron/exec/AuronExecSuite.scala
@@ -24,6 +24,7 @@ import org.apache.spark.sql.catalyst.expressions.WindowExpression
 import org.apache.spark.sql.catalyst.expressions.WindowSpecDefinition
 import org.apache.spark.sql.execution.auron.plan.{NativeCollectLimitExec, NativeGlobalLimitExec, NativeLocalLimitExec, NativeTakeOrderedExec}
 import org.apache.spark.sql.execution.auron.plan.NativeWindowExec
+import org.apache.spark.sql.internal.SQLConf
 
 import org.apache.auron.BaseAuronSQLSuite
 import org.apache.auron.util.AuronTestUtils
@@ -39,6 +40,34 @@ class AuronExecSuite extends AuronQueryTest with BaseAuronSQLSuite {
         assert(collectFirst(df.queryExecution.executedPlan) { case e: NativeCollectLimitExec =>
           e
         }.isDefined)
+      }
+    }
+  }
+
+  test("CollectLimit batches partition scans") {
+    withTempPath { path =>
+      spark.range(8).repartition(8).write.parquet(path.getCanonicalPath)
+
+      withSQLConf(
+        SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false",
+        "spark.sql.files.maxPartitionBytes" -> "4096",
+        "spark.sql.limit.initialNumPartitions" -> "100") {
+        val df = spark.read.parquet(path.getCanonicalPath).where("id < 0").limit(1)
+        val collectLimit = collectFirst(df.queryExecution.executedPlan) {
+          case exec: NativeCollectLimitExec => exec
+        }.get
+        val numPartitions = collectLimit.child.execute().getNumPartitions
+        assert(numPartitions > 1 && numPartitions <= 100)
+
+        val jobGroup = s"collect-limit-${System.nanoTime()}"
+        spark.sparkContext.setJobGroup(jobGroup, "test CollectLimit job count")
+        try {
+          assert(collectLimit.executeCollect().isEmpty)
+          val jobCount = spark.sparkContext.statusTracker.getJobIdsForGroup(jobGroup).length
+          assert(jobCount < numPartitions)
+        } finally {
+          spark.sparkContext.clearJobGroup()
+        }
       }
     }
   }

--- a/spark-extension-shims-spark/src/test/scala/org/apache/auron/exec/AuronExecSuite.scala
+++ b/spark-extension-shims-spark/src/test/scala/org/apache/auron/exec/AuronExecSuite.scala
@@ -51,7 +51,7 @@ class AuronExecSuite extends AuronQueryTest with BaseAuronSQLSuite {
       withSQLConf(
         SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false",
         "spark.sql.files.maxPartitionBytes" -> "4096",
-        "spark.sql.limit.initialNumPartitions" -> "100") {
+        "spark.sql.limit.initialNumPartitions" -> "1") {
         val df = spark.read.parquet(path.getCanonicalPath).where("id < 0").limit(1)
         val collectLimit = collectFirst(df.queryExecution.executedPlan) {
           case exec: NativeCollectLimitExec => exec
@@ -63,8 +63,9 @@ class AuronExecSuite extends AuronQueryTest with BaseAuronSQLSuite {
         spark.sparkContext.setJobGroup(jobGroup, "test CollectLimit job count")
         try {
           assert(collectLimit.executeCollect().isEmpty)
+          waitUntilListenerBusEmpty()
           val jobCount = spark.sparkContext.statusTracker.getJobIdsForGroup(jobGroup).length
-          assert(jobCount < numPartitions)
+          assert(jobCount > 0 && jobCount < numPartitions)
         } finally {
           spark.sparkContext.clearJobGroup()
         }

--- a/spark-extension-shims-spark/src/test/scala/org/apache/auron/exec/AuronExecSuite.scala
+++ b/spark-extension-shims-spark/src/test/scala/org/apache/auron/exec/AuronExecSuite.scala
@@ -46,7 +46,7 @@ class AuronExecSuite extends AuronQueryTest with BaseAuronSQLSuite {
 
   test("CollectLimit batches partition scans") {
     withTempPath { path =>
-      spark.range(8).repartition(8).write.parquet(path.getCanonicalPath)
+      spark.range(0, 80, 1, 8).write.parquet(path.getCanonicalPath)
 
       withSQLConf(
         SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false",

--- a/spark-extension-shims-spark/src/test/scala/org/apache/auron/exec/AuronExecSuite.scala
+++ b/spark-extension-shims-spark/src/test/scala/org/apache/auron/exec/AuronExecSuite.scala
@@ -57,7 +57,7 @@ class AuronExecSuite extends AuronQueryTest with BaseAuronSQLSuite {
           case exec: NativeCollectLimitExec => exec
         }.get
         val numPartitions = collectLimit.child.execute().getNumPartitions
-        assert(numPartitions > 1 && numPartitions <= 100)
+        assert(numPartitions > 1)
 
         val jobGroup = s"collect-limit-${System.nanoTime()}"
         spark.sparkContext.setJobGroup(jobGroup, "test CollectLimit job count")

--- a/spark-extension-shims-spark/src/test/scala/org/apache/spark/sql/AuronQueryTest.scala
+++ b/spark-extension-shims-spark/src/test/scala/org/apache/spark/sql/AuronQueryTest.scala
@@ -93,4 +93,8 @@ abstract class AuronQueryTest
       true
     case _ => false
   }
+
+  protected def waitUntilListenerBusEmpty(): Unit = {
+    spark.sparkContext.listenerBus.waitUntilEmpty()
+  }
 }

--- a/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeCollectLimitBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeCollectLimitBase.scala
@@ -17,7 +17,6 @@
 package org.apache.spark.sql.execution.auron.plan
 
 import scala.collection.mutable
-import scala.collection.mutable.ArrayBuffer
 
 import org.apache.spark.OneToOneDependency
 import org.apache.spark.sql.auron.{NativeHelper, NativeRDD, NativeSupports, Shims}
@@ -43,15 +42,7 @@ abstract class NativeCollectLimitBase(limit: Int, offset: Int, override val chil
 
   override def executeCollect(): Array[InternalRow] = {
     val partial = Shims.get.createNativeLocalLimitExec(limit, child)
-    val buf = new ArrayBuffer[InternalRow]
-
-    // collect rows partition-by-partition up to 'limit', avoiding full-partition collect.
-    val it = partial.execute().toLocalIterator
-    while (buf.size < limit && it.hasNext) {
-      val row = it.next().copy()
-      buf += row
-    }
-    val rows = buf.toArray
+    val rows = partial.executeTake(limit)
     if (offset > 0) rows.drop(offset) else rows
   }
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2457

# Rationale for this change

`NativeCollectLimitBase.executeCollect()` currently uses `toLocalIterator`, which submits a separate Spark job for every scanned partition.

For empty or highly selective inputs, this can produce many unnecessary jobs and make driver-side scheduling dominate query execution.

# What changes are included in this PR?

- Replace the `toLocalIterator` collection loop with `executeTake`.
- Add a regression test to verify that partitions are scanned in batches.

# Are there any user-facing changes?

Queries over empty or sparse partitions may submit fewer Spark jobs.

# How was this patch tested?

Added a regression test to `AuronExecSuite`.

# Was this patch authored or co-authored using generative AI tooling?
- [x] Yes
- [ ] No

If yes, include: `Generated-by: GPT-5`

ASF guidance: https://www.apache.org/legal/generative-tooling.html
