### PR TITLE
[AURON #2491] Carry Spark's logical link onto converted native plans

### DIFF
--- a/spark-extension-shims-spark/src/test/scala/org/apache/auron/AuronQuerySuite.scala
+++ b/spark-extension-shims-spark/src/test/scala/org/apache/auron/AuronQuerySuite.scala
@@ -1156,6 +1156,16 @@ class AuronQuerySuite extends AuronQueryTest with BaseAuronSQLSuite with AuronSQ
     }
   }
 
+  // Before Spark 3.2, TreeNode.withNewChildren is overridable and copies tags only by way of
+  // makeCopy. The native plan nodes override it with a plain copy of the case class, so no tag
+  // survives a child rebuild on those versions. The converter still sets the logical link
+  // everywhere, but adaptive execution drops it again as soon as it substitutes a query stage
+  // into the tree, so only the versions below can be asserted on the executed plan.
+  private def assumeTagsSurviveChildRebuild(): Unit =
+    assume(
+      sparkver.matchVersion("3.2 / 3.3 / 3.4 / 3.5 / 4.0 / 4.1 / 4.2"),
+      "native plan nodes drop tags on withNewChildren before Spark 3.2")
+
   test("the same DataFrame can be executed more than once") {
     withLinkTestTables {
       val df =
@@ -1168,6 +1178,7 @@ class AuronQuerySuite extends AuronQueryTest with BaseAuronSQLSuite with AuronSQ
   }
 
   test("converted native plans carry Spark's logical link") {
+    assumeTagsSurviveChildRebuild()
     withLinkTestTables {
       val df =
         checkSparkAnswerAndOperator("select c1 from t1 where c2 > (select max(c3) from t2)")
@@ -1185,6 +1196,7 @@ class AuronQuerySuite extends AuronQueryTest with BaseAuronSQLSuite with AuronSQ
   }
 
   test("converted native plans keep one logical link per operator") {
+    assumeTagsSurviveChildRebuild()
     withLinkTestTables {
       val df =
         checkSparkAnswerAndOperator("select t1.c1, t2.c3 from t1 join t2 on t1.c2 = t2.c3")

--- a/spark-extension-shims-spark/src/test/scala/org/apache/auron/AuronQuerySuite.scala
+++ b/spark-extension-shims-spark/src/test/scala/org/apache/auron/AuronQuerySuite.scala
@@ -18,7 +18,10 @@ package org.apache.auron
 
 import org.apache.spark.sql.{AuronQueryTest, Row}
 import org.apache.spark.sql.auron.NativeRDD
+import org.apache.spark.sql.auron.NativeSupports
 import org.apache.spark.sql.auron.join.JoinBuildSides.{JoinBuildLeft, JoinBuildRight}
+import org.apache.spark.sql.catalyst.plans.logical.{Join, LogicalPlan}
+import org.apache.spark.sql.execution.auron.plan.NativeBroadcastJoinBase
 import org.apache.spark.sql.execution.auron.plan.NativeFilterBase
 import org.apache.spark.sql.execution.auron.plan.NativeShuffledHashJoinBase
 import org.apache.spark.sql.execution.auron.plan.NativeShuffleExchangeBase
@@ -1142,6 +1145,78 @@ class AuronQuerySuite extends AuronQueryTest with BaseAuronSQLSuite with AuronSQ
       // OR drops the b-branch -> pushes only `id = 5` -> row groups without id=5 are skipped,
       // losing the row where b='900000'
       checkSparkAnswerAndOperator("select * from orc_or where id = 5 or b = 900000")
+    }
+  }
+
+  private def withLinkTestTables(body: => Unit): Unit = {
+    withTable("t1", "t2") {
+      sql("create table t1 using parquet as select id as c1, id + 1 as c2 from range(10)")
+      sql("create table t2 using parquet as select id as c3 from range(5)")
+      body
+    }
+  }
+
+  test("the same DataFrame can be executed more than once") {
+    withLinkTestTables {
+      val df =
+        checkSparkAnswerAndOperator("select c1 from t1 where c2 > (select max(c3) from t2)")
+
+      // Re-executing the same DataFrame re-enters adaptive stage creation, this time against
+      // the plan Auron produced rather than the plan Spark planned.
+      checkAnswer(df, (4L to 9L).map(Row(_)))
+    }
+  }
+
+  test("converted native plans carry Spark's logical link") {
+    withLinkTestTables {
+      val df =
+        checkSparkAnswerAndOperator("select c1 from t1 where c2 > (select max(c3) from t2)")
+
+      val plan = stripAQEPlan(df.queryExecution.executedPlan)
+      val nativeNodes = plan.collect { case p: NativeSupports => p }
+      assert(nativeNodes.nonEmpty, s"expected native operators in:\n$plan")
+
+      // Every native node is checked because this query needs no exchange in the main tree.
+      assert(
+        nativeNodes.forall(_.logicalLink.isDefined),
+        "native operators without a logical link: " +
+          s"${nativeNodes.filter(_.logicalLink.isEmpty).map(_.nodeName).mkString(", ")}\n$plan")
+    }
+  }
+
+  test("converted native plans keep one logical link per operator") {
+    withLinkTestTables {
+      val df =
+        checkSparkAnswerAndOperator("select t1.c1, t2.c3 from t1 join t2 on t1.c2 = t2.c3")
+
+      val plan = stripAQEPlan(df.queryExecution.executedPlan)
+      val links = plan.collect { case p: NativeSupports => p }.flatMap(_.logicalLink)
+      val distinctLinks = links.foldLeft(Seq.empty[LogicalPlan]) { (acc, link) =>
+        if (acc.exists(_.eq(link))) acc else acc :+ link
+      }
+
+      // A strategy plans one logical node into a whole physical subtree and links only that
+      // subtree's root, so nodes within one planning unit legitimately share a link. Across
+      // units the links must differ. Comparing by reference keeps two units of the same kind
+      // distinct.
+      assert(
+        distinctLinks.size > 1,
+        "native operators share a single logical link: " +
+          s"${distinctLinks.map(_.nodeName).mkString(", ")}\n$plan")
+
+      // Counting links cannot tell a correct labelling from one shifted a level up the tree,
+      // where every node carries its parent's link and the count is unchanged. Pin the join.
+      val joinNodes = plan.collect {
+        case p: NativeBroadcastJoinBase => p
+        case p: NativeSortMergeJoinBase => p
+        case p: NativeShuffledHashJoinBase => p
+      }
+      assert(joinNodes.size == 1, s"expected exactly one native join in:\n$plan")
+      assert(
+        joinNodes.head.logicalLink.exists(_.isInstanceOf[Join]),
+        "native join is linked to " +
+          s"${joinNodes.head.logicalLink.map(_.nodeName).getOrElse("nothing")}, not a Join" +
+          s"\n$plan")
     }
   }
 }

--- a/spark-extension/src/main/scala/org/apache/spark/sql/auron/AuronConverters.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/auron/AuronConverters.scala
@@ -202,7 +202,14 @@ object AuronConverters extends Logging {
       exec.getTagValue(joinSmallerSideTag).foreach(newExec.setTagValue(joinSmallerSideTag, _))
 
       if (!isNeverConvert(newExec)) {
-        newExec = convertSparkPlan(newExec)
+        val convertedExec = convertSparkPlan(newExec)
+        newExec = if (convertedExec.eq(newExec)) {
+          convertedExec
+        } else {
+          // A converted node is built from scratch, so Spark's logical link does not travel
+          // with it. AQE searches a query stage's subtree for a link and asserts it finds one.
+          Shims.get.setLogicalLink(convertedExec, exec)
+        }
       }
       danglingConverted = newDanglingConverted :+ newExec
     }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2491

# Rationale for this change

Converting a Spark plan node to a native one builds a new node, and Spark's `logicalLink` does not travel with it. On Spark 4 that is enough to fail a query.

`AdaptiveSparkPlanExec.setLogicalLinkForNewQueryStage` asserts that a new query stage's subtree carries a logical link. The assertion is the same in 3.5 and 4.0; what differs is when it sees Auron's output. Spark 3.5 short-circuits a repeated collect, since `getFinalPhysicalPlan()` returns early once `isFinalPlan` is set, so no new stage is created. Spark 4 re-enters `createQueryStages(..., firstRun = true)` on every collect, and the comment on that branch names the case directly ("e.g, when we do `df.collect` multiple times"). On that pass the plan handed to the assertion is the post-`preColumnarTransitions` one, and the link is gone.

So executing the same `DataFrame` twice fails on Spark 4 whenever the final plan is fully native and has no exchange in it:

```scala
val df = spark.sql("select c1 from t1 where c2 > (select max(c3) from t2)")
df.collect()
df.collect()   // AssertionError inside setLogicalLinkForNewQueryStage
```

Any shuffle in the tree masks it, because a `ShuffleQueryStageExec` satisfies the assertion on its own, and so does any partial fallback that leaves a Spark node carrying a link. Auron sets `ADAPTIVE_EXECUTION_FORCE_APPLY`, so AQE is always in the path.

The first collect is unaffected: it runs against the pre-columnar plan. `QueryStageExec` is a `LeafExecNode`, so link-setting does not descend into a stage's inner plan either.

# What changes are included in this PR?

`AuronConverters.convertSparkPlanRecursively` now carries the original node's logical link onto the node that replaces it, alongside the four tags it already copies there. `Shims.setLogicalLink` already existed and is unchanged; this adds the call site.

The link is set only when conversion actually returned a different instance. When it returns the same node, that node already carries its link through `copyTagsFrom`, and setting it again would promote its inherited tag to a primary one and recurse into the original children.

The call sits in the recursive walk rather than in `tryConvert` for two reasons. `tryConvert` is not the only path that builds a replacement — `Shims.get.convertMoreSparkPlan` does so outside it. And `convertSparkPlan` runs twice per plan: `AuronConvertStrategy` converts the whole tree once purely to compute tags and discards the result, so a call in `tryConvert` would also fire on that discarded pass.

Some history, since the call is not new. It existed until `441a1a24` (2022-12-12), which moved `setTagValue(convertibleTag, true)` from the shim into `tryConvert` and dropped the `setLogicalLink` effect along with it. The shim body of that era also recursed over children, though under a guard that made the recursion inert — Spark's own `setLogicalLink` fans inherited tags downward first, so the guard never passed below the top node. The current shim has no such recursion.

# Are there any user-facing changes?

Executing the same `DataFrame` more than once now succeeds on Spark 4, as it does on Spark 3 and as it does without Auron.

Converted nodes now carry a logical link where they previously carried none. Spark's `setLogicalLink` writes a primary tag on the node it is called on and fans inherited tags downward, halting at any descendant that already owns a primary tag, so a link is only ever added below a node that already had it — never moved upward. Both consumers that could be affected take the topmost match, so the answers they compute are unchanged. Every other reader of `logicalLink` in `sql/core` runs before the columnar rules, and the only rule running after Auron is `CollapseCodegenStages`, which does not read it.

One consumer was not proven unaffected and is worth watching rather than claiming: `RemoveRedundantProjects.canRemove` keys off `logicalLink.isEmpty`, and a pre-columnar `ProjectExec` that gains an inherited tag stops qualifying. The rule lists were traced and no path was found where it re-runs on nodes Auron has touched, but that is an absence of evidence rather than a proof. TPC-DS plan stability is the check that would catch it.

# How was this patch tested?

Three cases in `AuronQuerySuite`, on the same fully native, exchange-free fixture.

The repeated execution case runs on every profile from spark-3.0 to spark-4.2. The two assertions on the executed plan run on spark-3.2 and above and are assumed away below it. Before Spark 3.2, `TreeNode.withNewChildren` is overridable and reaches `copyTagsFrom` only by way of `makeCopy`, and the native plan nodes override it with a plain copy of the case class, so no node tag survives a child rebuild there. The converter sets the link on every version, but on 3.0 and 3.1 adaptive execution drops it again as soon as it substitutes a query stage into the tree. That gap sits in the node overrides rather than in the conversion path, it predates this change, and it does not affect the bug being fixed, which is specific to Spark 4.

- the same `DataFrame` executed twice returns the right rows. This is the regression itself, and it is inert on Spark 3, where the second collect short-circuits
- every native node in the plan carries a logical link
- native nodes in one plan do not all collapse onto a single link, and the node realizing the join is linked to a `Join`

Each was proved to pin what it claims by mutation, run module-wide against the whole suite rather than a single class:

| mutation | which test fails |
|---|---|
| the fix removed | all three (2 on Spark 3, where the first is inert) |
| the link stamped onto every descendant, collapsing them | the collapse check |
| the link stamped one level down, shifting every operator | the identity check, while the collapse check still passes |

The third mutation is why both assertions are kept: a shift mislabels every operator while leaving the distinct count intact, so a cardinality check alone would pass it.

Measured on spark-3.5/scala-2.12 and spark-4.0.2/scala-2.13: 150 → 152 passing on 3.5, 149 → 152 on 4.0, with exactly the three new tests changing state and no other test affected in either direction, confirmed by set difference rather than by counting.

The identity assertion matches the three native join base types rather than a concrete class, and was re-run with broadcast joins disabled and sort-merge preferred to confirm it does not depend on a join strategy.

# Was this patch authored or co-authored using generative AI tooling?
- [x] Yes
- [ ] No

Generated-by: Claude Code (Opus 5)

