### PR TITLE
[AURON #2482] handle optional sort indices for zero-column batches

### DIFF
--- a/native-engine/datafusion-ext-plans/src/sort_exec.rs
+++ b/native-engine/datafusion-ext-plans/src/sort_exec.rs
@@ -722,7 +722,7 @@ impl ExternalSorter {
                 take_batch(batch, sorted_indices.expect("non-fast-path indices"))?
             }
         } else {
-            create_zero_column_batch(sorted_indices.len())
+            create_zero_column_batch(sorted_indices.as_ref().map_or(keys.num_rows(), Vec::len))
         };
 
         // add to in-mem blocks


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2482

# Rationale for this change

The primitive sort fast path changed `sorted_indices` from `Vec<u32>` to `Option<Vec<u32>>`, but the zero-column batch path still calls `len()` as if it were a `Vec`.

This causes `datafusion-ext-plans` to fail compilation.

# What changes are included in this PR?

Use the sorted indices length when present, and fall back to the number of key rows for the primitive fast path.

# Are there any user-facing changes?

No.

# How was this patch tested?

UTs passed.

# Was this patch authored or co-authored using generative AI tooling?
- [x] Yes
- [ ] No

If yes, include: `Generated-by: <tool name and version>`

ASF guidance: https://www.apache.org/legal/generative-tooling.html
