### PR TITLE
[AURON #2460] Add --mvn, --goal and -- passthrough to auron-build.sh

### DIFF
--- a/auron-build.sh
+++ b/auron-build.sh
@@ -46,8 +46,10 @@ SUPPORTED_HUDI_VERSIONS=("0.15")
 #   Print script usage information, supported options, and example commands.
 # -----------------------------------------------------------------------------
 print_help() {
-    echo "Usage: $0 [OPTIONS] <maven build options>"
+    echo "Usage: $0 [OPTIONS] [--] <maven build options>"
     echo "Build Auron project with specified Maven profiles"
+    echo
+    echo "Any arguments after -- are passed to Maven unchanged."
     echo
     echo "Options:"
     echo "  --pre                    Activate pre-release profile"
@@ -57,6 +59,8 @@ print_help() {
     echo "  --sparktests <true|false> Run spark tests (default: false)"
     echo "  --docker <true|false>    Build in Docker environment (default: false)"
     echo "  --threads <N|NC>         Maven build threads (e.g. 1, 4, 1C). Default: local unset, docker 8"
+    echo "  --mvn <PATH>             Maven executable to build with (default: build/mvn, which downloads Maven)"
+    echo "  --goal <GOAL>            Maven goal to run, e.g. package or install (default: install)"
     IFS=','; echo "  --image <NAME>           Docker image to use (e.g. ${SUPPORTED_OS_IMAGES[*]}, default: ${SUPPORTED_OS_IMAGES[*]:0:1})"; unset IFS
     IFS=','; echo "  --sparkver <VERSION>     Specify Spark version (e.g. ${SUPPORTED_SPARK_VERSIONS[*]})"; unset IFS
     IFS=','; echo "  --flinkver <VERSION>     Specify Flink version (e.g. ${SUPPORTED_FLINK_VERSIONS[*]})"; unset IFS
@@ -163,6 +167,7 @@ PRE_PROFILE=false
 RELEASE_PROFILE=false
 CLEAN=true
 SKIP_TESTS=true
+MVN_GOAL="install"
 SPARK_TESTS=false
 THREADS=""
 SPARK_VER=""
@@ -375,8 +380,33 @@ while [[ $# -gt 0 ]]; do
                 exit 1
             fi
             ;;
+        --mvn)
+            if [[ -n "$2" && "$2" != -* ]]; then
+                if ! MVN_CMD="$(command -v "$2")"; then
+                    echo "ERROR: --mvn '$2' is not an executable or a command on PATH" >&2
+                    exit 1
+                fi
+                shift 2
+            else
+                echo "ERROR: Missing argument for --mvn, specify a path to a Maven executable" >&2
+                exit 1
+            fi
+            ;;
+        --goal)
+            if [[ -n "$2" && "$2" != -* ]]; then
+                MVN_GOAL="$2"
+                shift 2
+            else
+                echo "ERROR: Missing argument for --goal, specify a Maven goal such as package or install" >&2
+                exit 1
+            fi
+            ;;
         -h|--help)
             print_help
+            ;;
+        --)
+            shift
+            break
             ;;
         --*)
             echo "ERROR: Unknown option '$1'" >&2
@@ -467,9 +497,9 @@ fi
 
 BUILD_ARGS=()
 if [[ "$SKIP_TESTS" == true ]]; then
-    BUILD_ARGS+=("install" "-DskipTests")
+    BUILD_ARGS+=("$MVN_GOAL" "-DskipTests")
 else
-    BUILD_ARGS+=("install")
+    BUILD_ARGS+=("$MVN_GOAL")
 fi
 
 if [[ "$SPARK_TESTS" == true ]]; then

