### PR TITLE
[AURON #2495] Docs: update README description

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 github:
-  description: "The Auron accelerator for distributed computing framework (e.g., Spark) leverages native vectorized execution to accelerate query processing"
+  description: "Apache Auron(Incubating) is an accelerator for big data engines, leveraging native vectorized execution to accelerate query processing."
   homepage: https://auron.apache.org/
   labels:
     - rust-lang

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 <p align="center"><img src="./dev/auron-logo.png" alt="Auron logo" /></p>
 
-The Auron accelerator for big data engines (e.g., Spark, Flink) leverages native vectorized execution to accelerate query processing. It combines
+Apache Auron(Incubating) is an accelerator for big data engines, leveraging native vectorized execution to accelerate query processing. It combines
 the power of the [Apache DataFusion](https://arrow.apache.org/datafusion/) library and the scale of the distributed
 computing framework.
 


### PR DESCRIPTION
## Summary

Removed the parenthetical engine listing `(e.g., Spark, Flink)` from README first sentence, aligning with updated messaging.

## Changes

**Before:**
> The Auron accelerator for big data engines (e.g., Spark, Flink) leverages native vectorized execution to accelerate query processing.

**After:**
> Apache Auron(Incubating) is an accelerator for big data engines, leveraging native vectorized execution to accelerate query processing.