### PR TITLE
[AURON #2509] Support date_add and date_sub functions natively

### DIFF
--- a/native-engine/datafusion-ext-functions/src/lib.rs
+++ b/native-engine/datafusion-ext-functions/src/lib.rs
@@ -97,6 +97,8 @@ pub fn create_auron_ext_function(
         "Spark_Quarter" => shared_function!(spark_dates::spark_quarter),
         "Spark_LastDay" => shared_function!(spark_dates::spark_last_day),
         "Spark_DateDiff" => shared_function!(spark_dates::spark_datediff),
+        "Spark_DateAdd" => shared_function!(spark_dates::spark_date_add),
+        "Spark_DateSub" => shared_function!(spark_dates::spark_date_sub),
         "Spark_MakeDate" => shared_function!(spark_dates::spark_make_date),
         "Spark_Hour" => shared_function!(spark_dates::spark_hour),
         "Spark_Minute" => shared_function!(spark_dates::spark_minute),

--- a/native-engine/datafusion-ext-functions/src/spark_dates.rs
+++ b/native-engine/datafusion-ext-functions/src/spark_dates.rs
@@ -18,10 +18,10 @@ use std::sync::Arc;
 use arrow::{
     array::{
         ArrayRef, BooleanArray, Date32Array, Date32Builder, Float64Array, Int32Array,
-        TimestampMillisecondArray,
+        TimestampMillisecondArray, as_primitive_array,
     },
-    compute::{DatePart, date_part},
-    datatypes::{DataType, TimeUnit},
+    compute::{DatePart, binary, date_part},
+    datatypes::{DataType, Date32Type, Int32Type, TimeUnit},
 };
 use chrono::{Duration, LocalResult, NaiveDate, Offset, TimeZone, Utc, prelude::*};
 use chrono_tz::Tz;
@@ -318,6 +318,44 @@ pub fn spark_datediff(args: &[ColumnarValue]) -> Result<ColumnarValue> {
     ));
 
     Ok(ColumnarValue::Array(Arc::new(result)))
+}
+
+pub fn spark_date_add(args: &[ColumnarValue]) -> Result<ColumnarValue> {
+    spark_date_add_sub(args, i32::wrapping_add)
+}
+
+pub fn spark_date_sub(args: &[ColumnarValue]) -> Result<ColumnarValue> {
+    spark_date_add_sub(args, i32::wrapping_sub)
+}
+
+fn spark_date_add_sub(
+    args: &[ColumnarValue],
+    op: impl Fn(i32, i32) -> i32,
+) -> Result<ColumnarValue> {
+    if args.len() != 2 {
+        return Err(DataFusionError::Execution(
+            "date_add/date_sub requires two arguments".to_string(),
+        ));
+    }
+    let arrays = ColumnarValue::values_to_arrays(args)?;
+    let dates = cast(&arrays[0], &DataType::Date32)?;
+    let days = cast(&arrays[1], &DataType::Int32)?;
+    // Spark wraps date arithmetic even in ANSI mode.
+    let result: Date32Array = binary(
+        as_primitive_array::<Date32Type>(&dates),
+        as_primitive_array::<Int32Type>(&days),
+        op,
+    )?;
+    if args
+        .iter()
+        .all(|arg| matches!(arg, ColumnarValue::Scalar(_)))
+    {
+        Ok(ColumnarValue::Scalar(ScalarValue::try_from_array(
+            &result, 0,
+        )?))
+    } else {
+        Ok(ColumnarValue::Array(Arc::new(result)))
+    }
 }
 
 pub fn spark_make_date(args: &[ColumnarValue]) -> Result<ColumnarValue> {
@@ -727,6 +765,114 @@ mod tests {
             None,
         ]));
         assert_eq!(&spark_datediff(&args)?.into_array(7)?, &expected_ret);
