### PR TITLE
[AURON #2475] Fix float-to-decimal precision loss

### DIFF
--- a/auron-spark-tests/spark31/src/test/scala/org/apache/auron/utils/AuronSparkTestSettings.scala
+++ b/auron-spark-tests/spark31/src/test/scala/org/apache/auron/utils/AuronSparkTestSettings.scala
@@ -84,7 +84,6 @@ class AuronSparkTestSettings extends SparkTestSettings {
     .exclude("SPARK-35955: Aggregate avg should not return wrong results for decimal overflow")
     .exclude("NaN is greater than all other non-NaN numeric values")
     .exclude("SPARK-20897: cached self-join should not fail")
-    .exclude("SPARK-22271: mean overflows and returns null for some decimal variables")
     .exclude("SPARK-32764: -0.0 and 0.0 should be equal")
 
   enableSuite[AuronParquetAvroCompatibilitySuite]

--- a/auron-spark-tests/spark32/src/test/scala/org/apache/auron/utils/AuronSparkTestSettings.scala
+++ b/auron-spark-tests/spark32/src/test/scala/org/apache/auron/utils/AuronSparkTestSettings.scala
@@ -81,7 +81,6 @@ class AuronSparkTestSettings extends SparkTestSettings {
     .exclude("SPARK-35955: Aggregate avg should not return wrong results for decimal overflow")
     .exclude("NaN is greater than all other non-NaN numeric values")
     .exclude("SPARK-20897: cached self-join should not fail")
-    .exclude("SPARK-22271: mean overflows and returns null for some decimal variables")
     .exclude("SPARK-32764: -0.0 and 0.0 should be equal")
 
   enableSuite[AuronParquetAvroCompatibilitySuite]

--- a/auron-spark-tests/spark33/src/test/scala/org/apache/auron/utils/AuronSparkTestSettings.scala
+++ b/auron-spark-tests/spark33/src/test/scala/org/apache/auron/utils/AuronSparkTestSettings.scala
@@ -52,7 +52,6 @@ class AuronSparkTestSettings extends SparkTestSettings {
     .exclude("SPARK-35955: Aggregate avg should not return wrong results for decimal overflow")
     .exclude("NaN is greater than all other non-NaN numeric values")
     .exclude("SPARK-20897: cached self-join should not fail")
-    .exclude("SPARK-22271: mean overflows and returns null for some decimal variables")
     .exclude("SPARK-32764: -0.0 and 0.0 should be equal")
 
   // Will be implemented in the future.

--- a/auron-spark-tests/spark34/src/test/scala/org/apache/auron/utils/AuronSparkTestSettings.scala
+++ b/auron-spark-tests/spark34/src/test/scala/org/apache/auron/utils/AuronSparkTestSettings.scala
@@ -81,7 +81,6 @@ class AuronSparkTestSettings extends SparkTestSettings {
     .exclude("SPARK-35955: Aggregate avg should not return wrong results for decimal overflow")
     .exclude("NaN is greater than all other non-NaN numeric values")
     .exclude("SPARK-20897: cached self-join should not fail")
-    .exclude("SPARK-22271: mean overflows and returns null for some decimal variables")
     .exclude("SPARK-32764: -0.0 and 0.0 should be equal")
     .exclude("SPARK-41048: Improve output partitioning and ordering with AQE cache")
 

--- a/auron-spark-tests/spark35/src/test/scala/org/apache/auron/utils/AuronSparkTestSettings.scala
+++ b/auron-spark-tests/spark35/src/test/scala/org/apache/auron/utils/AuronSparkTestSettings.scala
@@ -85,7 +85,6 @@ class AuronSparkTestSettings extends SparkTestSettings {
     .exclude("SPARK-35955: Aggregate avg should not return wrong results for decimal overflow")
     .exclude("NaN is greater than all other non-NaN numeric values")
     .exclude("SPARK-20897: cached self-join should not fail")
-    .exclude("SPARK-22271: mean overflows and returns null for some decimal variables")
     .exclude("SPARK-32764: -0.0 and 0.0 should be equal")
     .exclude("SPARK-41048: Improve output partitioning and ordering with AQE cache")
 

--- a/native-engine/datafusion-ext-commons/src/arrow/cast.rs
+++ b/native-engine/datafusion-ext-commons/src/arrow/cast.rs
@@ -223,7 +223,8 @@ pub fn cast_impl(
         (&DataType::Utf8, DataType::Decimal128(..)) => {
             arrow::compute::kernels::cast::cast(&to_plain_string_array(array), cast_type)?
         }
-        // spark compatible float to decimal
+        // Spark formats finite floats as shortest round-trip strings before exact rescaling;
+        // non-finite values become NULL.
         (&DataType::Float32, DataType::Decimal128(..))
         | (&DataType::Float64, DataType::Decimal128(..)) => {
             let floats = arrow::compute::cast(array, &DataType::Float64)?;
@@ -670,6 +671,13 @@ mod test {
             as_decimal128_array(&casted)?,
             &Decimal128Array::from(vec![100_000_001_490_116_120i128])
                 .with_precision_and_scale(20, 18)?
+        );
+
+        let rounding_array: ArrayRef = Arc::new(Float64Array::from(vec![1.25, -1.25, -0.0]));
+        let casted = cast(&rounding_array, &DataType::Decimal128(2, 1))?;
+        assert_eq!(
+            as_decimal128_array(&casted)?,
+            &Decimal128Array::from(vec![13, -13, 0]).with_precision_and_scale(2, 1)?
         );
         Ok(())
     }

--- a/native-engine/datafusion-ext-commons/src/arrow/cast.rs
+++ b/native-engine/datafusion-ext-commons/src/arrow/cast.rs
@@ -223,6 +223,21 @@ pub fn cast_impl(
         (&DataType::Utf8, DataType::Decimal128(..)) => {
             arrow::compute::kernels::cast::cast(&to_plain_string_array(array), cast_type)?
         }
+        // spark compatible float to decimal
+        (&DataType::Float32, DataType::Decimal128(..))
+        | (&DataType::Float64, DataType::Decimal128(..)) => {
+            let floats = arrow::compute::cast(array, &DataType::Float64)?;
+            let strings = floats
+                .as_primitive::<Float64Type>()
+                .iter()
+                .map(|value| {
+                    value
+                        .filter(|value| value.is_finite())
+                        .map(|value| value.to_string())
+                })
+                .collect::<StringArray>();
+            cast_impl(&strings, cast_type, match_struct_fields)?
+        }
         // map to string (spark compatible)
         (&DataType::Map(..), &DataType::Utf8) => {
             let map_array = as_map_array(array);
@@ -621,6 +636,40 @@ mod test {
                 Some(i32::MIN as i128 * 1000000000000000000),
             ])
             .with_precision_and_scale(38, 18)?
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_float_to_decimal() -> Result<()> {
+        let f64_array: ArrayRef = Arc::new(Float64Array::from_iter(vec![
+            Some(0.034567890),
+            None,
+            Some(f64::NAN),
+            Some(f64::INFINITY),
+            Some(f64::NEG_INFINITY),
+            Some(1e40),
+        ]));
+        let casted = cast(&f64_array, &DataType::Decimal128(38, 33))?;
+        assert_eq!(
+            as_decimal128_array(&casted)?,
+            &Decimal128Array::from_iter(vec![
+                Some(34_567_890_000_000_000_000_000_000_000_000i128),
+                None,
+                None,
+                None,
+                None,
+                None,
+            ])
+            .with_precision_and_scale(38, 33)?
+        );
+
+        let f32_array: ArrayRef = Arc::new(Float32Array::from(vec![0.1]));
+        let casted = cast(&f32_array, &DataType::Decimal128(20, 18))?;
+        assert_eq!(
+            as_decimal128_array(&casted)?,
+            &Decimal128Array::from(vec![100_000_001_490_116_120i128])
+                .with_precision_and_scale(20, 18)?
         );
         Ok(())
     }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2475

# Rationale for this change

Auron currently delegates `Float32/Float64 -> Decimal128` casts to Arrow's native cast kernel. That kernel scales the input by `10^scale` using floating-point arithmetic, which introduces incorrect digits at high decimal scales.

Spark instead converts the floating-point value to its shortest round-trip decimal representation before rescaling it exactly.

# What changes are included in this PR?

- Add a Spark-compatible `Float32/Float64 -> Decimal128` path in `cast_impl`.
- Widen `Float32` values to `Float64` before formatting, matching Spark behavior.
- Reuse the existing string-to-decimal path for rounding and precision-overflow handling.
- Return NULL for NULL, NaN, infinity, and precision-overflow inputs.
- Add Rust regression coverage for high-scale casts and edge cases.
- Re-enable the `SPARK-22271` regression test for Spark 3.1 through 3.5.

# Are there any user-facing changes?

Bug fix only. Casting float or double values to decimal now matches Spark at high decimal scales. There are no public API or configuration changes.

# How was this patch tested?

- `cargo test -p datafusion-ext-commons test_float_to_decimal -- --nocapture`
- `cargo test -p datafusion-ext-commons`
- `./dev/reformat --check`
- `./auron-build.sh --pre --sparkver 3.5 --scalaver 2.12 --skiptests true`


# Was this patch authored or co-authored using generative AI tooling?

- [x] Yes
- [ ] No

Generated-by: OpenAI Codex (GPT-5)

ASF guidance: https://www.apache.org/legal/generative-tooling.html