### PR TITLE
[AURON #2351] Reduce native broadcast task serialization size

### DIFF
--- a/spark-extension-shims-spark/src/test/scala/org/apache/auron/AuronCheckConvertBroadcastExchangeSuite.scala
+++ b/spark-extension-shims-spark/src/test/scala/org/apache/auron/AuronCheckConvertBroadcastExchangeSuite.scala
@@ -36,15 +36,16 @@ class AuronCheckConvertBroadcastExchangeSuite extends AuronQueryTest with BaseAu
       Seq(0, 255).toDF("key").createOrReplaceTempView("broad_cast_table2")
 
       val df = spark.sql(
-        "select /*+ broadcast(a)*/ b.key from broad_cast_table1 a " +
+        "select /*+ broadcast(a)*/ b.key, a.payload from broad_cast_table1 a " +
           "inner join broad_cast_table2 b on a.key = b.key")
 
-      checkAnswer(df, Seq(Row(0), Row(255)))
+      checkAnswer(df, Seq(Row(0, s"0$payload"), Row(255, s"255$payload")))
       val exchange = collectFirst(df.queryExecution.executedPlan) {
         case broadcastExchangeExec: NativeBroadcastExchangeExec => broadcastExchangeExec
       }.get
       val broadcast = exchange.executeBroadcast[Any]()
       try {
+        assert(broadcast eq exchange.executeBroadcast[Any]())
         val serialized = SparkEnv.get.closureSerializer.newInstance().serialize(broadcast)
         assert(serialized.remaining() < 64 * 1024)
       } finally {

--- a/spark-extension-shims-spark/src/test/scala/org/apache/auron/AuronCheckConvertBroadcastExchangeSuite.scala
+++ b/spark-extension-shims-spark/src/test/scala/org/apache/auron/AuronCheckConvertBroadcastExchangeSuite.scala
@@ -16,12 +16,42 @@
  */
 package org.apache.auron
 
+import org.apache.spark.SparkEnv
 import org.apache.spark.sql.{AuronQueryTest, Row}
 import org.apache.spark.sql.execution.auron.plan.NativeBroadcastExchangeExec
 import org.apache.spark.sql.execution.exchange.BroadcastExchangeExec
 
 class AuronCheckConvertBroadcastExchangeSuite extends AuronQueryTest with BaseAuronSQLSuite {
   import testImplicits._
+
+  test("do not serialize the broadcast relation with Spark tasks") {
+    withSQLConf(
+      "spark.auron.enable.broadcastExchange" -> "true",
+      "spark.auron.enable.bhj" -> "false") {
+      val payload = "x" * 4096
+      (0 until 256)
+        .map(i => (i, s"$i$payload"))
+        .toDF("key", "payload")
+        .createOrReplaceTempView("broad_cast_table1")
+      Seq(0, 255).toDF("key").createOrReplaceTempView("broad_cast_table2")
+
+      val df = spark.sql(
+        "select /*+ broadcast(a)*/ b.key from broad_cast_table1 a " +
+          "inner join broad_cast_table2 b on a.key = b.key")
+
+      checkAnswer(df, Seq(Row(0), Row(255)))
+      val exchange = collectFirst(df.queryExecution.executedPlan) {
+        case broadcastExchangeExec: NativeBroadcastExchangeExec => broadcastExchangeExec
+      }.get
+      val broadcast = exchange.executeBroadcast[Any]()
+      try {
+        val serialized = SparkEnv.get.closureSerializer.newInstance().serialize(broadcast)
+        assert(serialized.remaining() < 64 * 1024)
+      } finally {
+        broadcast.destroy()
+      }
+    }
+  }
 
   test(
     "test bhj broadcastExchange to native where spark.auron.enable.broadcastExchange is true") {

--- a/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeBroadcastExchangeBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeBroadcastExchangeBase.scala
@@ -27,7 +27,6 @@ import scala.collection.immutable.SortedMap
 import scala.concurrent.Promise
 import scala.jdk.CollectionConverters._
 
-import org.apache.commons.lang3.reflect.MethodUtils
 import org.apache.spark.OneToOneDependency
 import org.apache.spark.Partition
 import org.apache.spark.SparkException
@@ -145,18 +144,7 @@ abstract class NativeBroadcastExchangeBase(mode: BroadcastMode, override val chi
       .map(_.copy())
       .toArray
 
-    val broadcast = relationFuture.get // broadcast must be resolved
-    val v = mode.transform(dataRows)
-    val dummyBroadcasted = new Broadcast[Any](-1) {
-      override protected def getValue(): Any = v
-      override protected def doUnpersist(blocking: Boolean): Unit = {
-        MethodUtils.invokeMethod(broadcast, true, "doUnpersist", Array(blocking))
-      }
-      override protected def doDestroy(blocking: Boolean): Unit = {
-        MethodUtils.invokeMethod(broadcast, true, "doDestroy", Array(blocking))
-      }
-    }
-    dummyBroadcasted.asInstanceOf[Broadcast[T]]
+    sparkContext.broadcast(mode.transform(dataRows)).asInstanceOf[Broadcast[T]]
   }
 
   def doExecuteBroadcastNative[T](): broadcast.Broadcast[T] = {

--- a/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeBroadcastExchangeBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeBroadcastExchangeBase.scala
@@ -126,8 +126,14 @@ abstract class NativeBroadcastExchangeBase(mode: BroadcastMode, override val chi
 
   // Mixed native/Spark execution needs a second JVM broadcast; otherwise the transformed relation
   // would be serialized with every Spark task.
+  // Build it under a separate lock because relationFuture initializes lazy fields on another thread.
   @transient
-  private lazy val sparkBroadcast: Broadcast[Any] = {
+  private lazy val sparkBroadcastLock = new Object
+
+  @transient
+  private var sparkBroadcast: Broadcast[Any] = _
+
+  private def createSparkBroadcast(): Broadcast[Any] = {
     val singlePartition = new Partition() {
       override def index: Int = 0
     }
@@ -150,8 +156,12 @@ abstract class NativeBroadcastExchangeBase(mode: BroadcastMode, override val chi
     sparkContext.broadcast(mode.transform(dataRows))
   }
 
-  override def doExecuteBroadcast[T](): Broadcast[T] =
+  override def doExecuteBroadcast[T](): Broadcast[T] = sparkBroadcastLock.synchronized {
+    if (sparkBroadcast == null) {
+      sparkBroadcast = createSparkBroadcast()
+    }
     sparkBroadcast.asInstanceOf[Broadcast[T]]
+  }
 
   def doExecuteBroadcastNative[T](): broadcast.Broadcast[T] = {
     val timeout: Long = SQLConf.get.broadcastTimeout

--- a/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeBroadcastExchangeBase.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/execution/auron/plan/NativeBroadcastExchangeBase.scala
@@ -124,7 +124,10 @@ abstract class NativeBroadcastExchangeBase(mode: BroadcastMode, override val chi
     relationFuture
   }
 
-  override def doExecuteBroadcast[T](): Broadcast[T] = {
+  // Mixed native/Spark execution needs a second JVM broadcast; otherwise the transformed relation
+  // would be serialized with every Spark task.
+  @transient
+  private lazy val sparkBroadcast: Broadcast[Any] = {
     val singlePartition = new Partition() {
       override def index: Int = 0
     }
@@ -144,8 +147,11 @@ abstract class NativeBroadcastExchangeBase(mode: BroadcastMode, override val chi
       .map(_.copy())
       .toArray
 
-    sparkContext.broadcast(mode.transform(dataRows)).asInstanceOf[Broadcast[T]]
+    sparkContext.broadcast(mode.transform(dataRows))
   }
+
+  override def doExecuteBroadcast[T](): Broadcast[T] =
+    sparkBroadcast.asInstanceOf[Broadcast[T]]
 
   def doExecuteBroadcastNative[T](): broadcast.Broadcast[T] = {
     val timeout: Long = SQLConf.get.broadcastTimeout


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2351

# Rationale for this change

`NativeBroadcastExchangeBase.doExecuteBroadcast` returned an anonymous `Broadcast`
that captured the transformed relation. Spark serialized that wrapper with tasks,
causing the task binary size to grow with the build-side data.

# What changes are included in this PR?

- Return a real Spark broadcast for the transformed relation instead of a value-capturing wrapper.
- Keep the existing native IPC broadcast path unchanged.
- Add regression coverage for mixed native/Spark execution and serialized broadcast size.

# Are there any user-facing changes?

No. This only changes the internal broadcast handling.

# How was this patch tested?

```bash
./build/mvn -Pspark-3.5 -Pscala-2.12 -pl spark-extension-shims-spark test -Dsuites=org.apache.auron.AuronCheckConvertBroadcastExchangeSuite -Dsuffixes=NoDiscoveredSuites

./build/mvn -Pspark-3.5 -Pscala-2.12 -pl spark-extension-shims-spark -am install -DskipTests -DskipBuildNative

./dev/reformat --check
```

# Was this patch authored or co-authored using generative AI tooling?
- [x] Yes
- [ ] No

Generated-by: OpenAI Codex (GPT-5)

ASF guidance: https://www.apache.org/legal/generative-tooling.html