### PR TITLE
[AURON #2521] Fix NULL predicate handling in aggregate filters

### DIFF
--- a/native-engine/datafusion-ext-plans/src/agg/agg_ctx.rs
+++ b/native-engine/datafusion-ext-plans/src/agg/agg_ctx.rs
@@ -442,12 +442,8 @@ impl AggContext {
     /// - `filtered_input`: input batch row indices to read from
     ///
     /// Only rows in `[batch_start_idx, batch_end_idx)` where the filter is
-    /// true are included. The mapping logic handles all `IdxSelection`
-    /// variants.
-    ///
-    /// NULL handling: `BooleanArray::value(i)` returns `false` for null slots,
-    /// which matches SQL FILTER semantics where NULL is treated as not-true and
-    /// the row is excluded from the aggregate.
+    /// non-null and true are included. The mapping logic handles all
+    /// `IdxSelection` variants.
     fn build_filtered_indices(
         acc_idx: IdxSelection,
         batch_start_idx: usize,
@@ -460,7 +456,7 @@ impl AggContext {
             // Single accumulator for all rows in this group.
             IdxSelection::Single(idx) => {
                 for i in batch_start_idx..batch_end_idx {
-                    if filter_array.value(i) {
+                    if filter_array.is_valid(i) && filter_array.value(i) {
                         filtered_acc.push(idx);
                         filtered_input.push(i);
                     }
@@ -469,7 +465,7 @@ impl AggContext {
             // Per-row accumulator indices (used by sort aggregation).
             IdxSelection::Indices(indices) => {
                 for i in batch_start_idx..batch_end_idx {
-                    if filter_array.value(i) {
+                    if filter_array.is_valid(i) && filter_array.value(i) {
                         filtered_acc.push(indices[i - batch_start_idx]);
                         filtered_input.push(i);
                     }
@@ -478,7 +474,7 @@ impl AggContext {
             // Per-row accumulator indices as u32 (used by hash aggregation).
             IdxSelection::IndicesU32(indices) => {
                 for i in batch_start_idx..batch_end_idx {
-                    if filter_array.value(i) {
+                    if filter_array.is_valid(i) && filter_array.value(i) {
                         filtered_acc.push(indices[i - batch_start_idx] as usize);
                         filtered_input.push(i);
                     }
@@ -487,7 +483,7 @@ impl AggContext {
             // Contiguous accumulator range (used by merge / partial-skip paths).
             IdxSelection::Range(start, _end) => {
                 for i in batch_start_idx..batch_end_idx {
-                    if filter_array.value(i) {
+                    if filter_array.is_valid(i) && filter_array.value(i) {
                         filtered_acc.push(start + (i - batch_start_idx));
                         filtered_input.push(i);
                     }

--- a/spark-extension-shims-spark/src/test/scala/org/apache/auron/AuronQuerySuite.scala
+++ b/spark-extension-shims-spark/src/test/scala/org/apache/auron/AuronQuerySuite.scala
@@ -1132,6 +1132,28 @@ class AuronQuerySuite extends AuronQueryTest with BaseAuronSQLSuite with AuronSQ
     }
   }
 
+  test("aggregate filter excludes null predicates") {
+    withTable("t_filter_agg_null") {
+      sql("""CREATE TABLE t_filter_agg_null(category STRING, amount INT, flag BOOLEAN)
+        |USING parquet""".stripMargin)
+      sql("""INSERT INTO t_filter_agg_null VALUES
+        |('a', 10, true), ('a', 100, NULL), ('a', 1, false), ('b', 200, NULL)
+        |""".stripMargin)
+
+      checkAnswer(
+        checkSparkAnswerAndOperator("""SELECT
+          |SUM(amount) FILTER (WHERE NOT flag), COUNT(*) FILTER (WHERE NOT flag)
+          |FROM t_filter_agg_null""".stripMargin),
+        Seq(Row(1L, 1L)))
+
+      checkAnswer(
+        checkSparkAnswerAndOperator("""SELECT category,
+          |SUM(amount) FILTER (WHERE NOT flag), COUNT(*) FILTER (WHERE NOT flag)
+          |FROM t_filter_agg_null GROUP BY category""".stripMargin),
+        Seq(Row("a", 1L, 1L), Row("b", null, 0L)))
+    }
+  }
+
   test("test OR pushdown with an unconvertible disjunct for orc table") {
     withTable("orc_or") {
       sql("create table orc_or(id int, b string) using orc")


### PR DESCRIPTION
# Which issue does this PR close?

Closes #2521

# Rationale for this change

Aggregate FILTER may include NULL predicates when their underlying boolean value bits are true. For example, FILTER (WHERE NOT flag) can produce incorrect SUM and COUNT results for nullable flag columns.

# What changes are included in this PR?

- Check predicate validity when selecting rows for aggregation.
- Add Spark SQL regression coverage for global and grouped SUM/COUNT, including a group with only NULL predicates.

# Are there any user-facing changes?

Aggregate filters exclude NULL predicates, matching Spark.

# How was this patch tested?

Added end-to-end tests comparing native SUM/COUNT with Spark for nullable filters, with and without GROUP BY.

# Was this patch authored or co-authored using generative AI tooling?
- [X] Yes
- [ ] No

If yes, include: `Generated-by: Openai codex gpt-6-astra`

ASF guidance: https://www.apache.org/legal/generative-tooling.html
