### PR TITLE
[AURON #2308] Fix native shuffle exchange NPE in shuffle write tasks

### DIFF
--- a/spark-extension-shims-spark/src/test/scala/org/apache/auron/AuronQuerySuite.scala
+++ b/spark-extension-shims-spark/src/test/scala/org/apache/auron/AuronQuerySuite.scala
@@ -17,9 +17,11 @@
 package org.apache.auron
 
 import org.apache.spark.sql.{AuronQueryTest, Row}
+import org.apache.spark.sql.auron.NativeRDD
 import org.apache.spark.sql.auron.join.JoinBuildSides.{JoinBuildLeft, JoinBuildRight}
 import org.apache.spark.sql.execution.auron.plan.NativeFilterBase
 import org.apache.spark.sql.execution.auron.plan.NativeShuffledHashJoinBase
+import org.apache.spark.sql.execution.auron.plan.NativeShuffleExchangeBase
 import org.apache.spark.sql.execution.auron.plan.NativeShuffleExchangeExec
 import org.apache.spark.sql.execution.auron.plan.NativeSortMergeJoinBase
 import org.apache.spark.sql.execution.joins.auron.plan.NativeBroadcastJoinExec
@@ -114,9 +116,15 @@ class AuronQuerySuite extends AuronQueryTest with BaseAuronSQLSuite with AuronSQ
       sql("create table t1(c1 binary, c2 int) using parquet")
       sql("insert into t1 values (cast('test1' as binary), 1), (cast('test2' as binary), 2)")
       val df = checkSparkAnswerAndOperator("select c2 from t1 order by c1")
-      assert(collectFirst(df.queryExecution.executedPlan) { case e: NativeShuffleExchangeExec =>
-        e
-      }.isDefined)
+      val exchange = collectFirst(df.queryExecution.executedPlan) {
+        case e: NativeShuffleExchangeExec =>
+          e
+      }.get
+      val nativeShuffleRDD =
+        exchange.shuffleDependency.rdd.dependencies.head.rdd.asInstanceOf[NativeRDD]
+      assert(!nativeShuffleRDD.nativePlanWrapper.p.getClass.getDeclaredFields.exists { field =>
+        classOf[NativeShuffleExchangeBase].isAssignableFrom(field.getType)
+      })
     }
   }
 

--- a/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeShuffleExchangeBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeShuffleExchangeBase.scala
@@ -244,6 +244,9 @@ abstract class NativeShuffleExchangeBase(
       case _ => null
     }
 
+    val nativeHashExprs = this.nativeHashExprs
+    val nativeSortExecNode = this.nativeSortExecNode
+
     val nativeShuffleRDD = new NativeRDD(
       nativeInputRDD.sparkContext,
       nativeMetrics,


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2308

# Rationale for this change

The shuffle-write `NativeRDD` closure accessed `nativeHashExprs` and `nativeSortExecNode` through the enclosing `NativeShuffleExchangeBase`.

This caused the task closure to retain the exchange plan. When Spark cleared the `SparkPlan` tree before task execution, RangePartitioning shuffle writes could dereference the cleared outer plan and throw a `NullPointerException`.

# What changes are included in this PR?

- Evaluate `nativeHashExprs` and `nativeSortExecNode` before constructing the shuffle-write `NativeRDD`, so the task closure only captures the evaluated native plan values.
- Extend the existing binary RangePartitioning test to verify that the native plan closure no longer captures `NativeShuffleExchangeBase`.

# Are there any user-facing changes?

No. This is an internal execution correctness fix.

# How was this patch tested?

```bash
./dev/reformat --check

./build/mvn -Pspark-3.5 -Pscala-2.12 -pl spark-extension -am install -DskipTests -DskipBuildNative

./build/mvn -Pspark-3.5 -Pscala-2.12 -pl spark-extension-shims-spark test -Dsuites=org.apache.auron.AuronQuerySuite -Dsuffixes=NoDiscoveredSuites
```

# Was this patch authored or co-authored using generative AI tooling?
- [x] Yes
- [ ] No

Generated-by: OpenAI Codex (GPT-5)

ASF guidance: https://www.apache.org/legal/generative-tooling.html