### PR TITLE
[AURON #2510] Add non-UTC timestamp coverage for native datediff

### DIFF
--- a/spark-extension-shims-spark/src/test/scala/org/apache/auron/AuronFunctionSuite.scala
+++ b/spark-extension-shims-spark/src/test/scala/org/apache/auron/AuronFunctionSuite.scala
@@ -234,8 +234,9 @@ class AuronFunctionSuite extends AuronQueryTest with BaseAuronSQLSuite {
             |  (timestamp'1970-01-01 00:30:00', null)
             |""".stripMargin)
 
-        val df = checkSparkAnswerAndOperator("select datediff(end_ts, start_ts) from t1")
-        checkAnswer(df, Seq(Row(0), Row(1), Row(-1), Row(null), Row(null)))
+        val query = "select datediff(end_ts, start_ts) from t1"
+        checkSparkAnswerAndOperator(query)
+        checkAnswer(sql(query), Seq(Row(0), Row(1), Row(-1), Row(null), Row(null)))
       }
     }
   }

--- a/spark-extension-shims-spark/src/test/scala/org/apache/auron/AuronFunctionSuite.scala
+++ b/spark-extension-shims-spark/src/test/scala/org/apache/auron/AuronFunctionSuite.scala
@@ -220,6 +220,26 @@ class AuronFunctionSuite extends AuronQueryTest with BaseAuronSQLSuite {
     }
   }
 
+  test("datediff function with non-UTC timestamp inputs") {
+    withSQLConf(SQLConf.SESSION_LOCAL_TIMEZONE.key -> "America/Los_Angeles") {
+      withTable("t1") {
+        sql("create table t1(end_ts timestamp, start_ts timestamp) using parquet")
+        // The first pair has the same local date but different UTC dates; the next two
+        // cross local midnight within the same UTC date.
+        sql("""insert into t1 values
+            |  (timestamp'1970-01-01 16:30:00', timestamp'1970-01-01 00:30:00'),
+            |  (timestamp'1970-01-02 00:30:00', timestamp'1970-01-01 23:30:00'),
+            |  (timestamp'1970-01-01 23:30:00', timestamp'1970-01-02 00:30:00'),
+            |  (null, timestamp'1970-01-01 00:30:00'),
+            |  (timestamp'1970-01-01 00:30:00', null)
+            |""".stripMargin)
+
+        val df = checkSparkAnswerAndOperator("select datediff(end_ts, start_ts) from t1")
+        checkAnswer(df, Seq(Row(0), Row(1), Row(-1), Row(null), Row(null)))
+      }
+    }
+  }
+
   test("date-part functions with non-UTC timezone") {
     withTable("t1") {
       sql("create table t1(c1 timestamp) using parquet")


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2510

# Rationale for this change

The datediff coverage added in #2502 only uses DATE inputs. TIMESTAMP inputs also need coverage for conversion to dates in the session time zone.

# What changes are included in this PR?

Add a regression test using TIMESTAMP columns in America/Los_Angeles. It covers local and UTC date boundaries, positive and negative differences, and null inputs.

The test checks explicit expected results, compares with Spark, and verifies native operators.

# Are there any user-facing changes?

No. This change only adds regression coverage.

# How was this patch tested?

On Spark 3.5.8 with Scala 2.12 and JDK 8:

```bash
./build/mvn -B -ntp -Ppre -Pspark-3.5 -Pscala-2.12 -pl spark-extension-shims-spark -DskipBuildNative -DskipTests=false '-Dsuites=org.apache.auron.AuronFunctionSuite datediff' test
./build/mvn -B -ntp -Ppre -Pspark-3.5 -Pscala-2.12 -pl spark-extension-shims-spark -DskipBuildNative -DskipTests=false -Dsuites=org.apache.auron.AuronFunctionSuite test
./dev/reformat --check
```

# Was this patch authored or co-authored using generative AI tooling?

- [x] Yes
- [ ] No

Generated-by: OpenAI Codex (GPT-6)