### PR TITLE
[AURON #2499] perf: avoid identity take in GenerateExec

### DIFF
--- a/native-engine/datafusion-ext-plans/src/generate_exec.rs
+++ b/native-engine/datafusion-ext-plans/src/generate_exec.rs
@@ -274,9 +274,13 @@ fn execute_generate(
                         let generated_ids = generated_ids.finish();
                         let child_outputs = take_cols(&child_outputs, child_output_row_ids)?;
                         let generated_outputs = match generated_outputs {
-                            Some(generated_outputs) => {
+                            Some(generated_outputs) if outer => {
                                 take_cols(&generated_outputs.cols, generated_ids)?
                             }
+                            // Without outer rows, generated_ids is always the identity
+                            // sequence 0..generated_outputs.len(). Reuse the generated
+                            // arrays instead of copying them through Arrow take.
+                            Some(generated_outputs) => generated_outputs.cols,
                             None => generator_output_schema
                                 .fields()
                                 .iter()

--- a/native-engine/datafusion-ext-plans/src/generate_exec.rs
+++ b/native-engine/datafusion-ext-plans/src/generate_exec.rs
@@ -277,9 +277,9 @@ fn execute_generate(
                             Some(generated_outputs) if outer => {
                                 take_cols(&generated_outputs.cols, generated_ids)?
                             }
-                            // Without outer rows, generated_ids is always the identity
-                            // sequence 0..generated_outputs.len(). Reuse the generated
-                            // arrays instead of copying them through Arrow take.
+                            // When outer is false, generated_ids is the identity sequence
+                            // 0..generated_outputs.row_ids.len(). Reuse the generated arrays
+                            // instead of copying them through Arrow take.
                             Some(generated_outputs) => generated_outputs.cols,
                             None => generator_output_schema
                                 .fields()


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2499

# Rationale for this change

Avoid redundant generated-array copies during non-outer `GenerateExec`.

# What changes are included in this PR?

- Reuse generated output arrays directly when `outer` is false.
- Keep the existing `take` path for outer generation.
- Preserve the child-column `take` required to duplicate parent rows.

# Are there any user-facing changes?

No. This is an internal performance improvement.

# How was this patch tested?

Existed unit tests passed.

# Benchmarks

The benchmark uses 10,000 input rows with 8 values per row. The reported values are averages of two runs.

| Benchmark | Before | After | Improvement |
| --- | ---: | ---: | ---: |
| `explode_array_i32` | 0.625 ms | 0.567 ms | 9.3% |
| `posexplode_array_i32` | 0.728 ms | 0.617 ms | 15.3% |
| `explode_map_utf8_i32` | 1.156 ms | 0.544 ms | 53.0% |
| `explode_array_i32_parent_null_gaps` | 0.551 ms | 0.526 ms | 4.5% |

# Was this patch authored or co-authored using generative AI tooling?
- [x] Yes
- [ ] No

If yes, include: `Generated-by: gpt-5.6`

ASF guidance: https://www.apache.org/legal/generative-tooling.html
