### PR TITLE
[AURON #2463] Fix native Top-K with only sort keys

### DIFF
--- a/native-engine/datafusion-ext-plans/src/sort_exec.rs
+++ b/native-engine/datafusion-ext-plans/src/sort_exec.rs
@@ -675,7 +675,7 @@ impl ExternalSorter {
         let sorted_batch = if !self.prune_sort_keys_from_batch.is_all_pruned() {
             take_batch(batch, sorted_indices)?
         } else {
-            create_zero_column_batch(batch.num_rows())
+            create_zero_column_batch(sorted_indices.len())
         };
 
         // add to in-mem blocks
@@ -1497,6 +1497,16 @@ mod test {
         )?))
     }
 
+    fn build_single_column_table(name: &str, values: Vec<i32>) -> Result<Arc<dyn ExecutionPlan>> {
+        let schema = Arc::new(Schema::new(vec![Field::new(name, DataType::Int32, false)]));
+        let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(Int32Array::from(values))])?;
+        Ok(Arc::new(TestMemoryExec::try_new(
+            &[vec![batch]],
+            schema,
+            None,
+        )?))
+    }
+
     // Verify that `common_prefix_len` correctly computes prefixes of small fixed
     // sizes. This ensures compiler optimizations do not incorrectly transform
     // the function for small lengths.
@@ -1543,6 +1553,35 @@ mod test {
             "+---+---+---+",
         ];
         assert_batches_eq!(expected, &batches);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_top_k_with_only_sort_column() -> Result<()> {
+        MemManager::init(100);
+        let session_ctx = SessionContext::new();
+        let task_ctx = session_ctx.task_ctx();
+        let input = build_single_column_table("id", (0..10).rev().collect())?;
+        let sort_exprs = vec![PhysicalSortExpr {
+            expr: Arc::new(Column::new("id", 0)),
+            options: SortOptions::default(),
+        }];
+
+        let sort = SortExec::new(input, sort_exprs, Some(6), 0);
+        let output = sort.execute(0, task_ctx)?;
+        let batches = common::collect(output).await?;
+        let expected = r#"+----+
+| id |
++----+
+| 0  |
+| 1  |
+| 2  |
+| 3  |
+| 4  |
+| 5  |
++----+"#;
+        assert_batches_eq!(expected.lines().collect::<Vec<_>>(), &batches);
 
         Ok(())
     }

--- a/spark-extension-shims-spark/src/test/scala/org/apache/auron/exec/AuronExecSuite.scala
+++ b/spark-extension-shims-spark/src/test/scala/org/apache/auron/exec/AuronExecSuite.scala
@@ -116,6 +116,16 @@ class AuronExecSuite extends AuronQueryTest with BaseAuronSQLSuite {
     }
   }
 
+  test("TakeOrderedAndProject with only the sort column") {
+    withTempView("t1") {
+      spark.range(10).repartition(1).createOrReplaceTempView("t1")
+      val df = checkSparkAnswerAndOperator("SELECT id FROM t1 ORDER BY id LIMIT 6")
+      assert(collect(df.queryExecution.executedPlan) { case e: NativeTakeOrderedExec =>
+        e
+      }.size == 1)
+    }
+  }
+
   test("TakeOrderedAndProject with offset") {
     if (AuronTestUtils.isSparkV34OrGreater) {
       withTempView("t1") {


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2463

# Rationale for this change

When all output columns are sort keys, the native sorter stores the sort keys separately and creates a zero-column data batch.

For Top-K queries, the sorted indices are limited before this batch is created, but the batch currently retains the original input row count. This mismatch can cause the merge cursor to read past the retained sort-key rows.

# What changes are included in this PR?

- Use the number of retained sorted indices as the row count of the zero-column batch.

# Are there any user-facing changes?

Bug fix only.

# How was this patch tested?

Added a regression test to AuronExecSuite.

# Was this patch authored or co-authored using generative AI tooling?
- [x] Yes
- [ ] No

If yes, include: `Generated-by: GPT-5`

ASF guidance: https://www.apache.org/legal/generative-tooling.html
