### PR TITLE
[AURON #1863] Support the zero-argument Flink UNIX_TIMESTAMP natively

### DIFF
--- a/auron-flink-extension/auron-flink-planner/src/main/java/org/apache/auron/flink/table/planner/converter/RexCallConverter.java
+++ b/auron-flink-extension/auron-flink-planner/src/main/java/org/apache/auron/flink/table/planner/converter/RexCallConverter.java
@@ -18,6 +18,7 @@ package org.apache.auron.flink.table.planner.converter;
 
 import java.time.ZoneId;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
@@ -73,12 +74,15 @@ import org.apache.flink.table.planner.utils.TableConfigUtils;
  * result is cast to the call's result type so all branches share one type.
  *
  * <p>{@code UNIX_TIMESTAMP} (matched by operator identity, like {@code TRY_CAST})
- * maps to a native {@code Flink_UnixTimestamp} ext-function call with arguments
- * {@code [value, chronoFormat, zoneId]}. The single-argument form uses Flink's
- * default format; the two-argument form is supported only when the format operand
+ * maps to one of two native ext-function calls, chosen by arity. The
+ * string-parsing forms become {@code Flink_UnixTimestamp} with arguments
+ * {@code [value, chronoFormat, zoneId]}: the single-argument form uses Flink's
+ * default format, the two-argument form is supported only when the format operand
  * is a literal whose pattern {@link FlinkDateTimeFormatConverter} can translate,
- * and the zero-argument form falls back. It additionally requires a session time
- * zone the native function can resolve (see {@link #isNativelySupportedZone}).
+ * and both require a session time zone the native function can resolve (see
+ * {@link #isNativelySupportedZone}). The zero-argument form reads the wall clock
+ * rather than parsing a string, and becomes {@code Flink_UnixTimestampNow}, which
+ * takes no argument and needs no time zone.
  */
 public class RexCallConverter implements FlinkRexNodeConverter {
 
@@ -417,19 +421,20 @@ public class RexCallConverter implements FlinkRexNodeConverter {
      * Returns {@code true} if this {@code UNIX_TIMESTAMP} call can run natively. The single-argument
      * form uses Flink's default format; the two-argument form additionally requires the format
      * operand to be a compile-time literal whose pattern the native parser handles identically
-     * (see {@link FlinkDateTimeFormatConverter}). Both also require a session time zone the native
-     * function can resolve (see {@link #isNativelySupportedZone}).
+     * (see {@link FlinkDateTimeFormatConverter}). Both interpret their string against the session
+     * time zone, so both require a zone the native function can resolve (see
+     * {@link #isNativelySupportedZone}).
      *
-     * <p>The zero-argument form is rejected here so it always falls back to Flink. It is a
-     * different function rather than a defaulted arity: it parses no input at all, and instead
-     * reads the wall clock once per record, so the operator is not deterministic and is never
-     * folded to a literal at plan time. It also has no value operand, which the native
-     * ext-function path needs to size its output against the batch.
+     * <p>The zero-argument form is a different function rather than a defaulted arity: it parses
+     * no input at all and instead reads the wall clock, so it is not deterministic and is never
+     * folded to a literal at plan time. Its result is epoch seconds, a zone-independent instant,
+     * which is why it is admitted above the zone check: a session zone the native side cannot
+     * resolve has no bearing on a value that never consults one.
      */
     private static boolean isUnixTimestampSupported(RexCall call, ConverterContext context) {
         List<RexNode> operands = call.getOperands();
         if (operands.isEmpty()) {
-            return false;
+            return true;
         }
         ZoneId zone = TableConfigUtils.getLocalTimeZone(context.getTableConfig());
         if (!isNativelySupportedZone(zone.getId())) {
@@ -475,10 +480,16 @@ public class RexCallConverter implements FlinkRexNodeConverter {
     }
 
     /**
-     * Builds a native {@code Flink_UnixTimestamp} ext-function call. The native argument list is
-     * always {@code [value, chronoFormat, zoneId]}, and both of Flink's string-parsing arities are
-     * normalized onto that shape here: the value operand is converted recursively, the format is
-     * translated to the native specifier string (defaulting to Flink's
+     * Builds the native ext-function call backing {@code UNIX_TIMESTAMP}. Two different native
+     * functions serve it, selected by arity.
+     *
+     * <p>The zero-argument form becomes {@code Flink_UnixTimestampNow}, which takes no argument:
+     * it reads the clock and returns epoch seconds as a scalar the projection broadcasts across
+     * the batch, so it needs neither a value to size against nor a zone.
+     *
+     * <p>The string-parsing forms become {@code Flink_UnixTimestamp}, whose native argument list is
+     * always {@code [value, chronoFormat, zoneId]}: the value operand is converted recursively, the
+     * format is translated to the native specifier string (defaulting to Flink's
      * {@code yyyy-MM-dd HH:mm:ss} when the call carries no format operand), and the session
      * timezone is resolved at plan time. The native function therefore never has to default a
      * missing format or timezone itself, and treats any other arity as a plumbing bug.
@@ -490,10 +501,17 @@ public class RexCallConverter implements FlinkRexNodeConverter {
      */
     private PhysicalExprNode buildUnixTimestamp(RexCall call, ConverterContext context) {
         List<RexNode> operands = call.getOperands();
-        if (operands.isEmpty() || operands.size() > 2) {
+        if (operands.size() > 2) {
             throw new IllegalArgumentException(
-                    "UNIX_TIMESTAMP is native only in its 1-argument and 2-argument forms, got " + operands.size()
-                            + " arguments");
+                    "UNIX_TIMESTAMP is native only in its 0-argument, 1-argument and 2-argument forms, got "
+                            + operands.size() + " arguments");
+        }
+        ArrowType bigIntType = ArrowType.newBuilder()
+                .setINT64(EmptyMessage.getDefaultInstance())
+                .build();
+        if (operands.isEmpty()) {
+            return FlinkNodeConverterUtils.buildExtScalarFunctionNode(
+                    "Flink_UnixTimestampNow", Collections.emptyList(), bigIntType);
         }
         PhysicalExprNode value = convertOperand(operands.get(0), context);
 
@@ -509,9 +527,6 @@ public class RexCallConverter implements FlinkRexNodeConverter {
                     "UNIX_TIMESTAMP session time zone is not natively resolvable: " + zone.getId());
         }
 
-        ArrowType bigIntType = ArrowType.newBuilder()
-                .setINT64(EmptyMessage.getDefaultInstance())
-                .build();
         return FlinkNodeConverterUtils.buildExtScalarFunctionNode(
                 "Flink_UnixTimestamp",
                 Arrays.asList(

--- a/auron-flink-extension/auron-flink-planner/src/test/java/org/apache/auron/flink/table/planner/converter/RexCallConverterTest.java
+++ b/auron-flink-extension/auron-flink-planner/src/test/java/org/apache/auron/flink/table/planner/converter/RexCallConverterTest.java
@@ -586,14 +586,29 @@ class RexCallConverterTest {
         assertFalse(converter.isSupported(call, contextWithZone("SystemV/PST8")));
     }
 
-    /** The zero-argument form never reaches the native function: the gate rejects it so the Calc
-     * falls back, and the builder refuses it outright rather than reading an absent value operand. */
+    /** The zero-argument form parses no operand, so it converts to a distinct native function that
+     * takes no arguments at all rather than to the string-parsing one. */
     @Test
-    void testUnixTimestampZeroArgFallsBack() {
+    void testUnixTimestampZeroArgNodeShape() {
         RexNode call = makeCall(bigintType(), FlinkSqlOperatorTable.UNIX_TIMESTAMP);
 
-        assertFalse(converter.isSupported(call, context));
-        assertThrows(IllegalArgumentException.class, () -> converter.convert(call, context));
+        PhysicalExprNode result = converter.convert(call, context);
+
+        assertTrue(result.hasScalarFunction());
+        PhysicalScalarFunctionNode fn = result.getScalarFunction();
+        assertEquals("Flink_UnixTimestampNow", fn.getName());
+        assertEquals(ScalarFunction.AuronExtFunctions, fn.getFun());
+        assertEquals(0, fn.getArgsCount(), "The zero-argument form carries no native argument");
+        assertEquals(ArrowType.ArrowTypeEnumCase.INT64, fn.getReturnType().getArrowTypeEnumCase());
+    }
+
+    /** The zero-argument result is epoch seconds, which no session time zone bears on, so the gate
+     * admits it even under a zone the native lookup cannot resolve. */
+    @Test
+    void testUnixTimestampZeroArgSupportedWithFixedOffsetZone() {
+        RexNode call = makeCall(bigintType(), FlinkSqlOperatorTable.UNIX_TIMESTAMP);
+
+        assertTrue(converter.isSupported(call, contextWithZone("GMT-08:00")));
     }
 
     @Test

--- a/auron-flink-extension/auron-flink-planner/src/test/java/org/apache/auron/flink/table/runtime/AuronFlinkCalcITCase.java
+++ b/auron-flink-extension/auron-flink-planner/src/test/java/org/apache/auron/flink/table/runtime/AuronFlinkCalcITCase.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import org.apache.auron.flink.table.AuronFlinkTableTestBase;
+import org.apache.auron.flink.table.planner.UnsupportedFlinkNodeRecorder;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.CollectionUtil;
 import org.junit.jupiter.api.Test;
@@ -257,6 +258,40 @@ public class AuronFlinkCalcITCase extends AuronFlinkTableTestBase {
                 .collect());
         rows.sort(Comparator.comparingLong(o -> (long) o.getField(0)));
         assertThat(rows).isEqualTo(Arrays.asList(Row.of(1602316801L), Row.of(1602316802L), Row.of(1602316803L)));
+    }
+
+    /**
+     * The zero-argument UNIX_TIMESTAMP reads the wall clock rather than parsing a column. It yields
+     * one row per input row, each carrying epoch seconds bracketed by the test's own clock reads.
+     *
+     * <p>Fallback to Flink's codegen Calc is silent and total, and produces an identical row set, so
+     * the values alone cannot show the Calc ran natively. The fallback counter narrows it: a Calc
+     * that fails to convert always records either an unsupported node or a composition failure
+     * before it falls back, so a count of zero means this Calc converted. It does not mean the Calc
+     * ran. A native library holding no registry arm for the function still converts at plan time
+     * and only fails once executing, where nothing records a fallback, leaving the counter at zero
+     * and the result set empty.
+     *
+     * <p>The row count is what establishes that the native plan executed. {@code allSatisfy} passes
+     * vacuously over an empty list, so dropping {@code hasSize(3)} would let that runtime failure
+     * read as success and leave native execution unverified.
+     */
+    @Test
+    public void testUnixTimestampZeroArgRunsNatively() {
+        UnsupportedFlinkNodeRecorder.resetForTest();
+        long before = System.currentTimeMillis() / 1000;
+        List<Row> rows = CollectionUtil.iteratorToList(
+                tableEnvironment.executeSql("select UNIX_TIMESTAMP() from T1").collect());
+        long after = System.currentTimeMillis() / 1000;
+
+        assertThat(UnsupportedFlinkNodeRecorder.peekEmitCount())
+                .as("a non-zero fallback count means the Calc did not run natively")
+                .isZero();
+        assertThat(rows)
+                .as("one clock-bracketed row per input row; an empty result set means the native"
+                        + " library implements no arm for this function")
+                .hasSize(3)
+                .allSatisfy(row -> assertThat((long) row.getField(0)).isBetween(before, after));
     }
 
     /** A NOT LIKE filter keeps rows whose string does not match the pattern. */

--- a/auron-flink-extension/auron-flink-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecCalcTest.java
+++ b/auron-flink-extension/auron-flink-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecCalcTest.java
@@ -286,21 +286,26 @@ class StreamExecCalcTest {
     // UNIX_TIMESTAMP integration
     // =====================================================================
 
-    /** Contract: a zero-argument {@code UNIX_TIMESTAMP()} is unsupported, so a Calc projecting it
-     * falls back rather than converting to a native operator. */
+    /** Contract: a Calc whose only projection is a zero-argument {@code UNIX_TIMESTAMP()} converts
+     * to a native operator instead of falling back, even though it reads no input column. */
     @Test
-    void testUnixTimestampZeroArgFallsBack() throws Exception {
-        Transformation<RowData> stub = new FakeSourceTransformation();
+    void testUnixTimestampZeroArgConvertsNatively() throws Exception {
         RexNode unixTs =
                 REX_BUILDER.makeCall(bigintType(), FlinkSqlOperatorTable.UNIX_TIMESTAMP, Collections.emptyList());
         CapturingTranslator node = new CapturingTranslator(
-                tableConfig, Arrays.asList(unixTs), null, inputProperty, RowType.of(new BigIntType()), "calc", stub);
+                tableConfig,
+                Arrays.asList(unixTs),
+                null,
+                inputProperty,
+                RowType.of(new BigIntType()),
+                "calc",
+                new FakeSourceTransformation());
         wireFakeUpstream(node, TWO_INT_ROW);
 
         Transformation<RowData> result = invokeTranslate(node);
 
-        assertSame(stub, result);
-        assertEquals(1, node.fallbackCount);
+        assertEquals(0, node.fallbackCount);
+        assertTrue(operatorOf(result) instanceof FlinkAuronCalcOperator);
     }
 
     /** Contract: the effective {@link ExecNodeConfig} — not the empty persisted config — seeds the

--- a/native-engine/datafusion-ext-functions/src/flink_datetime.rs
+++ b/native-engine/datafusion-ext-functions/src/flink_datetime.rs
@@ -99,10 +99,20 @@ pub fn flink_unix_timestamp(args: &[ColumnarValue]) -> Result<ColumnarValue> {
 /// operand is needed to size the output. The clock is therefore read once per
 /// call site per batch, and every row of that batch carries the same second.
 ///
-/// The clock is read as `timestamp_millis() / 1000` to mirror Flink's
-/// `System.currentTimeMillis() / 1000` operator for operator, so the two
-/// implementations can be compared side by side.
-pub fn flink_unix_timestamp_now(_args: &[ColumnarValue]) -> Result<ColumnarValue> {
+/// A non-empty argument list is a hard error rather than an ignored operand,
+/// on the same grounds as the arity check in [`flink_unix_timestamp`]: nothing
+/// enforces arity before this point, so a plumbing bug is only visible here.
+///
+/// The clock is read as `timestamp_millis() / 1000` so the truncation matches
+/// Flink's `System.currentTimeMillis() / 1000` exactly.
+pub fn flink_unix_timestamp_now(args: &[ColumnarValue]) -> Result<ColumnarValue> {
+    if !args.is_empty() {
+        return Err(DataFusionError::Execution(format!(
+            "Flink_UnixTimestampNow takes no arguments, got {}",
+            args.len()
+        )));
+    }
+
     let secs = Utc::now().timestamp_millis() / 1000;
     Ok(ColumnarValue::Scalar(ScalarValue::Int64(Some(secs))))
 }
@@ -651,6 +661,11 @@ mod tests {
             ColumnarValue::Scalar(ScalarValue::Utf8(Some("extra".to_string()))),
         ];
         assert!(flink_unix_timestamp(&four).is_err());
+
+        let one = vec![ColumnarValue::Scalar(ScalarValue::Utf8(Some(
+            "unexpected".to_string(),
+        )))];
+        assert!(flink_unix_timestamp_now(&one).is_err());
     }
 
     #[test]

--- a/native-engine/datafusion-ext-functions/src/flink_datetime.rs
+++ b/native-engine/datafusion-ext-functions/src/flink_datetime.rs
@@ -19,7 +19,7 @@ use arrow::{
     array::{Int64Array, StringArray},
     datatypes::DataType,
 };
-use chrono::{DateTime, LocalResult, NaiveDateTime, Offset, TimeZone};
+use chrono::{DateTime, LocalResult, NaiveDateTime, Offset, TimeZone, Utc};
 use chrono_tz::{OffsetComponents, Tz};
 use datafusion::{
     common::{DataFusionError, Result, ScalarValue},
@@ -45,8 +45,8 @@ use datafusion_ext_commons::arrow::cast::cast;
 /// every call reaching this function carries all three arguments already bound.
 ///
 /// Flink's no-argument `UNIX_TIMESTAMP()` parses nothing and yields the current
-/// wall-clock time per record. It is not routed here: it has no input column to
-/// size the output against, and it shares none of the parsing contract below.
+/// wall-clock time. It is served by [`flink_unix_timestamp_now`], which shares
+/// none of the parsing contract below.
 ///
 /// An unparseable value yields `i64::MIN` (Flink's `Long.MIN_VALUE`), never
 /// NULL and never an error; a NULL value yields NULL. Arity, format and
@@ -89,6 +89,22 @@ pub fn flink_unix_timestamp(args: &[ColumnarValue]) -> Result<ColumnarValue> {
     );
 
     Ok(ColumnarValue::Array(Arc::new(result)))
+}
+
+/// Native implementation of Flink SQL `UNIX_TIMESTAMP()`: the current Unix
+/// timestamp in seconds.
+///
+/// Takes no arguments. The result is a `ColumnarValue::Scalar`, which the
+/// projection broadcasts to the width of the batch being evaluated, so no
+/// operand is needed to size the output. The clock is therefore read once per
+/// call site per batch, and every row of that batch carries the same second.
+///
+/// The clock is read as `timestamp_millis() / 1000` to mirror Flink's
+/// `System.currentTimeMillis() / 1000` operator for operator, so the two
+/// implementations can be compared side by side.
+pub fn flink_unix_timestamp_now(_args: &[ColumnarValue]) -> Result<ColumnarValue> {
+    let secs = Utc::now().timestamp_millis() / 1000;
+    Ok(ColumnarValue::Scalar(ScalarValue::Int64(Some(secs))))
 }
 
 fn utf8_scalar(arg: &ColumnarValue) -> Option<String> {
@@ -654,6 +670,49 @@ mod tests {
         assert_eq!(run("2020-10-10 00:00:01", "", "UTC"), MIN);
         assert_eq!(run("2020-10-10 00:00:01", "", "Asia/Shanghai"), MIN);
         assert_eq!(run("", "", "UTC"), MIN);
+    }
+
+    // The no-argument form returns a Scalar, not an Array. That is what lets it
+    // take no operand: the projection broadcasts the scalar to the batch width,
+    // giving every row of the batch the same second.
+    #[test]
+    fn now_returns_scalar_broadcast_over_the_batch() {
+        let out = flink_unix_timestamp_now(&[]).expect("flink_unix_timestamp_now must not error");
+        assert!(matches!(
+            &out,
+            ColumnarValue::Scalar(ScalarValue::Int64(Some(_)))
+        ));
+
+        let batch_len = 4;
+        let out = out.into_array(batch_len).expect("must materialize");
+        let out = out
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .expect("result must be Int64Array");
+        assert_eq!(out.len(), batch_len);
+        for i in 0..batch_len {
+            assert!(!out.is_null(i));
+            assert_eq!(out.value(i), out.value(0));
+        }
+    }
+
+    // The result is in seconds, not milliseconds: it lands inside the window
+    // bracketed by the test's own clock reads.
+    #[test]
+    fn now_returns_epoch_seconds() {
+        let before = Utc::now().timestamp();
+        let out = flink_unix_timestamp_now(&[]).expect("flink_unix_timestamp_now must not error");
+        let after = Utc::now().timestamp();
+
+        let secs = match out {
+            ColumnarValue::Scalar(ScalarValue::Int64(secs)) => secs,
+            _ => None,
+        }
+        .expect("result must be a non-null Int64 scalar");
+        assert!(
+            (before..=after).contains(&secs),
+            "expected {secs} within [{before}, {after}]"
+        );
     }
 
     #[test]

--- a/native-engine/datafusion-ext-functions/src/lib.rs
+++ b/native-engine/datafusion-ext-functions/src/lib.rs
@@ -99,6 +99,7 @@ pub fn create_auron_ext_function(
         }
         "Spark_IsNaN" => Arc::new(spark_isnan::spark_isnan),
         "Flink_UnixTimestamp" => Arc::new(flink_datetime::flink_unix_timestamp),
+        "Flink_UnixTimestampNow" => Arc::new(flink_datetime::flink_unix_timestamp_now),
         _ => df_unimplemented_err!("auron ext function not implemented: {name}")?,
     })
 }


### PR DESCRIPTION
# Which issue does this PR close?

Part of #1863.

#1863 enumerates all three argument forms of `UNIX_TIMESTAMP`. The 1-argument and 2-argument string-parsing forms landed in #2409 and #2448, and this PR adds the remaining 0-argument form. #1863 stays open after this one merges, for the timezone configuration work tracked as sub-issue #2455.

# Rationale for this change

`UNIX_TIMESTAMP()` with no arguments returns the current epoch seconds. The converter rejected it, so any Calc containing it fell back to Flink wholesale, taking every other expression in that Calc down with it.

Two things were believed to block it. Both turned out to be false, and I stated one of them myself earlier in this issue.

**"A zero-argument ext function cannot size its output."** The ext-function ABI drops the batch row count, so a 0-argument function appears to have no way to know how many values to return. That is true only for a function returning an `Array`. The length check in `ScalarFunctionExpr::evaluate` sits entirely inside the `ColumnarValue::Array` branch, so a function returning `ColumnarValue::Scalar` never reaches it, and the projection broadcasts the scalar to the batch width. No operand is needed, and no carrier column either.

**"The 0-argument form needs the session time zone."** It does not. The generated Flink operator holds a `timeZone` field, passes it to the 1-argument and 2-argument calls, and emits `result$1 = DateTimeUtils.unixTimestamp()` with no argument at all. The result is epoch seconds, which is zone-independent.

An approach was proposed on #1863 that works around the first premise: pass any input column to the Rust function purely to convey the batch length, ignore its data, and return that many timestamps. That would have worked, and it was a sound answer to the constraint as I had described it. This PR does not use it, because once the constraint turns out not to exist the carrier column has no job left. The difference is visible in the diff, so it is worth stating plainly: no column is passed, the Rust function reads no length, and the row count comes from the projection broadcasting a scalar. The observable behavior is the same either way.

# What changes are included in this PR?

Three commits.

1. A native zero-argument ext function `Flink_UnixTimestampNow` returning `ColumnarValue::Scalar(Int64)`. The clock is read as `timestamp_millis() / 1000`, mirroring Flink's `System.currentTimeMillis() / 1000` operator for operator.
2. The converter admits the 0-argument form and emits that function with an empty operand list. The 0-argument arm sits **above** the session time zone check, since a zone the native side cannot resolve is no reason to fall back a query that never consults a zone. Class and method javadoc are corrected: they previously described the 0-argument form as falling back and described `UNIX_TIMESTAMP` as always mapping to `Flink_UnixTimestamp` with `[value, chronoFormat, zoneId]`.
3. End-to-end coverage in `AuronFlinkCalcITCase`.

No protobuf change, no `Cargo.toml` change, no `pom.xml` change. It is a separate native function rather than a fourth arity on `Flink_UnixTimestamp`, whose contract is "parse this string with this format in this zone" and which the 0-argument form shares none of.

# Are there any user-facing changes?

Yes, and one of them is a deliberate semantic divergence worth reviewing on its own merits.

A query using `UNIX_TIMESTAMP()` that previously fell back to Flink now runs natively.

**Flink evaluates the niladic form per record. This implementation reads the clock once per call site per evaluation and broadcasts it across the batch**, so rows in one batch share a timestamp, and that timestamp is taken when the batch is evaluated rather than when each row arrived. Two `UNIX_TIMESTAMP()` calls in one projection are read independently, which matches Flink.

How large the skew can get depends on what closes the batch:

| Path | Bound |
|---|---|
| Calc with a declared `WATERMARK FOR` | about 205 ms, the default `autoWatermarkInterval` |
| Calc with no watermark strategy | 8192 rows only, so `8192 / rate` seconds. About 82 s at 100 rec/s |
| Fused Kafka plan | the native scan blocks until its buffer fills, default 3000, with no time flush |

The unwatermarked case is the common shape for a processing-time query, so this is not a corner case. It was discussed and settled on the issue (https://github.com/apache/auron/issues/1863#issuecomment-5249021849): per-batch is acceptable, since the zero-argument form is non-idempotent anyway and what users generally want is to know roughly when a record was processed. It is also the finest granularity among comparable engines: StreamFusion stamps `PROCTIME()` once per operator compile, Flink's own batch mode folds `CURRENT_TIMESTAMP` to a query-start literal, DataFusion, ClickHouse and Velox are per query, DuckDB is per transaction, and ClickHouse ships `nowInBlock()` as a documented per-block clock. Flink also declares the niladic form only `SqlMonotonicity.INCREASING`, which a per-batch constant satisfies.

Gating it conditionally on a declared watermark was considered and rejected: the converter has no access to the ExecNode graph, the predicate misses DataStream-level watermarks, `auto-watermark-interval=0` and idle partitions, it keys native support off an unrelated DDL clause, and it only shrinks the skew rather than removing it.

# How was this patch tested?

Native unit tests for the scalar return and its broadcast to batch width, and for the value being a plausible epoch second rather than milliseconds.

Converter tests for the emitted node shape, and `testUnixTimestampZeroArgSupportedWithFixedOffsetZone`, which exists to catch the 0-argument arm being placed below the time zone check. It is a real discriminator: moving the arm below the check fails that test and no other. Two tests that asserted the form falls back are inverted.

An ITCase asserting one clock-bracketed row per input row and no recorded fallback. Both assertions are load-bearing and neither subsumes the other. A zero fallback count establishes that the Calc converted, not that it ran: a native library holding no registry arm for the function still converts at plan time and fails only during execution, where nothing records a fallback, leaving the counter at zero and the result set empty. The row count is what establishes the native plan executed.

The ITCase was checked to be non-vacuous by running rather than by inspection: reverting the converter gate fails it on the fallback count, and running against a library without the registry arm fails it on the row count.

Full module build green, 0 checkstyle violations, spotless clean.

# Was this patch authored or co-authored using generative AI tooling?
- [x] Yes
- [ ] No

`Generated-by: Claude Code (Claude Opus 5)`
