### PR TITLE
[AURON #2459] Resolve build info paths relative to auron-build.sh

### DIFF
--- a/auron-build.sh
+++ b/auron-build.sh
@@ -150,7 +150,8 @@ run_docker_compose_up() {
     exit 1
 }
 
-MVN_CMD="$(dirname "$0")/build/mvn"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MVN_CMD="$SCRIPT_DIR/build/mvn"
 
 # -----------------------------------------------------------------------------
 # Section: Initialize Variables
@@ -523,11 +524,20 @@ MVN_ARGS=("${CLEAN_ARGS[@]}" "${BUILD_ARGS[@]}")
 # Description:
 #   Generate auron-build-info.properties for build metadata tracking.
 # -----------------------------------------------------------------------------
-BUILD_INFO_FILE="common/src/main/resources/auron-build-info.properties"
+BUILD_INFO_FILE="$SCRIPT_DIR/common/src/main/resources/auron-build-info.properties"
 mkdir -p "$(dirname "$BUILD_INFO_FILE")"
 
 JAVA_VERSION=$(java -version 2>&1 | head -n 1 | awk '{print $3}' | tr -d '"')
-PROJECT_VERSION=$(./build/mvn help:evaluate -N -Dexpression=project.version -Pspark-${SPARK_VER} -q -DforceStdout 2>/dev/null)
+MVN_STDERR=$(mktemp)
+if ! PROJECT_VERSION=$("$MVN_CMD" help:evaluate -N -f "$SCRIPT_DIR/pom.xml" -Dexpression=project.version -Pspark-${SPARK_VER} -q -DforceStdout 2>"$MVN_STDERR") \
+   || [[ ! "$PROJECT_VERSION" =~ ^[A-Za-z0-9._-]+$ ]]; then
+  echo "[ERROR] Failed to resolve project.version using $MVN_CMD" >&2
+  [[ -n "$PROJECT_VERSION" ]] && echo "[ERROR] stdout was: $PROJECT_VERSION" >&2
+  sed 's/^/[ERROR] /' "$MVN_STDERR" >&2
+  rm -f "$MVN_STDERR"
+  exit 1
+fi
+rm -f "$MVN_STDERR"
 RUST_VERSION=$(rustc --version | awk '{print $2}')
 
 get_build_info() {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fixes #2459.

`auron-build.sh` resolved both the build info file and the Maven used to look up `project.version` relative to the caller's working directory. Run from anywhere other than the project root, it wrote `auron-build-info.properties` outside the project so the build never picked it up, and left `project.version` out of the file entirely because the lookup failed into `/dev/null` and empty values are skipped by the writing loop.

Three changes:

- Resolve `SCRIPT_DIR` from `BASH_SOURCE` and use it for `BUILD_INFO_FILE`, so the file always lands in the project.
- Use the already resolved `MVN_CMD` instead of a hardcoded `./build/mvn`.
- Pass `-f "$SCRIPT_DIR/pom.xml"` so Maven reads the project pom, and fail with the captured Maven output when the version cannot be resolved.

The `-f` part is worth calling out. Without it, `help:evaluate` run from another directory does not fail; Maven falls back to its synthetic standalone pom and reports version `1`, so the jar gets a plausible but wrong version. Pinning the pom and validating the result covers that.

## How was this patch tested?

Manually, on Spark 3.1 / Scala 2.12.

Before, from a directory outside the project, `project.version` is missing and the file is written to the wrong place:

```
$ cd /tmp/elsewhere && bash /path/to/auron/auron-build.sh --release --sparkver 3.1 --scalaver 2.12
[INFO] Build configuration (from common/src/main/resources/auron-build-info.properties):
[INFO]   spark.version : 3.1
[INFO]   scala.version : 2.12
[INFO]   build.timestamp : 2026-08-08T23:32:59Z
auron-build.sh: line 611: /tmp/elsewhere/build/mvn: No such file or directory
```

After, from the same directory:

```
[INFO] Build configuration (from /path/to/auron/common/src/main/resources/auron-build-info.properties):
[INFO]   spark.version : 3.1
[INFO]   rust.version : 1.97.1
[INFO]   java.version : 17.0.19
[INFO]   project.version : 9.0.0-SNAPSHOT
[INFO]   scala.version : 2.12
[INFO]   build.timestamp : 2026-08-10T05:07:19Z
```

Also checked:

- Running from the project root is unchanged.
- Nothing is written into the caller's directory any more.
- With an unresolvable Maven the script now exits 1 and prints the Maven output, instead of continuing and producing a jar with no version.
