### PR TITLE
[AURON #2488] Support dayofyear function natively

### DIFF
--- a/native-engine/datafusion-ext-functions/src/lib.rs
+++ b/native-engine/datafusion-ext-functions/src/lib.rs
@@ -91,6 +91,7 @@ pub fn create_auron_ext_function(
         "Spark_Year" => shared_function!(spark_dates::spark_year),
         "Spark_Month" => shared_function!(spark_dates::spark_month),
         "Spark_Day" => shared_function!(spark_dates::spark_day),
+        "Spark_DayOfYear" => shared_function!(spark_dates::spark_dayofyear),
         "Spark_DayOfWeek" => shared_function!(spark_dates::spark_dayofweek),
         "Spark_WeekOfYear" => shared_function!(spark_dates::spark_weekofyear),
         "Spark_Quarter" => shared_function!(spark_dates::spark_quarter),

--- a/native-engine/datafusion-ext-functions/src/spark_dates.rs
+++ b/native-engine/datafusion-ext-functions/src/spark_dates.rs
@@ -277,6 +277,14 @@ pub fn spark_day(args: &[ColumnarValue]) -> Result<ColumnarValue> {
     )?))
 }
 
+pub fn spark_dayofyear(args: &[ColumnarValue]) -> Result<ColumnarValue> {
+    let local = resolve_local_date32(args)?;
+    Ok(ColumnarValue::Array(date_part(
+        &(Arc::new(local) as ArrayRef),
+        DatePart::DayOfYear,
+    )?))
+}
+
 pub fn spark_last_day(args: &[ColumnarValue]) -> Result<ColumnarValue> {
     let input = resolve_local_date32(args)?;
     let last_day = Date32Array::from_iter(input.iter().map(|opt_days| {
@@ -604,6 +612,30 @@ mod tests {
             None,
         ]));
         assert_eq!(&spark_day(&args)?.into_array(1)?, &expected_ret);
+        Ok(())
+    }
+
+    #[test]
+    fn test_spark_dayofyear() -> Result<()> {
+        let date = |year, month, day| {
+            NaiveDate::from_ymd_opt(year, month, day)
+                .expect("test date must be valid")
+                .to_epoch_days()
+        };
+        let input = Arc::new(Date32Array::from(vec![
+            Some(date(2016, 4, 9)),
+            Some(date(2023, 12, 31)),
+            Some(date(2024, 12, 31)),
+            None,
+        ]));
+        let args = vec![ColumnarValue::Array(input)];
+        let expected_ret: ArrayRef = Arc::new(Int32Array::from(vec![
+            Some(100),
+            Some(365),
+            Some(366),
+            None,
+        ]));
+        assert_eq!(&spark_dayofyear(&args)?.into_array(1)?, &expected_ret);
         Ok(())
     }
 
@@ -1325,6 +1357,8 @@ mod tests {
         let out_month =
             spark_month(&[ColumnarValue::Array(ts.clone()), tz.clone()])?.into_array(1)?;
         let out_day = spark_day(&[ColumnarValue::Array(ts.clone()), tz.clone()])?.into_array(1)?;
+        let out_doy =
+            spark_dayofyear(&[ColumnarValue::Array(ts.clone()), tz.clone()])?.into_array(1)?;
         let out_quarter =
             spark_quarter(&[ColumnarValue::Array(ts.clone()), tz.clone()])?.into_array(1)?;
         let out_dow = spark_dayofweek(&[ColumnarValue::Array(ts), tz])?.into_array(1)?;
@@ -1332,12 +1366,14 @@ mod tests {
         let expected_year: ArrayRef = Arc::new(Int32Array::from(vec![Some(2022)]));
         let expected_month: ArrayRef = Arc::new(Int32Array::from(vec![Some(1)]));
         let expected_day: ArrayRef = Arc::new(Int32Array::from(vec![Some(1)]));
+        let expected_doy: ArrayRef = Arc::new(Int32Array::from(vec![Some(1)]));
         let expected_quarter: ArrayRef = Arc::new(Int32Array::from(vec![Some(1)]));
         let expected_dow: ArrayRef = Arc::new(Int32Array::from(vec![Some(7)])); // Saturday
 
         assert_eq!(&out_year, &expected_year);
         assert_eq!(&out_month, &expected_month);
         assert_eq!(&out_day, &expected_day);
+        assert_eq!(&out_doy, &expected_doy);
         assert_eq!(&out_quarter, &expected_quarter);
         assert_eq!(&out_dow, &expected_dow);
         Ok(())

--- a/spark-extension-shims-spark/src/test/scala/org/apache/auron/AuronFunctionSuite.scala
+++ b/spark-extension-shims-spark/src/test/scala/org/apache/auron/AuronFunctionSuite.scala
@@ -170,6 +170,23 @@ class AuronFunctionSuite extends AuronQueryTest with BaseAuronSQLSuite {
     }
   }
 
+  test("dayofyear function") {
+    withSQLConf(SQLConf.SESSION_LOCAL_TIMEZONE.key -> "UTC") {
+      withTable("t1") {
+        sql("create table t1(c1 date, c2 timestamp) using parquet")
+        sql("""
+            |insert into t1 values
+            |  (date'2016-04-09', timestamp'2016-04-09 12:34:56'),
+            |  (date'2023-12-31', timestamp'2023-12-31 23:59:59'),
+            |  (date'2024-12-31', timestamp'2024-12-31 23:59:59'),
+            |  (null, null)
+            |""".stripMargin)
+
+        checkSparkAnswerAndOperator("select dayofyear(c1), dayofyear(c2) from t1")
+      }
+    }
+  }
+
   test("last_day function") {
     withTable("t1") {
       sql("create table t1(c1 date) using parquet")
@@ -193,7 +210,7 @@ class AuronFunctionSuite extends AuronQueryTest with BaseAuronSQLSuite {
       }
       withSQLConf(SQLConf.SESSION_LOCAL_TIMEZONE.key -> "America/New_York") {
         checkSparkAnswerAndOperator(
-          "select year(c1), month(c1), dayofmonth(c1), dayofweek(c1), quarter(c1) from t1")
+          "select year(c1), month(c1), dayofmonth(c1), dayofyear(c1), dayofweek(c1), quarter(c1) from t1")
       }
     }
   }
@@ -204,7 +221,7 @@ class AuronFunctionSuite extends AuronQueryTest with BaseAuronSQLSuite {
         sql("create table t1(c1 date) using parquet")
         sql("insert into t1 values(date'2021-01-04')")
         checkSparkAnswerAndOperator(
-          "select year(c1), month(c1), dayofmonth(c1), dayofweek(c1), quarter(c1) from t1")
+          "select year(c1), month(c1), dayofmonth(c1), dayofyear(c1), dayofweek(c1), quarter(c1) from t1")
       }
     }
   }