--- a/auron-build.sh
+++ b/auron-build.sh
@@ -59,7 +59,8 @@ print_help() {
     echo "  --sparktests <true|false> Run spark tests (default: false)"
     echo "  --docker <true|false>    Build in Docker environment (default: false)"
     echo "  --threads <N|NC>         Maven build threads (e.g. 1, 4, 1C). Default: local unset, docker 8"
-    echo "  --mvn <PATH>             Maven executable to build with (default: build/mvn, which downloads Maven)"
+    echo "  --mvn <PATH>             Maven executable to build with, local builds only"
+    echo "                           (default: build/mvn, which downloads Maven)"
     echo "  --goal <GOAL>            Maven goal to run, e.g. package or install (default: install)"
     IFS=','; echo "  --image <NAME>           Docker image to use (e.g. ${SUPPORTED_OS_IMAGES[*]}, default: ${SUPPORTED_OS_IMAGES[*]:0:1})"; unset IFS
     IFS=','; echo "  --sparkver <VERSION>     Specify Spark version (e.g. ${SUPPORTED_SPARK_VERSIONS[*]})"; unset IFS
@@ -155,6 +156,7 @@ run_docker_compose_up() {
 }
 
 MVN_CMD="$(dirname "$0")/build/mvn"
+MVN_CMD_OVERRIDDEN=false
 
 # -----------------------------------------------------------------------------
 # Section: Initialize Variables
@@ -382,6 +384,7 @@ while [[ $# -gt 0 ]]; do
             ;;
         --mvn)
             if [[ -n "$2" && "$2" != -* ]]; then
+                MVN_CMD_OVERRIDDEN=true
                 if ! MVN_CMD="$(command -v "$2")"; then
                     echo "ERROR: --mvn '$2' is not an executable or a command on PATH" >&2
                     exit 1
@@ -557,7 +560,7 @@ BUILD_INFO_FILE="common/src/main/resources/auron-build-info.properties"
 mkdir -p "$(dirname "$BUILD_INFO_FILE")"
 
 JAVA_VERSION=$(java -version 2>&1 | head -n 1 | awk '{print $3}' | tr -d '"')
-PROJECT_VERSION=$(./build/mvn help:evaluate -N -Dexpression=project.version -Pspark-${SPARK_VER} -q -DforceStdout 2>/dev/null)
+PROJECT_VERSION=$("$MVN_CMD" help:evaluate -N -Dexpression=project.version -Pspark-${SPARK_VER} -q -DforceStdout 2>/dev/null)
 RUST_VERSION=$(rustc --version | awk '{print $2}')
 
 get_build_info() {
@@ -621,6 +624,9 @@ fi
 # -----------------------------------------------------------------------------
 if [[ "$USE_DOCKER" == true ]]; then
     echo "[INFO] Compiling inside Docker container using image: $IMAGE_NAME"
+    if [[ "$MVN_CMD_OVERRIDDEN" == true ]]; then
+        echo "[WARN] --mvn only applies to local builds; the container always uses ./build/mvn"
+    fi
     if [[ "$CLEAN" == true ]]; then
         # Clean the host-side directory that is mounted into the Docker container.
         # This avoids "device or resource busy" errors when running `mvn clean` inside the container.
@@ -629,7 +635,13 @@ if [[ "$USE_DOCKER" == true ]]; then
     fi
 
     echo "[INFO] Compiling inside Docker container..."
-    export AURON_BUILD_ARGS="${BUILD_ARGS[*]}"
+    # Forward -D arguments and everything after `--` into the container.
+    DOCKER_MVN_ARGS=("${BUILD_ARGS[@]}" "${MVN_D_ARGS[@]}" "$@")
+    AURON_BUILD_ARGS=""
+    for arg in "${DOCKER_MVN_ARGS[@]}"; do
+        AURON_BUILD_ARGS+="$(printf '%q' "$arg") "
+    done
+    export AURON_BUILD_ARGS="${AURON_BUILD_ARGS% }"
     export BUILD_CONTEXT="./${IMAGE_NAME}"
     # Spark 4.x requires JDK 17+, auto-set if not specified
     if [[ -z "$AURON_JAVA_VERSION" && "$SPARK_VER" == 4.* ]]; then

--- a/dev/docker-build/docker-compose.yml
+++ b/dev/docker-build/docker-compose.yml
@@ -39,5 +39,5 @@ services:
         source ~/.bashrc &&
         cd /auron &&
         echo "[DOCKER] Running: ./build/mvn $AURON_BUILD_ARGS" &&
-        ./build/mvn $AURON_BUILD_ARGS
+        eval "./build/mvn $AURON_BUILD_ARGS"
       '


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fixes #2460.

Three small additions that make `auron-build.sh` usable as a build step inside another script, and on machines without network access:

- `--mvn <PATH>` builds with an already installed Maven instead of `build/mvn`, which downloads Maven and so fails in an offline or airgapped build. It accepts either a path or a command on `PATH`, and errors if it resolves to neither.
- `--goal <GOAL>` sets the Maven goal. It defaults to `install`, so nothing changes for existing callers, but a caller that only wants artifacts can run `package` and leave the local repository alone.
- `--` ends option parsing, so everything after it reaches Maven unchanged. #2227 fixed `-D` handling via `MVN_D_ARGS`, but `-P`, `-B` and long options such as `--no-transfer-progress` are still either swallowed by the `break` in the `-*` handler or rejected as an unknown option. The `--` arm sits alongside the existing `-D` handling rather than replacing it, and is placed before the `--*` arm so it is not caught as an unknown option.

This is independent of #2461 and the two can merge in either order.

## How was this patch tested?

Manually, with a stub Maven that echoes its arguments so the composed command line is visible.

All three together:

```
$ bash auron-build.sh --release --mvn /tmp/stubmvn --goal package \
    --sparkver 3.1 --scalaver 2.12 -- -Pceleborn-0.6 -B --no-transfer-progress
STUB_MVN_INVOKED_WITH: clean package -DskipTests -Prelease -Pspark-3.1 -Pscala-2.12 -Pceleborn-0.6 -B --no-transfer-progress
```

The goal is `package` rather than `install`, and `-P`, `-B` and the long option all arrive intact.

Also checked:

- Without `--goal` the command line still says `clean install`, so existing callers are unaffected.
- `-DskipBuildNative` placed among the options still lands in `MVN_D_ARGS` as before, so #2227 behaviour is preserved.
- `--mvn` resolves a bare command name off `PATH` as well as an explicit path.
- `--mvn /nope/mvn` exits 1 with `ERROR: --mvn '/nope/mvn' is not an executable or a command on PATH`.
- `--goal` with no argument exits 1 with a message naming the expected values.
- An unknown long option such as `--bogus` is still rejected, so the new `--` arm does not weaken that check.