+        Ok(())
+    }
+
+    #[test]
+    fn test_spark_date_add_sub() -> Result<()> {
+        let date = |year, month, day| {
+            NaiveDate::from_ymd_opt(year, month, day)
+                .expect("test date must be valid")
+                .to_epoch_days()
+        };
+        // start date, offset, expected date_add, expected date_sub
+        let cases = [
+            (date(2024, 2, 28), 1, date(2024, 2, 29), date(2024, 2, 27)),
+            (date(2024, 3, 1), -1, date(2024, 2, 29), date(2024, 3, 2)),
+            (date(2023, 3, 1), 1, date(2023, 3, 2), date(2023, 2, 28)),
+            (date(2024, 1, 31), 1, date(2024, 2, 1), date(2024, 1, 30)),
+            (date(2024, 12, 31), 1, date(2025, 1, 1), date(2024, 12, 30)),
+            (date(1969, 12, 31), 1, 0, date(1969, 12, 30)),
+            (0, 0, 0, 0),
+            (i32::MAX, 1, i32::MIN, i32::MAX - 1),
+            (i32::MIN, 1, i32::MIN + 1, i32::MAX),
+            (0, i32::MIN, i32::MIN, i32::MIN),
+            (-1, i32::MIN, i32::MAX, i32::MAX),
+        ];
+        let dates = Date32Array::from_iter(cases.iter().map(|c| Some(c.0)).chain([None, Some(0)]));
+        let days = Int32Array::from_iter(cases.iter().map(|c| Some(c.1)).chain([Some(1), None]));
+        let args = [
+            ColumnarValue::Array(Arc::new(dates)),
+            ColumnarValue::Array(Arc::new(days)),
+        ];
+        for (name, expected) in [
+            (
+                "Spark_DateAdd",
+                cases.iter().map(|c| Some(c.2)).collect::<Vec<_>>(),
+            ),
+            (
+                "Spark_DateSub",
+                cases.iter().map(|c| Some(c.3)).collect::<Vec<_>>(),
+            ),
+        ] {
+            let function = crate::create_auron_ext_function(name, 0)?;
+            let expected: ArrayRef = Arc::new(Date32Array::from_iter(
+                expected.into_iter().chain([None, None]),
+            ));
+            assert_eq!(&function(&args)?.into_array(expected.len())?, &expected);
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_spark_date_add_sub_shapes_and_day_types() -> Result<()> {
+        for (name, direction) in [("Spark_DateAdd", 1), ("Spark_DateSub", -1)] {
+            let function = crate::create_auron_ext_function(name, 0)?;
+            for day_type in [DataType::Int8, DataType::Int16, DataType::Int32] {
+                let days = cast(&Int32Array::from(vec![Some(1), Some(-1), None]), &day_type)?;
+                let day = ScalarValue::try_from_array(&days, 0)?;
+                let null_day = ScalarValue::try_from_array(&days, 2)?;
+                let dates: ArrayRef = Arc::new(Date32Array::from(vec![Some(0), Some(0), None]));
+                for (start, offset, expected) in [
+                    (
+                        ColumnarValue::Array(dates.clone()),
+                        ColumnarValue::Array(days.clone()),
+                        vec![Some(direction), Some(-direction), None],
+                    ),
+                    (
+                        ColumnarValue::Scalar(ScalarValue::Date32(Some(0))),
+                        ColumnarValue::Array(days),
+                        vec![Some(direction), Some(-direction), None],
+                    ),
+                    (
+                        ColumnarValue::Array(dates.clone()),
+                        ColumnarValue::Scalar(day.clone()),
+                        vec![Some(direction), Some(direction), None],
+                    ),
+                    (
+                        ColumnarValue::Array(dates),
+                        ColumnarValue::Scalar(null_day),
+                        vec![None, None, None],
+                    ),
+                ] {
+                    let expected: ArrayRef = Arc::new(Date32Array::from(expected));
+                    assert_eq!(&function(&[start, offset])?.into_array(3)?, &expected);
+                }
+                let result = function(&[
+                    ColumnarValue::Scalar(ScalarValue::Date32(Some(0))),
+                    ColumnarValue::Scalar(day.clone()),
+                ])?;
+                assert!(
+                    matches!(result, ColumnarValue::Scalar(ScalarValue::Date32(Some(v))) if v == direction)
+                );
+                let result = function(&[
+                    ColumnarValue::Scalar(ScalarValue::Date32(None)),
+                    ColumnarValue::Scalar(day.clone()),
+                ])?;
+                assert!(matches!(
+                    result,
+                    ColumnarValue::Scalar(ScalarValue::Date32(None))
+                ));
+                let empty = function(&[
+                    ColumnarValue::Array(Arc::new(Date32Array::from(Vec::<i32>::new()))),
+                    ColumnarValue::Scalar(day),
+                ])?
+                .into_array(0)?;
+                assert_eq!(empty.data_type(), &DataType::Date32);
+                assert!(empty.is_empty());
+            }
+            assert!(function(&[]).is_err());
+        }
         Ok(())
     }
 

--- a/spark-extension-shims-spark/src/test/scala/org/apache/auron/AuronFunctionSuite.scala
+++ b/spark-extension-shims-spark/src/test/scala/org/apache/auron/AuronFunctionSuite.scala
@@ -220,6 +220,76 @@ class AuronFunctionSuite extends AuronQueryTest with BaseAuronSQLSuite {
     }
   }
 
+  test("date_add and date_sub functions") {
+    withTable("t1") {
+      sql("create table t1(start_date date, days int) using parquet")
+      sql("""insert into t1 values
+          |  (date'2024-02-28', 1),
+          |  (date'2024-03-01', -1),
+          |  (date'2023-03-01', 1),
+          |  (date'2024-01-31', 1),
+          |  (date'2024-12-31', 1),
+          |  (date'1969-12-31', 1),
+          |  (date'2024-01-01', 0),
+          |  (null, 1),
+          |  (date'2024-01-01', null)
+          |""".stripMargin)
+
+      for (ansi <- Seq("false", "true"); dayType <- Seq("tinyint", "smallint", "int")) {
+        withSQLConf(SQLConf.ANSI_ENABLED.key -> ansi) {
+          checkSparkAnswerAndOperator(s"""select
+              |  date_add(start_date, cast(days as $dayType)),
+              |  date_sub(start_date, cast(days as $dayType)),
+              |  date_add(start_date, 1), date_sub(start_date, -1),
+              |  date_add(date'2024-01-01', cast(days as $dayType)),
+              |  date_sub(date'2024-01-01', cast(days as $dayType))
+              |from t1""".stripMargin)
+        }
+      }
+    }
+  }
+
+  test("date_add and date_sub integer overflow") {
+    withTable("t1") {
+      sql("create table t1(start_date date, days int) using parquet")
+      sql("""insert into t1 values
+          |  (date'1970-01-02', 2147483647),
+          |  (date'1969-12-31', -2147483648),
+          |  (date'1970-01-01', -2147483648),
+          |  (date'1970-01-01', 2147483647)
+          |""".stripMargin)
+
+      for (ansi <- Seq("false", "true")) {
+        withSQLConf(SQLConf.ANSI_ENABLED.key -> ansi) {
+          // Compare epoch days without converting extreme dates to java.sql.Date.
+          checkSparkAnswerAndOperator("""select
+              |  datediff(date_add(start_date, days), date'1970-01-01'),
+              |  datediff(date_sub(start_date, days), date'1970-01-01')
+              |from t1""".stripMargin)
+        }
+      }
+    }
+  }
+
+  test("date_add and date_sub timestamp and string inputs") {
+    withTable("t1") {
+      sql("create table t1(ts timestamp, dt string, days int) using parquet")
+      withSQLConf(SQLConf.SESSION_LOCAL_TIMEZONE.key -> "UTC") {
+        sql("""insert into t1 values
+            |  (timestamp'1970-01-01 04:30:00', '1969-12-31', 1),
+            |  (timestamp'2024-03-01 04:30:00', '2024-02-29', -1),
+            |  (null, null, 1)
+            |""".stripMargin)
+      }
+      withSQLConf(SQLConf.SESSION_LOCAL_TIMEZONE.key -> "America/Los_Angeles") {
+        checkSparkAnswerAndOperator("""select
+            |  date_add(ts, days), date_sub(ts, days),
+            |  date_add(dt, days), date_sub(dt, days)
+            |from t1""".stripMargin)
+      }
+    }
+  }
+
   test("date-part functions with non-UTC timezone") {
     withTable("t1") {
       sql("create table t1(c1 timestamp) using parquet")

--- a/spark-extension/src/main/scala/org/apache/spark/sql/auron/NativeConverters.scala
+++ b/spark-extension/src/main/scala/org/apache/spark/sql/auron/NativeConverters.scala
@@ -1004,6 +1004,10 @@ object NativeConverters extends Logging {
         buildExtScalarFunction("Spark_LastDay", e.children, e.dataType)
       case e: DateDiff =>
         buildExtScalarFunction("Spark_DateDiff", e.children, e.dataType)
+      case e: DateAdd =>
+        buildExtScalarFunction("Spark_DateAdd", e.children, e.dataType)
+      case e: DateSub =>
+        buildExtScalarFunction("Spark_DateSub", e.children, e.dataType)
 
       case e: Levenshtein =>
         buildScalarFunction(pb.ScalarFunction.Levenshtein, e.children, e.dataType)


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2509

# Rationale for this change

`date_add` and `date_sub` currently fall back to Spark. This adds native support alongside the existing date functions.

# What changes are included in this PR?

- Convert Spark `DateAdd` and `DateSub` expressions to native extension functions.
- Implement Date32 arithmetic with Spark-compatible null propagation and integer wrapping.
- Add Rust and Spark tests for calendar boundaries, negative offsets, integer types, overflow, and input casts.

# Are there any user-facing changes?

`date_add` and `date_sub` can now run natively. No new configuration is required.

# How was this patch tested?

- `cargo test -p datafusion-ext-functions --lib --locked`.
- `./build/mvn -pl spark-extension-shims-spark -am install -DskipTests -Ppre -Pspark-3.5 -Pscala-2.12`.
- `./dev/reformat --check`.
- `./build/mvn -pl spark-extension-shims-spark test -DskipBuildNative -Ppre -Pspark-3.5 -Pscala-2.12 -Dsuites=org.apache.auron.AuronFunctionSuite`.

# Was this patch authored or co-authored using generative AI tooling?

- [ ] Yes
- [x] No

ASF guidance: https://www.apache.org/legal/generative-tooling.html