### PR TITLE
[AURON #2468] Support binary sort keys in native range shuffle

### DIFF
--- a/spark-extension-shims-spark/src/test/scala/org/apache/auron/AuronQuerySuite.scala
+++ b/spark-extension-shims-spark/src/test/scala/org/apache/auron/AuronQuerySuite.scala
@@ -20,6 +20,7 @@ import org.apache.spark.sql.{AuronQueryTest, Row}
 import org.apache.spark.sql.auron.join.JoinBuildSides.{JoinBuildLeft, JoinBuildRight}
 import org.apache.spark.sql.execution.auron.plan.NativeFilterBase
 import org.apache.spark.sql.execution.auron.plan.NativeShuffledHashJoinBase
+import org.apache.spark.sql.execution.auron.plan.NativeShuffleExchangeExec
 import org.apache.spark.sql.execution.auron.plan.NativeSortMergeJoinBase
 import org.apache.spark.sql.execution.joins.auron.plan.NativeBroadcastJoinExec
 
@@ -112,7 +113,10 @@ class AuronQuerySuite extends AuronQueryTest with BaseAuronSQLSuite with AuronSQ
     withTable("t1", "t2") {
       sql("create table t1(c1 binary, c2 int) using parquet")
       sql("insert into t1 values (cast('test1' as binary), 1), (cast('test2' as binary), 2)")
-      checkSparkAnswerAndOperator("select c2 from t1 order by c1")
+      val df = checkSparkAnswerAndOperator("select c2 from t1 order by c1")
+      assert(collectFirst(df.queryExecution.executedPlan) { case e: NativeShuffleExchangeExec =>
+        e
+      }.isDefined)
     }
   }
 

--- a/spark-extension/src/main/scala/org/apache/spark/sql/auron/AuronConverters.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/auron/AuronConverters.scala
@@ -447,7 +447,7 @@ object AuronConverters extends Logging {
     outputPartitioning match {
       case partitioning: RangePartitioning =>
         val unsupportedOrderType = partitioning.ordering
-          .find(e => !isTypeSupported(e.dataType))
+          .find(e => !isTypeSupported(e.dataType) && e.dataType != BinaryType)
         assert(
           unsupportedOrderType.isEmpty,
           s"Unsupported order type in range partitioning: ${unsupportedOrderType.get}")


### PR DESCRIPTION
**Which issue does this PR close?**
Closes #2468 

**Rationale for this change**
Auron currently rejects `BinaryType` sort keys when converting Spark `RangePartitioning` to a native shuffle exchange.

Binary values are already supported by Auron's Arrow type conversion and native row encoding, so this restriction causes queries that order or range-partition by a binary column to fall back unnecessarily.

**What changes are included in this PR?**
Allows a top-level `BinaryType` sort key in native range partitioning.
Updates the existing binary range-partitioning test to assert that `NativeShuffleExchangeExec` is used.

The general supported-type check is unchanged, so binary support is not enabled for unrelated operators or data source scans.

**Are there any user-facing changes?**
Queries that range-partition by a binary column can now use Auron's native shuffle path.

There are no user-facing API or configuration changes.

**How was this patch tested?**
UT.

**Was this patch authored or co-authored using generative AI tooling?**
- [x] Yes
- [ ] No
Codex was used only to Review and understand the codebase