--- a/spark-extension/src/main/scala/org/apache/spark/sql/auron/NativeConverters.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/auron/NativeConverters.scala
@@ -992,6 +992,8 @@ object NativeConverters extends Logging {
         buildTimePartExt("Spark_Month", child, isPruningExpr, fallback)
       case DayOfMonth(child) =>
         buildTimePartExt("Spark_Day", child, isPruningExpr, fallback)
+      case DayOfYear(child) =>
+        buildTimePartExt("Spark_DayOfYear", child, isPruningExpr, fallback)
       case DayOfWeek(child) =>
         buildTimePartExt("Spark_DayOfWeek", child, isPruningExpr, fallback)
       case WeekOfYear(child) =>


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2488

# Rationale for this change

Spark `DayOfYear` expressions cannot currently be converted to native expressions, causing affected plans to fall back to Spark execution.

# What changes are included in this PR?

- Convert Spark `DayOfYear` expressions to the `Spark_DayOfYear` extension function.
- Implement `Spark_DayOfYear` using the existing local Date32 conversion and Arrow `DatePart::DayOfYear`.
- Add Rust unit tests and Spark regression coverage for date and timestamp inputs, leap-year and year-boundary cases, null values, and non-UTC session time zones.

# Are there any user-facing changes?

No. The Spark SQL syntax and result semantics remain unchanged. Eligible `dayofyear` expressions can now run natively.

# How was this patch tested?

```bash
cargo test -p datafusion-ext-functions spark_dates::tests::test_spark_dayofyear -- --exact

cargo test -p datafusion-ext-functions --lib

./dev/reformat --check

./auron-build.sh --pre --clean true --sparkver 3.5 --scalaver 2.12 --skiptests false -DwildcardSuites=org.apache.auron.AuronFunctionSuite
```

# Was this patch authored or co-authored using generative AI tooling?
- [x] Yes
- [ ] No

Generated-by: OpenAI Codex (GPT-5)

ASF guidance: https://www.apache.org/legal/generative-tooling.html
