### PR TITLE
[AURON #1902] Reuse extension function implementations

### DIFF
--- a/native-engine/datafusion-ext-functions/src/lib.rs
+++ b/native-engine/datafusion-ext-functions/src/lib.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use datafusion::{common::Result, logical_expr::ScalarFunctionImplementation};
 use datafusion_ext_commons::df_unimplemented_err;
@@ -38,6 +38,13 @@ mod spark_round;
 mod spark_strings;
 mod spark_unscaled_value;
 
+macro_rules! shared_function {
+    ($function:expr) => {{
+        static INSTANCE: OnceLock<ScalarFunctionImplementation> = OnceLock::new();
+        Arc::clone(INSTANCE.get_or_init(|| Arc::new($function)))
+    }};
+}
+
 #[allow(clippy::panic)] // Temporarily allow panic to refactor to Result later
 pub fn create_auron_ext_function(
     name: &str,
@@ -47,59 +54,93 @@ pub fn create_auron_ext_function(
     // if used for flink should be start with 'Flink_',
     // same to other engines.
     Ok(match name {
-        "Placeholder" => Arc::new(|_| panic!("placeholder() should never be called")),
-        "Spark_NullIf" => Arc::new(spark_null_if::spark_null_if),
-        "Spark_NullIfZero" => Arc::new(spark_null_if::spark_null_if_zero),
-        "Spark_UnscaledValue" => Arc::new(spark_unscaled_value::spark_unscaled_value),
-        "Spark_MakeDecimal" => Arc::new(spark_make_decimal::spark_make_decimal),
-        "Spark_CheckOverflow" => Arc::new(spark_check_overflow::spark_check_overflow),
-        "Spark_Murmur3Hash" => Arc::new(spark_hash::spark_murmur3_hash),
-        "Spark_XxHash64" => Arc::new(spark_hash::spark_xxhash64),
-        "Spark_Sha224" => Arc::new(spark_crypto::spark_sha224),
-        "Spark_Sha256" => Arc::new(spark_crypto::spark_sha256),
-        "Spark_Sha384" => Arc::new(spark_crypto::spark_sha384),
-        "Spark_Sha512" => Arc::new(spark_crypto::spark_sha512),
-        "Spark_MD5" => Arc::new(spark_crypto::spark_md5),
-        "Spark_GetJsonObject" => Arc::new(spark_get_json_object::spark_get_json_object),
+        "Placeholder" => shared_function!(|_| panic!("placeholder() should never be called")),
+        "Spark_NullIf" => shared_function!(spark_null_if::spark_null_if),
+        "Spark_NullIfZero" => shared_function!(spark_null_if::spark_null_if_zero),
+        "Spark_UnscaledValue" => shared_function!(spark_unscaled_value::spark_unscaled_value),
+        "Spark_MakeDecimal" => shared_function!(spark_make_decimal::spark_make_decimal),
+        "Spark_CheckOverflow" => shared_function!(spark_check_overflow::spark_check_overflow),
+        "Spark_Murmur3Hash" => shared_function!(spark_hash::spark_murmur3_hash),
+        "Spark_XxHash64" => shared_function!(spark_hash::spark_xxhash64),
+        "Spark_Sha224" => shared_function!(spark_crypto::spark_sha224),
+        "Spark_Sha256" => shared_function!(spark_crypto::spark_sha256),
+        "Spark_Sha384" => shared_function!(spark_crypto::spark_sha384),
+        "Spark_Sha512" => shared_function!(spark_crypto::spark_sha512),
+        "Spark_MD5" => shared_function!(spark_crypto::spark_md5),
+        "Spark_GetJsonObject" => shared_function!(spark_get_json_object::spark_get_json_object),
         "Spark_GetParsedJsonObject" => {
-            Arc::new(spark_get_json_object::spark_get_parsed_json_object)
+            shared_function!(spark_get_json_object::spark_get_parsed_json_object)
         }
-        "Spark_ParseJson" => Arc::new(spark_get_json_object::spark_parse_json),
-        "Spark_ArrayReverse" => Arc::new(spark_array::array_reverse),
-        "Spark_ArrayFlatten" => Arc::new(spark_array::array_flatten),
-        "Spark_MakeArray" => Arc::new(spark_make_array::array),
-        "Spark_MapConcat" => Arc::new(spark_map::map_concat),
-        "Spark_MapFromArrays" => Arc::new(spark_map::map_from_arrays),
-        "Spark_MapFromEntries" => Arc::new(spark_map::map_from_entries),
-        "Spark_StrToMap" => Arc::new(spark_map::str_to_map),
-        "Spark_StringSpace" => Arc::new(spark_strings::string_space),
-        "Spark_StringRepeat" => Arc::new(spark_strings::string_repeat),
-        "Spark_StringSplit" => Arc::new(spark_strings::string_split),
-        "Spark_StringConcat" => Arc::new(spark_strings::string_concat),
-        "Spark_StringConcatWs" => Arc::new(spark_strings::string_concat_ws),
-        "Spark_StringLower" => Arc::new(spark_strings::string_lower),
-        "Spark_StringUpper" => Arc::new(spark_strings::string_upper),
-        "Spark_Substring" => Arc::new(spark_strings::spark_substring),
-        "Spark_InitCap" => Arc::new(spark_initcap::string_initcap),
-        "Spark_Year" => Arc::new(spark_dates::spark_year),
-        "Spark_Month" => Arc::new(spark_dates::spark_month),
-        "Spark_Day" => Arc::new(spark_dates::spark_day),
-        "Spark_DayOfWeek" => Arc::new(spark_dates::spark_dayofweek),
-        "Spark_WeekOfYear" => Arc::new(spark_dates::spark_weekofyear),
-        "Spark_Quarter" => Arc::new(spark_dates::spark_quarter),
-        "Spark_Hour" => Arc::new(spark_dates::spark_hour),
-        "Spark_Minute" => Arc::new(spark_dates::spark_minute),
-        "Spark_Second" => Arc::new(spark_dates::spark_second),
-        "Spark_MonthsBetween" => Arc::new(spark_dates::spark_months_between),
-        "Spark_BrickhouseArrayUnion" => Arc::new(brickhouse::array_union::array_union),
-        "Spark_Round" => Arc::new(spark_round::spark_round),
-        "Spark_BRound" => Arc::new(spark_bround::spark_bround),
+        "Spark_ParseJson" => shared_function!(spark_get_json_object::spark_parse_json),
+        "Spark_ArrayReverse" => shared_function!(spark_array::array_reverse),
+        "Spark_ArrayFlatten" => shared_function!(spark_array::array_flatten),
+        "Spark_MakeArray" => shared_function!(spark_make_array::array),
+        "Spark_MapConcat" => shared_function!(spark_map::map_concat),
+        "Spark_MapFromArrays" => shared_function!(spark_map::map_from_arrays),
+        "Spark_MapFromEntries" => shared_function!(spark_map::map_from_entries),
+        "Spark_StrToMap" => shared_function!(spark_map::str_to_map),
+        "Spark_StringSpace" => shared_function!(spark_strings::string_space),
+        "Spark_StringRepeat" => shared_function!(spark_strings::string_repeat),
+        "Spark_StringSplit" => shared_function!(spark_strings::string_split),
+        "Spark_StringConcat" => shared_function!(spark_strings::string_concat),
+        "Spark_StringConcatWs" => shared_function!(spark_strings::string_concat_ws),
+        "Spark_StringLower" => shared_function!(spark_strings::string_lower),
+        "Spark_StringUpper" => shared_function!(spark_strings::string_upper),
+        "Spark_Substring" => shared_function!(spark_strings::spark_substring),
+        "Spark_InitCap" => shared_function!(spark_initcap::string_initcap),
+        "Spark_Year" => shared_function!(spark_dates::spark_year),
+        "Spark_Month" => shared_function!(spark_dates::spark_month),
+        "Spark_Day" => shared_function!(spark_dates::spark_day),
+        "Spark_DayOfWeek" => shared_function!(spark_dates::spark_dayofweek),
+        "Spark_WeekOfYear" => shared_function!(spark_dates::spark_weekofyear),
+        "Spark_Quarter" => shared_function!(spark_dates::spark_quarter),
+        "Spark_Hour" => shared_function!(spark_dates::spark_hour),
+        "Spark_Minute" => shared_function!(spark_dates::spark_minute),
+        "Spark_Second" => shared_function!(spark_dates::spark_second),
+        "Spark_MonthsBetween" => shared_function!(spark_dates::spark_months_between),
+        "Spark_BrickhouseArrayUnion" => shared_function!(brickhouse::array_union::array_union),
+        "Spark_Round" => shared_function!(spark_round::spark_round),
+        "Spark_BRound" => shared_function!(spark_bround::spark_bround),
         "Spark_NormalizeNanAndZero" => {
-            Arc::new(spark_normalize_nan_and_zero::spark_normalize_nan_and_zero)
+            shared_function!(spark_normalize_nan_and_zero::spark_normalize_nan_and_zero)
         }
-        "Spark_IsNaN" => Arc::new(spark_isnan::spark_isnan),
-        "Flink_UnixTimestamp" => Arc::new(flink_datetime::flink_unix_timestamp),
-        "Flink_UnixTimestampNow" => Arc::new(flink_datetime::flink_unix_timestamp_now),
+        "Spark_IsNaN" => shared_function!(spark_isnan::spark_isnan),
+        "Flink_UnixTimestamp" => shared_function!(flink_datetime::flink_unix_timestamp),
+        "Flink_UnixTimestampNow" => shared_function!(flink_datetime::flink_unix_timestamp_now),
         _ => df_unimplemented_err!("auron ext function not implemented: {name}")?,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use datafusion::{arrow::datatypes::DataType, logical_expr::Volatility, prelude::create_udf};
+
+    use super::*;
+
+    #[test]
+    fn reuses_function_implementation() -> Result<()> {
+        let first = create_auron_ext_function("Spark_GetJsonObject", 0)?;
+        let second = create_auron_ext_function("Spark_GetJsonObject", 0)?;
+        let other = create_auron_ext_function("Spark_ParseJson", 0)?;
+
+        assert!(Arc::ptr_eq(&first, &second));
+        assert!(!Arc::ptr_eq(&first, &other));
+
+        let first_udf = create_udf(
+            "spark_ext_function_Spark_GetJsonObject",
+            vec![DataType::Utf8, DataType::Utf8],
+            DataType::Utf8,
+            Volatility::Volatile,
+            first,
+        );
+        let second_udf = create_udf(
+            "spark_ext_function_Spark_GetJsonObject",
+            vec![DataType::Utf8, DataType::Utf8],
+            DataType::Utf8,
+            Volatility::Volatile,
+            second,
+        );
+        assert_eq!(first_udf, second_udf);
+        Ok(())
+    }
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #1902

# Rationale for this change

`create_auron_ext_function` created a new function implementation `Arc` for every lookup. As a result, equivalent extension UDFs did not compare equal in DataFusion, preventing repeated expressions from sharing cached evaluation results.

# What changes are included in this PR?

- Lazily initialize one shared implementation for each extension function.
- Preserve the existing direct match-based function lookup.
- Return a cloned `Arc` for subsequent lookups without adding a map or lock lookup.
- Add regression coverage for shared implementation identity, isolation between different functions, and DataFusion UDF equality.

# Are there any user-facing changes?

No public API or configuration changes. Repeated equivalent extension-function expressions can now reuse cached evaluation results.

# How was this patch tested?

- `cargo test -p datafusion-ext-functions reuses_function_implementation --lib`
- `cargo test -p datafusion-ext-functions --lib`
- `cargo test -p auron-planner --lib`
- `cargo test -p datafusion-ext-plans --lib`
- `cargo clippy -p datafusion-ext-functions --all-targets -- -D warnings`
- `./dev/reformat --check`

The repository formatting check passed across all required dependency profiles and Spark compatibility builds from Spark 3.0 through Spark 4.1.

# Was this patch authored or co-authored using generative AI tooling?

- [x] Yes
- [ ] No

Codex was used only to Review and understand the codebase